### PR TITLE
Removed RTTI typeid methods from cell identification

### DIFF
--- a/CHI_DOC/PAGES/ProgrammersManual/devman_01_codingconv.h
+++ b/CHI_DOC/PAGES/ProgrammersManual/devman_01_codingconv.h
@@ -280,7 +280,7 @@ if (x && !y)
   ...
 \endcode
 
-\subsection devman1_sec3_4 Templates and Casts
+\subsection devman1_sec3_4 Templates
 
 \code
 // No spaces inside the angle brackets (< and >), before
@@ -292,8 +292,30 @@ y = static_cast<char*>(x);
 std::vector<char *> x;
 \endcode
 
+\subsection devman1_sec3_5 Casting
 
+In general there are three variants of casting; C-style casting, `static_cast`
+and `dynamic_cast`.
 
+\code
+double aa = 10.5;
 
+float a = (float)aa;               // C-style (Use only for numerics)
+float b = static_cast<float>(aa);  // static_cast
+float c = dynamic_cast<float>(aa); // dynamic_cast
+\endcode
+
+The difference between the 3 are as follows: C-style casting is a brute-force
+way of casting one type into another. In most, if not all cases, the compiler
+will not provide any protection against casts that will be illegal. The better
+alternative is to use `static_cast` which will allow the compiler to determine
+whether the cast would be legal in a broad scope sense (i.e. casting parent
+pointer to child pointer). If the user needs to check for a valid cast, it is
+often better to use `dynamic_cast` which will return null if the cast is
+illegal, however, be aware that this uses RTTI and therefore has some cost.
+The following conventions therefore apply:
+
+- Use C-style casting only for numerical values
+- Objects and structures should use either `static_cast` or `dynamic_cast`
 
  */

--- a/CHI_TECH/ChiMath/SpatialDiscretization/FiniteVolume/fv.cc
+++ b/CHI_TECH/ChiMath/SpatialDiscretization/FiniteVolume/fv.cc
@@ -54,7 +54,7 @@ void SpatialDiscretization_FV::AddViewOfLocalContinuum(
     if (cell_fv_views_mapping[cell_index]<0)
     {
       //========================================= If slab item_id
-      if (typeid(*(cell)) == typeid(chi_mesh::CellSlab) )
+      if (cell->Type() == chi_mesh::SLAB_CELL)
       {
         SlabFVView* view =
           new SlabFVView((chi_mesh::CellSlab*)cell,vol_continuum);
@@ -74,7 +74,7 @@ void SpatialDiscretization_FV::AddViewOfLocalContinuum(
 //      }
 
       //========================================= If polygon item_id
-      if (typeid(*(cell)) == typeid(chi_mesh::CellPolygon) )
+      if (cell->Type() == chi_mesh::POLYGON_CELL)
       {
         PolygonFVView* view =
           new PolygonFVView((chi_mesh::CellPolygon*)(cell),vol_continuum);
@@ -84,7 +84,7 @@ void SpatialDiscretization_FV::AddViewOfLocalContinuum(
       }
 
 //      //========================================= If polyhedron item_id
-//      if (typeid(*(cell)) == typeid(chi_mesh::CellPolyhedron) )
+//      if (cell->Type() == chi_mesh::POLYHEDRON_CELL)
 //      {
 //        PolyhedronFEView* view =
 //          new PolyhedronFEView(

--- a/CHI_TECH/ChiMath/SpatialDiscretization/FiniteVolume/fv.cc
+++ b/CHI_TECH/ChiMath/SpatialDiscretization/FiniteVolume/fv.cc
@@ -54,7 +54,7 @@ void SpatialDiscretization_FV::AddViewOfLocalContinuum(
     if (cell_fv_views_mapping[cell_index]<0)
     {
       //========================================= If slab item_id
-      if (cell->Type() == chi_mesh::SLAB_CELL)
+      if (cell->Type() == chi_mesh::CellTypes::SLAB_CELL)
       {
         SlabFVView* view =
           new SlabFVView((chi_mesh::CellSlab*)cell,vol_continuum);
@@ -74,7 +74,7 @@ void SpatialDiscretization_FV::AddViewOfLocalContinuum(
 //      }
 
       //========================================= If polygon item_id
-      if (cell->Type() == chi_mesh::POLYGON_CELL)
+      if (cell->Type() == chi_mesh::CellTypes::POLYGON_CELL)
       {
         PolygonFVView* view =
           new PolygonFVView((chi_mesh::CellPolygon*)(cell),vol_continuum);
@@ -84,7 +84,7 @@ void SpatialDiscretization_FV::AddViewOfLocalContinuum(
       }
 
 //      //========================================= If polyhedron item_id
-//      if (cell->Type() == chi_mesh::POLYHEDRON_CELL)
+//      if (cell->Type() == chi_mesh::CellTypes::POLYHEDRON_CELL)
 //      {
 //        PolyhedronFEView* view =
 //          new PolyhedronFEView(

--- a/CHI_TECH/ChiMath/SpatialDiscretization/FiniteVolume/fv.cc
+++ b/CHI_TECH/ChiMath/SpatialDiscretization/FiniteVolume/fv.cc
@@ -54,7 +54,7 @@ void SpatialDiscretization_FV::AddViewOfLocalContinuum(
     if (cell_fv_views_mapping[cell_index]<0)
     {
       //========================================= If slab item_id
-      if (cell->Type() == chi_mesh::CellTypes::SLAB_CELL)
+      if (cell->Type() == chi_mesh::CellType::SLAB)
       {
         SlabFVView* view =
           new SlabFVView((chi_mesh::CellSlab*)cell,vol_continuum);
@@ -74,7 +74,7 @@ void SpatialDiscretization_FV::AddViewOfLocalContinuum(
 //      }
 
       //========================================= If polygon item_id
-      if (cell->Type() == chi_mesh::CellTypes::POLYGON_CELL)
+      if (cell->Type() == chi_mesh::CellType::POLYGON)
       {
         PolygonFVView* view =
           new PolygonFVView((chi_mesh::CellPolygon*)(cell),vol_continuum);
@@ -84,7 +84,7 @@ void SpatialDiscretization_FV::AddViewOfLocalContinuum(
       }
 
 //      //========================================= If polyhedron item_id
-//      if (cell->Type() == chi_mesh::CellTypes::POLYHEDRON_CELL)
+//      if (cell->Type() == chi_mesh::CellType::POLYHEDRON)
 //      {
 //        PolyhedronFEView* view =
 //          new PolyhedronFEView(

--- a/CHI_TECH/ChiMath/SpatialDiscretization/PiecewiseLinear/pwl_01_addviewofcont.cc
+++ b/CHI_TECH/ChiMath/SpatialDiscretization/PiecewiseLinear/pwl_01_addviewofcont.cc
@@ -47,7 +47,7 @@ void SpatialDiscretization_PWL::AddViewOfLocalContinuum(
     if (cell_fe_views_mapping[cell_index]<0)
     {
       //========================================= If slab item_id
-      if (cell->Type() == chi_mesh::CellTypes::SLAB_CELL)
+      if (cell->Type() == chi_mesh::CellType::SLAB)
       {
         SlabFEView* view =
           new SlabFEView((chi_mesh::CellSlab*)cell,vol_continuum);
@@ -67,7 +67,7 @@ void SpatialDiscretization_PWL::AddViewOfLocalContinuum(
       }
 
       //========================================= If polygon item_id
-      if (cell->Type() == chi_mesh::CellTypes::POLYGON_CELL)
+      if (cell->Type() == chi_mesh::CellType::POLYGON)
       {
         PolygonFEView* view =
           new PolygonFEView((chi_mesh::CellPolygon*)(cell),vol_continuum,this);
@@ -78,7 +78,7 @@ void SpatialDiscretization_PWL::AddViewOfLocalContinuum(
       }
 
       //========================================= If polyhedron item_id
-      if (cell->Type() == chi_mesh::CellTypes::POLYHEDRON_CELL)
+      if (cell->Type() == chi_mesh::CellType::POLYHEDRON)
       {
         PolyhedronFEView* view =
           new PolyhedronFEView(

--- a/CHI_TECH/ChiMath/SpatialDiscretization/PiecewiseLinear/pwl_01_addviewofcont.cc
+++ b/CHI_TECH/ChiMath/SpatialDiscretization/PiecewiseLinear/pwl_01_addviewofcont.cc
@@ -47,7 +47,7 @@ void SpatialDiscretization_PWL::AddViewOfLocalContinuum(
     if (cell_fe_views_mapping[cell_index]<0)
     {
       //========================================= If slab item_id
-      if (typeid(*(cell)) == typeid(chi_mesh::CellSlab) )
+      if (cell->Type() == chi_mesh::SLAB_CELL)
       {
         SlabFEView* view =
           new SlabFEView((chi_mesh::CellSlab*)cell,vol_continuum);
@@ -67,7 +67,7 @@ void SpatialDiscretization_PWL::AddViewOfLocalContinuum(
       }
 
       //========================================= If polygon item_id
-      if (typeid(*(cell)) == typeid(chi_mesh::CellPolygon) )
+      if (cell->Type() == chi_mesh::POLYGON_CELL)
       {
         PolygonFEView* view =
           new PolygonFEView((chi_mesh::CellPolygon*)(cell),vol_continuum,this);
@@ -78,7 +78,7 @@ void SpatialDiscretization_PWL::AddViewOfLocalContinuum(
       }
 
       //========================================= If polyhedron item_id
-      if (typeid(*(cell)) == typeid(chi_mesh::CellPolyhedron) )
+      if (cell->Type() == chi_mesh::POLYHEDRON_CELL)
       {
         PolyhedronFEView* view =
           new PolyhedronFEView(

--- a/CHI_TECH/ChiMath/SpatialDiscretization/PiecewiseLinear/pwl_01_addviewofcont.cc
+++ b/CHI_TECH/ChiMath/SpatialDiscretization/PiecewiseLinear/pwl_01_addviewofcont.cc
@@ -47,7 +47,7 @@ void SpatialDiscretization_PWL::AddViewOfLocalContinuum(
     if (cell_fe_views_mapping[cell_index]<0)
     {
       //========================================= If slab item_id
-      if (cell->Type() == chi_mesh::SLAB_CELL)
+      if (cell->Type() == chi_mesh::CellTypes::SLAB_CELL)
       {
         SlabFEView* view =
           new SlabFEView((chi_mesh::CellSlab*)cell,vol_continuum);
@@ -67,7 +67,7 @@ void SpatialDiscretization_PWL::AddViewOfLocalContinuum(
       }
 
       //========================================= If polygon item_id
-      if (cell->Type() == chi_mesh::POLYGON_CELL)
+      if (cell->Type() == chi_mesh::CellTypes::POLYGON_CELL)
       {
         PolygonFEView* view =
           new PolygonFEView((chi_mesh::CellPolygon*)(cell),vol_continuum,this);
@@ -78,7 +78,7 @@ void SpatialDiscretization_PWL::AddViewOfLocalContinuum(
       }
 
       //========================================= If polyhedron item_id
-      if (cell->Type() == chi_mesh::POLYHEDRON_CELL)
+      if (cell->Type() == chi_mesh::CellTypes::POLYHEDRON_CELL)
       {
         PolyhedronFEView* view =
           new PolyhedronFEView(

--- a/CHI_TECH/ChiMesh/Cell/cell.h
+++ b/CHI_TECH/ChiMesh/Cell/cell.h
@@ -40,7 +40,7 @@ public:
 private:
   const CellType cell_type;
 public:
-  Cell(CellType in_cell_type) : cell_type(in_cell_type)
+  explicit Cell(CellType in_cell_type) : cell_type(in_cell_type)
   {
     cell_global_id = -1;
     cell_local_id = -1;

--- a/CHI_TECH/ChiMesh/Cell/cell.h
+++ b/CHI_TECH/ChiMesh/Cell/cell.h
@@ -7,18 +7,18 @@
 //Appending cell types to namespace
 namespace chi_mesh
 {
-  enum class CellTypes
+  enum class CellType
   {
-    GHOST_CELL = 0,
-    SLAB_CELL = 1,
-    SPHERICAL_SHELL_CELL = 2,
-    CYLINDRICAL_ANNULUS_CELL = 3,
-    TRIANGLE_CELL = 4,
-    QUADRILATERAL_CELL = 5,
-    POLYGON_CELL = 6,
-    TETRAHEDRON_CELL = 7,
-    HEXAHEDRON_CELL = 8,
-    POLYHEDRON_CELL = 9
+    GHOST = 0,
+    SLAB = 1,
+    SPHERICAL_SHELL = 2,
+    CYLINDRICAL_ANNULUS = 3,
+    TRIANGLE = 4,
+    QUADRILATERAL = 5,
+    POLYGON = 6,
+    TETRAHEDRON = 7,
+    HEXAHEDRON = 8,
+    POLYHEDRON = 9
   };
 }
 
@@ -38,9 +38,9 @@ public:
   int material_id;
 
 private:
-  const CellTypes cell_type;
+  const CellType cell_type;
 public:
-  Cell(CellTypes in_cell_type) : cell_type(in_cell_type)
+  Cell(CellType in_cell_type) : cell_type(in_cell_type)
   {
     cell_global_id = -1;
     cell_local_id = -1;
@@ -60,7 +60,7 @@ public:
   virtual void FindBoundary2D(chi_mesh::Region* region) {}
   virtual bool CheckBoundary2D() {return true;}
 
-  const CellTypes Type() {return cell_type;}
+  const CellType Type() {return cell_type;}
 };
 
 

--- a/CHI_TECH/ChiMesh/Cell/cell.h
+++ b/CHI_TECH/ChiMesh/Cell/cell.h
@@ -6,7 +6,7 @@
 
 namespace chi_mesh
 {
-  enum CellTypes
+  enum class CellTypes
   {
     GHOST_CELL = 0,
     SLAB_CELL = 1,
@@ -55,7 +55,7 @@ public:
 
   virtual ~Cell()
   {
-    cell_type = GHOST_CELL;
+    cell_type = CellTypes::GHOST_CELL;
   }
 public:
   virtual void FindBoundary2D(chi_mesh::Region* region)

--- a/CHI_TECH/ChiMesh/Cell/cell.h
+++ b/CHI_TECH/ChiMesh/Cell/cell.h
@@ -4,6 +4,25 @@
 #include"../chi_mesh.h"
 #include <tuple>
 
+namespace chi_mesh
+{
+  enum CellTypes
+  {
+    GHOST_CELL = 0,
+    SLAB_CELL = 1,
+    SPHERICAL_SHELL_CELL = 2,
+    CYLINDRICAL_ANNULUS_CELL = 3,
+    TRIANGLE_CELL = 4,
+    QUADRILATERAL_CELL = 5,
+    POLYGON_CELL = 6,
+    TETRAHEDRON_CELL = 7,
+    HEXAHEDRON_CELL = 8,
+    POLYHEDRON_CELL = 9
+  };
+}
+
+
+
 //######################################################### Class def
 /**Generic mesh cell object*/
 class chi_mesh::Cell
@@ -16,6 +35,9 @@ public:
   int partition_id;
   Vertex centroid;
   int material_id;
+
+protected:
+  CellTypes cell_type;
 public:
   Cell()
   {
@@ -32,12 +54,18 @@ public:
   }
 
   virtual ~Cell()
-  {}
+  {
+    cell_type = GHOST_CELL;
+  }
 public:
   virtual void FindBoundary2D(chi_mesh::Region* region)
   {}
   virtual bool CheckBoundary2D()
   {return true;}
+  CellTypes Type()
+  {
+    return cell_type;
+  }
 };
 
 

--- a/CHI_TECH/ChiMesh/Cell/cell.h
+++ b/CHI_TECH/ChiMesh/Cell/cell.h
@@ -36,10 +36,10 @@ public:
   Vertex centroid;
   int material_id;
 
-protected:
-  CellTypes cell_type;
+private:
+  const CellTypes cell_type;
 public:
-  Cell()
+  Cell(CellTypes in_cell_type) : cell_type(in_cell_type)
   {
     cell_global_id = -1;
     cell_local_id = -1;
@@ -53,19 +53,13 @@ public:
     material_id = -1;
   }
 
-  virtual ~Cell()
-  {
-    cell_type = CellTypes::GHOST_CELL;
-  }
+  virtual ~Cell() {}
+
 public:
-  virtual void FindBoundary2D(chi_mesh::Region* region)
-  {}
-  virtual bool CheckBoundary2D()
-  {return true;}
-  CellTypes Type()
-  {
-    return cell_type;
-  }
+  virtual void FindBoundary2D(chi_mesh::Region* region) {}
+  virtual bool CheckBoundary2D() {return true;}
+
+  const CellTypes Type() {return cell_type;}
 };
 
 

--- a/CHI_TECH/ChiMesh/Cell/cell.h
+++ b/CHI_TECH/ChiMesh/Cell/cell.h
@@ -4,6 +4,7 @@
 #include"../chi_mesh.h"
 #include <tuple>
 
+//Appending cell types to namespace
 namespace chi_mesh
 {
   enum class CellTypes

--- a/CHI_TECH/ChiMesh/Cell/cell_polygon.h
+++ b/CHI_TECH/ChiMesh/Cell/cell_polygon.h
@@ -27,7 +27,7 @@ public:
 public:
   CellPolygon()
   {
-    cell_type = POLYGON_CELL;
+    cell_type = CellTypes::POLYGON_CELL;
   }
   //01
   void FindBoundary2D(chi_mesh::Region* region);

--- a/CHI_TECH/ChiMesh/Cell/cell_polygon.h
+++ b/CHI_TECH/ChiMesh/Cell/cell_polygon.h
@@ -24,7 +24,11 @@ public:
   std::vector<int>  v_indices;
   std::vector<int*> edges; ///< Stores arrays of edge indices
   std::vector<chi_mesh::Vector> edgenormals;
-
+public:
+  CellPolygon()
+  {
+    cell_type = POLYGON_CELL;
+  }
   //01
   void FindBoundary2D(chi_mesh::Region* region);
   //02

--- a/CHI_TECH/ChiMesh/Cell/cell_polygon.h
+++ b/CHI_TECH/ChiMesh/Cell/cell_polygon.h
@@ -25,10 +25,8 @@ public:
   std::vector<int*> edges; ///< Stores arrays of edge indices
   std::vector<chi_mesh::Vector> edgenormals;
 public:
-  CellPolygon()
-  {
-    cell_type = CellTypes::POLYGON_CELL;
-  }
+  CellPolygon() : Cell(CellTypes::POLYGON_CELL) {}
+
   //01
   void FindBoundary2D(chi_mesh::Region* region);
   //02

--- a/CHI_TECH/ChiMesh/Cell/cell_polygon.h
+++ b/CHI_TECH/ChiMesh/Cell/cell_polygon.h
@@ -25,7 +25,7 @@ public:
   std::vector<int*> edges; ///< Stores arrays of edge indices
   std::vector<chi_mesh::Vector> edgenormals;
 public:
-  CellPolygon() : Cell(CellTypes::POLYGON_CELL) {}
+  CellPolygon() : Cell(CellType::POLYGON) {}
 
   //01
   void FindBoundary2D(chi_mesh::Region* region);

--- a/CHI_TECH/ChiMesh/Cell/cell_polyhedron.h
+++ b/CHI_TECH/ChiMesh/Cell/cell_polyhedron.h
@@ -15,7 +15,7 @@ public:
 public:
   CellPolyhedron()
   {
-    cell_type = POLYHEDRON_CELL;
+    cell_type = CellTypes::POLYHEDRON_CELL;
   }
 };
 

--- a/CHI_TECH/ChiMesh/Cell/cell_polyhedron.h
+++ b/CHI_TECH/ChiMesh/Cell/cell_polyhedron.h
@@ -12,6 +12,11 @@ public:
   std::vector<int>       v_indices;
   std::vector<PolyFace*> faces;
 
+public:
+  CellPolyhedron()
+  {
+    cell_type = POLYHEDRON_CELL;
+  }
 };
 
 

--- a/CHI_TECH/ChiMesh/Cell/cell_polyhedron.h
+++ b/CHI_TECH/ChiMesh/Cell/cell_polyhedron.h
@@ -13,7 +13,7 @@ public:
   std::vector<PolyFace*> faces;
 
 public:
-  CellPolyhedron() : Cell(CellTypes::POLYHEDRON_CELL) {}
+  CellPolyhedron() : Cell(CellType::POLYHEDRON) {}
 };
 
 

--- a/CHI_TECH/ChiMesh/Cell/cell_polyhedron.h
+++ b/CHI_TECH/ChiMesh/Cell/cell_polyhedron.h
@@ -13,10 +13,7 @@ public:
   std::vector<PolyFace*> faces;
 
 public:
-  CellPolyhedron()
-  {
-    cell_type = CellTypes::POLYHEDRON_CELL;
-  }
+  CellPolyhedron() : Cell(CellTypes::POLYHEDRON_CELL) {}
 };
 
 

--- a/CHI_TECH/ChiMesh/Cell/cell_slab.h
+++ b/CHI_TECH/ChiMesh/Cell/cell_slab.h
@@ -23,6 +23,9 @@ public:
     v_indices[1] = -1;
     edges[0] = -1;
     edges[1] = -1;
+
+    face_normals[0] = chi_mesh::Vector();
+    face_normals[1] = chi_mesh::Vector();
   }
 };
 

--- a/CHI_TECH/ChiMesh/Cell/cell_slab.h
+++ b/CHI_TECH/ChiMesh/Cell/cell_slab.h
@@ -15,6 +15,12 @@ public:
   int     v_indices[2];
   int     edges[2];
   Vector  face_normals[2];
+
+public:
+  CellSlab()
+  {
+    cell_type = SLAB_CELL;
+  }
 };
 
 #endif

--- a/CHI_TECH/ChiMesh/Cell/cell_slab.h
+++ b/CHI_TECH/ChiMesh/Cell/cell_slab.h
@@ -17,7 +17,7 @@ public:
   Vector  face_normals[2];
 
 public:
-  CellSlab() : Cell(CellTypes::SLAB_CELL)
+  CellSlab() : Cell(CellType::SLAB)
   {
     v_indices[0] = -1;
     v_indices[1] = -1;

--- a/CHI_TECH/ChiMesh/Cell/cell_slab.h
+++ b/CHI_TECH/ChiMesh/Cell/cell_slab.h
@@ -19,7 +19,7 @@ public:
 public:
   CellSlab()
   {
-    cell_type = SLAB_CELL;
+    cell_type = CellTypes::SLAB_CELL;
   }
 };
 

--- a/CHI_TECH/ChiMesh/Cell/cell_slab.h
+++ b/CHI_TECH/ChiMesh/Cell/cell_slab.h
@@ -17,9 +17,12 @@ public:
   Vector  face_normals[2];
 
 public:
-  CellSlab()
+  CellSlab() : Cell(CellTypes::SLAB_CELL)
   {
-    cell_type = CellTypes::SLAB_CELL;
+    v_indices[0] = -1;
+    v_indices[1] = -1;
+    edges[0] = -1;
+    edges[1] = -1;
   }
 };
 

--- a/CHI_TECH/ChiMesh/Cell/cell_triangle.h
+++ b/CHI_TECH/ChiMesh/Cell/cell_triangle.h
@@ -14,7 +14,7 @@ public:
   int e_index[3][4];
 
 public:
-  CellTriangle():Cell()
+  CellTriangle():Cell(CellTypes::TRIANGLE_CELL)
   {
     for (int k=0;k<3;k++)
     {

--- a/CHI_TECH/ChiMesh/Cell/cell_triangle.h
+++ b/CHI_TECH/ChiMesh/Cell/cell_triangle.h
@@ -14,7 +14,7 @@ public:
   int e_index[3][4];
 
 public:
-  CellTriangle():Cell(CellTypes::TRIANGLE_CELL)
+  CellTriangle():Cell(CellType::TRIANGLE)
   {
     for (int k=0;k<3;k++)
     {

--- a/CHI_TECH/ChiMesh/FieldFunctionInterpolation/Line/chi_ffinter_line_execute.cc
+++ b/CHI_TECH/ChiMesh/FieldFunctionInterpolation/Line/chi_ffinter_line_execute.cc
@@ -99,7 +99,7 @@ CFEMInterpolate(Vec field,
     auto cell = grid_view->cells[cell_glob_index];
 
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% SLAB
-    if (cell->Type() == chi_mesh::CellTypes::SLAB_CELL)
+    if (cell->Type() == chi_mesh::CellType::SLAB)
     {
       chi_mesh::CellSlab* slab_cell = (chi_mesh::CellSlab*)cell;
       SlabFEView*      cell_fe_view =
@@ -127,7 +127,7 @@ CFEMInterpolate(Vec field,
     }
 
       //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYGON
-    else if (cell->Type() == chi_mesh::CellTypes::POLYGON_CELL)
+    else if (cell->Type() == chi_mesh::CellType::POLYGON)
     {
       chi_mesh::CellPolygon* poly_cell = (chi_mesh::CellPolygon*)cell;
       PolygonFEView*      cell_fe_view =
@@ -155,7 +155,7 @@ CFEMInterpolate(Vec field,
     }
 
       //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYHEDRON
-    else if (cell->Type() == chi_mesh::CellTypes::POLYHEDRON_CELL)
+    else if (cell->Type() == chi_mesh::CellType::POLYHEDRON)
     {
       chi_mesh::CellPolyhedron* polyh_cell = (chi_mesh::CellPolyhedron*)cell;
       PolyhedronFEView*       cell_fe_view =
@@ -211,7 +211,7 @@ void chi_mesh::FieldFunctionInterpolationLine::
     auto cell = grid_view->cells[cell_glob_index];
 
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% SLAB
-    if (cell->Type() == chi_mesh::CellTypes::SLAB_CELL)
+    if (cell->Type() == chi_mesh::CellType::SLAB)
     {
       chi_mesh::CellSlab* slab_cell = (chi_mesh::CellSlab*)cell;
       SlabFEView*      cell_fe_view =
@@ -240,7 +240,7 @@ void chi_mesh::FieldFunctionInterpolationLine::
 
 
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYHEDRON
-    if (cell->Type() == chi_mesh::CellTypes::POLYHEDRON_CELL)
+    if (cell->Type() == chi_mesh::CellType::POLYHEDRON)
     {
       chi_mesh::CellPolyhedron* polyh_cell = (chi_mesh::CellPolyhedron*)cell;
       PolyhedronFEView*       cell_fe_view =

--- a/CHI_TECH/ChiMesh/FieldFunctionInterpolation/Line/chi_ffinter_line_execute.cc
+++ b/CHI_TECH/ChiMesh/FieldFunctionInterpolation/Line/chi_ffinter_line_execute.cc
@@ -99,7 +99,7 @@ CFEMInterpolate(Vec field,
     auto cell = grid_view->cells[cell_glob_index];
 
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% SLAB
-    if (cell->Type() == chi_mesh::SLAB_CELL)
+    if (cell->Type() == chi_mesh::CellTypes::SLAB_CELL)
     {
       chi_mesh::CellSlab* slab_cell = (chi_mesh::CellSlab*)cell;
       SlabFEView*      cell_fe_view =
@@ -127,7 +127,7 @@ CFEMInterpolate(Vec field,
     }
 
       //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYGON
-    else if (cell->Type() == chi_mesh::POLYGON_CELL)
+    else if (cell->Type() == chi_mesh::CellTypes::POLYGON_CELL)
     {
       chi_mesh::CellPolygon* poly_cell = (chi_mesh::CellPolygon*)cell;
       PolygonFEView*      cell_fe_view =
@@ -155,7 +155,7 @@ CFEMInterpolate(Vec field,
     }
 
       //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYHEDRON
-    else if (cell->Type() == chi_mesh::POLYHEDRON_CELL)
+    else if (cell->Type() == chi_mesh::CellTypes::POLYHEDRON_CELL)
     {
       chi_mesh::CellPolyhedron* polyh_cell = (chi_mesh::CellPolyhedron*)cell;
       PolyhedronFEView*       cell_fe_view =
@@ -211,7 +211,7 @@ void chi_mesh::FieldFunctionInterpolationLine::
     auto cell = grid_view->cells[cell_glob_index];
 
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% SLAB
-    if (cell->Type() == chi_mesh::SLAB_CELL)
+    if (cell->Type() == chi_mesh::CellTypes::SLAB_CELL)
     {
       chi_mesh::CellSlab* slab_cell = (chi_mesh::CellSlab*)cell;
       SlabFEView*      cell_fe_view =
@@ -240,7 +240,7 @@ void chi_mesh::FieldFunctionInterpolationLine::
 
 
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYHEDRON
-    if (cell->Type() == chi_mesh::POLYHEDRON_CELL)
+    if (cell->Type() == chi_mesh::CellTypes::POLYHEDRON_CELL)
     {
       chi_mesh::CellPolyhedron* polyh_cell = (chi_mesh::CellPolyhedron*)cell;
       PolyhedronFEView*       cell_fe_view =

--- a/CHI_TECH/ChiMesh/FieldFunctionInterpolation/Line/chi_ffinter_line_execute.cc
+++ b/CHI_TECH/ChiMesh/FieldFunctionInterpolation/Line/chi_ffinter_line_execute.cc
@@ -99,7 +99,7 @@ CFEMInterpolate(Vec field,
     auto cell = grid_view->cells[cell_glob_index];
 
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% SLAB
-    if (typeid(*cell) == typeid(chi_mesh::CellSlab))
+    if (cell->Type() == chi_mesh::SLAB_CELL)
     {
       chi_mesh::CellSlab* slab_cell = (chi_mesh::CellSlab*)cell;
       SlabFEView*      cell_fe_view =
@@ -127,7 +127,7 @@ CFEMInterpolate(Vec field,
     }
 
       //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYGON
-    else if (typeid(*cell) == typeid(chi_mesh::CellPolygon))
+    else if (cell->Type() == chi_mesh::POLYGON_CELL)
     {
       chi_mesh::CellPolygon* poly_cell = (chi_mesh::CellPolygon*)cell;
       PolygonFEView*      cell_fe_view =
@@ -155,7 +155,7 @@ CFEMInterpolate(Vec field,
     }
 
       //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYHEDRON
-    else if (typeid(*cell) == typeid(chi_mesh::CellPolyhedron))
+    else if (cell->Type() == chi_mesh::POLYHEDRON_CELL)
     {
       chi_mesh::CellPolyhedron* polyh_cell = (chi_mesh::CellPolyhedron*)cell;
       PolyhedronFEView*       cell_fe_view =
@@ -211,7 +211,7 @@ void chi_mesh::FieldFunctionInterpolationLine::
     auto cell = grid_view->cells[cell_glob_index];
 
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% SLAB
-    if (typeid(*cell) == typeid(chi_mesh::CellSlab))
+    if (cell->Type() == chi_mesh::SLAB_CELL)
     {
       chi_mesh::CellSlab* slab_cell = (chi_mesh::CellSlab*)cell;
       SlabFEView*      cell_fe_view =
@@ -240,7 +240,7 @@ void chi_mesh::FieldFunctionInterpolationLine::
 
 
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYHEDRON
-    if (typeid(*cell) == typeid(chi_mesh::CellPolyhedron))
+    if (cell->Type() == chi_mesh::POLYHEDRON_CELL)
     {
       chi_mesh::CellPolyhedron* polyh_cell = (chi_mesh::CellPolyhedron*)cell;
       PolyhedronFEView*       cell_fe_view =

--- a/CHI_TECH/ChiMesh/FieldFunctionInterpolation/Line/chi_ffinter_line_initialize.cc
+++ b/CHI_TECH/ChiMesh/FieldFunctionInterpolation/Line/chi_ffinter_line_initialize.cc
@@ -72,7 +72,7 @@ Initialize()
         auto cell = grid_view->cells[cell_glob_index];
 
         //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% SLAB
-        if (cell->Type() == chi_mesh::CellTypes::SLAB_CELL)
+        if (cell->Type() == chi_mesh::CellType::SLAB)
         {
           chi_mesh::CellSlab* slab_cell = (chi_mesh::CellSlab*)cell;
 
@@ -110,7 +110,7 @@ Initialize()
         }//if slab
 
           //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYGON
-        else if (cell->Type() == chi_mesh::CellTypes::POLYGON_CELL)
+        else if (cell->Type() == chi_mesh::CellType::POLYGON)
         {
           chi_mesh::CellPolygon* poly_cell = (chi_mesh::CellPolygon*)cell;
 
@@ -155,7 +155,7 @@ Initialize()
         }//if polygon cell
 
           //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYHEDRON
-        else if (cell->Type() == chi_mesh::CellTypes::POLYHEDRON_CELL)
+        else if (cell->Type() == chi_mesh::CellType::POLYHEDRON)
         {
           chi_mesh::CellPolyhedron* polyh_cell = (chi_mesh::CellPolyhedron*)cell;
 
@@ -210,7 +210,7 @@ Initialize()
         auto cell = grid_view->cells[cell_glob_index];
 
         //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% SLAB
-        if (cell->Type() == chi_mesh::CellTypes::SLAB_CELL)
+        if (cell->Type() == chi_mesh::CellType::SLAB)
         {
           chi_mesh::CellSlab* slab_cell = (chi_mesh::CellSlab*)cell;
 
@@ -224,7 +224,7 @@ Initialize()
         }//if poly
 
         //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYGON
-        if (cell->Type() == chi_mesh::CellTypes::POLYGON_CELL)
+        if (cell->Type() == chi_mesh::CellType::POLYGON)
         {
           chi_mesh::CellPolygon* poly_cell = (chi_mesh::CellPolygon*)cell;
 
@@ -238,7 +238,7 @@ Initialize()
         }//if poly
 
           //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYHEDRON
-        else if (cell->Type() == chi_mesh::CellTypes::POLYHEDRON_CELL)
+        else if (cell->Type() == chi_mesh::CellType::POLYHEDRON)
         {
           chi_mesh::CellPolyhedron* polyh_cell = (chi_mesh::CellPolyhedron*)cell;
 

--- a/CHI_TECH/ChiMesh/FieldFunctionInterpolation/Line/chi_ffinter_line_initialize.cc
+++ b/CHI_TECH/ChiMesh/FieldFunctionInterpolation/Line/chi_ffinter_line_initialize.cc
@@ -72,7 +72,7 @@ Initialize()
         auto cell = grid_view->cells[cell_glob_index];
 
         //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% SLAB
-        if (typeid(*cell) == typeid(chi_mesh::CellSlab))
+        if (cell->Type() == chi_mesh::SLAB_CELL)
         {
           chi_mesh::CellSlab* slab_cell = (chi_mesh::CellSlab*)cell;
 
@@ -110,7 +110,7 @@ Initialize()
         }//if slab
 
           //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYGON
-        else if (typeid(*cell) == typeid(chi_mesh::CellPolygon))
+        else if (cell->Type() == chi_mesh::POLYGON_CELL)
         {
           chi_mesh::CellPolygon* poly_cell = (chi_mesh::CellPolygon*)cell;
 
@@ -155,7 +155,7 @@ Initialize()
         }//if polygon cell
 
           //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYHEDRON
-        else if (typeid(*cell) == typeid(chi_mesh::CellPolyhedron))
+        else if (cell->Type() == chi_mesh::POLYHEDRON_CELL)
         {
           chi_mesh::CellPolyhedron* polyh_cell = (chi_mesh::CellPolyhedron*)cell;
 
@@ -210,7 +210,7 @@ Initialize()
         auto cell = grid_view->cells[cell_glob_index];
 
         //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% SLAB
-        if (typeid(*cell) == typeid(chi_mesh::CellSlab))
+        if (cell->Type() == chi_mesh::SLAB_CELL)
         {
           chi_mesh::CellSlab* slab_cell = (chi_mesh::CellSlab*)cell;
 
@@ -224,7 +224,7 @@ Initialize()
         }//if poly
 
         //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYGON
-        if (typeid(*cell) == typeid(chi_mesh::CellPolygon))
+        if (cell->Type() == chi_mesh::POLYGON_CELL)
         {
           chi_mesh::CellPolygon* poly_cell = (chi_mesh::CellPolygon*)cell;
 
@@ -238,7 +238,7 @@ Initialize()
         }//if poly
 
           //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYHEDRON
-        else if (typeid(*cell) == typeid(chi_mesh::CellPolyhedron))
+        else if (cell->Type() == chi_mesh::POLYHEDRON_CELL)
         {
           chi_mesh::CellPolyhedron* polyh_cell = (chi_mesh::CellPolyhedron*)cell;
 

--- a/CHI_TECH/ChiMesh/FieldFunctionInterpolation/Line/chi_ffinter_line_initialize.cc
+++ b/CHI_TECH/ChiMesh/FieldFunctionInterpolation/Line/chi_ffinter_line_initialize.cc
@@ -72,7 +72,7 @@ Initialize()
         auto cell = grid_view->cells[cell_glob_index];
 
         //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% SLAB
-        if (cell->Type() == chi_mesh::SLAB_CELL)
+        if (cell->Type() == chi_mesh::CellTypes::SLAB_CELL)
         {
           chi_mesh::CellSlab* slab_cell = (chi_mesh::CellSlab*)cell;
 
@@ -110,7 +110,7 @@ Initialize()
         }//if slab
 
           //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYGON
-        else if (cell->Type() == chi_mesh::POLYGON_CELL)
+        else if (cell->Type() == chi_mesh::CellTypes::POLYGON_CELL)
         {
           chi_mesh::CellPolygon* poly_cell = (chi_mesh::CellPolygon*)cell;
 
@@ -155,7 +155,7 @@ Initialize()
         }//if polygon cell
 
           //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYHEDRON
-        else if (cell->Type() == chi_mesh::POLYHEDRON_CELL)
+        else if (cell->Type() == chi_mesh::CellTypes::POLYHEDRON_CELL)
         {
           chi_mesh::CellPolyhedron* polyh_cell = (chi_mesh::CellPolyhedron*)cell;
 
@@ -210,7 +210,7 @@ Initialize()
         auto cell = grid_view->cells[cell_glob_index];
 
         //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% SLAB
-        if (cell->Type() == chi_mesh::SLAB_CELL)
+        if (cell->Type() == chi_mesh::CellTypes::SLAB_CELL)
         {
           chi_mesh::CellSlab* slab_cell = (chi_mesh::CellSlab*)cell;
 
@@ -224,7 +224,7 @@ Initialize()
         }//if poly
 
         //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYGON
-        if (cell->Type() == chi_mesh::POLYGON_CELL)
+        if (cell->Type() == chi_mesh::CellTypes::POLYGON_CELL)
         {
           chi_mesh::CellPolygon* poly_cell = (chi_mesh::CellPolygon*)cell;
 
@@ -238,7 +238,7 @@ Initialize()
         }//if poly
 
           //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYHEDRON
-        else if (cell->Type() == chi_mesh::POLYHEDRON_CELL)
+        else if (cell->Type() == chi_mesh::CellTypes::POLYHEDRON_CELL)
         {
           chi_mesh::CellPolyhedron* polyh_cell = (chi_mesh::CellPolyhedron*)cell;
 

--- a/CHI_TECH/ChiMesh/FieldFunctionInterpolation/Slice/chi_ffinter_slice_initialize.cc
+++ b/CHI_TECH/ChiMesh/FieldFunctionInterpolation/Slice/chi_ffinter_slice_initialize.cc
@@ -41,7 +41,7 @@ void chi_mesh::FieldFunctionInterpolationSlice::
     auto cell = grid_view->cells[cell_glob_index];
 
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% SLAB
-    if (cell->Type() == chi_mesh::CellTypes::SLAB_CELL)
+    if (cell->Type() == chi_mesh::CellType::SLAB)
     {
       chi_log.Log(LOG_0)
         << "FieldFunctionInterpolationSlice does not support 1D cells.";
@@ -49,13 +49,13 @@ void chi_mesh::FieldFunctionInterpolationSlice::
     }
 
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYGON
-    if (cell->Type() == chi_mesh::CellTypes::POLYGON_CELL)
+    if (cell->Type() == chi_mesh::CellType::POLYGON)
     {
       intersecting_cell_indices.push_back(cell_glob_index);
     }
 
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYHEDRON
-    else if (cell->Type() == chi_mesh::CellTypes::POLYHEDRON_CELL)
+    else if (cell->Type() == chi_mesh::CellType::POLYHEDRON)
     {
       chi_mesh::CellPolyhedron* polyh_cell = (chi_mesh::CellPolyhedron*)cell;
       bool intersects = false;
@@ -97,7 +97,7 @@ void chi_mesh::FieldFunctionInterpolationSlice::
     auto cell = grid_view->cells[cell_glob_index];
 
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYGON
-    if (cell->Type() == chi_mesh::CellTypes::POLYGON_CELL)
+    if (cell->Type() == chi_mesh::CellType::POLYGON)
     {
       chi_mesh::CellPolygon* poly_cell = (chi_mesh::CellPolygon*)cell;
 
@@ -155,7 +155,7 @@ void chi_mesh::FieldFunctionInterpolationSlice::
 
 
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYHEDRON
-    if (cell->Type() == chi_mesh::CellTypes::POLYHEDRON_CELL)
+    if (cell->Type() == chi_mesh::CellType::POLYHEDRON)
     {
       chi_mesh::CellPolyhedron* polyh_cell = (chi_mesh::CellPolyhedron*)cell;
 

--- a/CHI_TECH/ChiMesh/FieldFunctionInterpolation/Slice/chi_ffinter_slice_initialize.cc
+++ b/CHI_TECH/ChiMesh/FieldFunctionInterpolation/Slice/chi_ffinter_slice_initialize.cc
@@ -41,7 +41,7 @@ void chi_mesh::FieldFunctionInterpolationSlice::
     auto cell = grid_view->cells[cell_glob_index];
 
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% SLAB
-    if (typeid(*cell) == typeid(chi_mesh::CellSlab))
+    if (cell->Type() == chi_mesh::SLAB_CELL)
     {
       chi_log.Log(LOG_0)
         << "FieldFunctionInterpolationSlice does not support 1D cells.";
@@ -49,13 +49,13 @@ void chi_mesh::FieldFunctionInterpolationSlice::
     }
 
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYGON
-    if (typeid(*cell) == typeid(chi_mesh::CellPolygon))
+    if (cell->Type() == chi_mesh::POLYGON_CELL)
     {
       intersecting_cell_indices.push_back(cell_glob_index);
     }
 
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYHEDRON
-    else if (typeid(*cell) == typeid(chi_mesh::CellPolyhedron))
+    else if (cell->Type() == chi_mesh::POLYHEDRON_CELL)
     {
       chi_mesh::CellPolyhedron* polyh_cell = (chi_mesh::CellPolyhedron*)cell;
       bool intersects = false;
@@ -97,7 +97,7 @@ void chi_mesh::FieldFunctionInterpolationSlice::
     auto cell = grid_view->cells[cell_glob_index];
 
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYGON
-    if (typeid(*cell) == typeid(chi_mesh::CellPolygon))
+    if (cell->Type() == chi_mesh::POLYGON_CELL)
     {
       chi_mesh::CellPolygon* poly_cell = (chi_mesh::CellPolygon*)cell;
 
@@ -155,7 +155,7 @@ void chi_mesh::FieldFunctionInterpolationSlice::
 
 
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYHEDRON
-    if (typeid(*cell) == typeid(chi_mesh::CellPolyhedron))
+    if (cell->Type() == chi_mesh::POLYHEDRON_CELL)
     {
       chi_mesh::CellPolyhedron* polyh_cell = (chi_mesh::CellPolyhedron*)cell;
 

--- a/CHI_TECH/ChiMesh/FieldFunctionInterpolation/Slice/chi_ffinter_slice_initialize.cc
+++ b/CHI_TECH/ChiMesh/FieldFunctionInterpolation/Slice/chi_ffinter_slice_initialize.cc
@@ -41,7 +41,7 @@ void chi_mesh::FieldFunctionInterpolationSlice::
     auto cell = grid_view->cells[cell_glob_index];
 
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% SLAB
-    if (cell->Type() == chi_mesh::SLAB_CELL)
+    if (cell->Type() == chi_mesh::CellTypes::SLAB_CELL)
     {
       chi_log.Log(LOG_0)
         << "FieldFunctionInterpolationSlice does not support 1D cells.";
@@ -49,13 +49,13 @@ void chi_mesh::FieldFunctionInterpolationSlice::
     }
 
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYGON
-    if (cell->Type() == chi_mesh::POLYGON_CELL)
+    if (cell->Type() == chi_mesh::CellTypes::POLYGON_CELL)
     {
       intersecting_cell_indices.push_back(cell_glob_index);
     }
 
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYHEDRON
-    else if (cell->Type() == chi_mesh::POLYHEDRON_CELL)
+    else if (cell->Type() == chi_mesh::CellTypes::POLYHEDRON_CELL)
     {
       chi_mesh::CellPolyhedron* polyh_cell = (chi_mesh::CellPolyhedron*)cell;
       bool intersects = false;
@@ -97,7 +97,7 @@ void chi_mesh::FieldFunctionInterpolationSlice::
     auto cell = grid_view->cells[cell_glob_index];
 
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYGON
-    if (cell->Type() == chi_mesh::POLYGON_CELL)
+    if (cell->Type() == chi_mesh::CellTypes::POLYGON_CELL)
     {
       chi_mesh::CellPolygon* poly_cell = (chi_mesh::CellPolygon*)cell;
 
@@ -155,7 +155,7 @@ void chi_mesh::FieldFunctionInterpolationSlice::
 
 
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYHEDRON
-    if (cell->Type() == chi_mesh::POLYHEDRON_CELL)
+    if (cell->Type() == chi_mesh::CellTypes::POLYHEDRON_CELL)
     {
       chi_mesh::CellPolyhedron* polyh_cell = (chi_mesh::CellPolyhedron*)cell;
 

--- a/CHI_TECH/ChiMesh/FieldFunctionInterpolation/Volume/chi_ffinter_volume_execute.cc
+++ b/CHI_TECH/ChiMesh/FieldFunctionInterpolation/Volume/chi_ffinter_volume_execute.cc
@@ -69,7 +69,7 @@ CFEMInterpolate(Vec field, std::vector<int> &mapping)
     if (inside_logvolume)
     {
       //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% SLAB
-      if (typeid(*cell) == typeid(chi_mesh::CellSlab))
+      if (cell->Type() == chi_mesh::SLAB_CELL)
       {
         chi_mesh::CellSlab* slab_cell = (chi_mesh::CellSlab*)cell;
         SlabFEView* cell_fe_view =
@@ -102,7 +102,7 @@ CFEMInterpolate(Vec field, std::vector<int> &mapping)
       }//if slab
 
       //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYGON
-      if (typeid(*cell) == typeid(chi_mesh::CellPolygon))
+      if (cell->Type() == chi_mesh::POLYGON_CELL)
       {
         chi_mesh::CellPolygon* poly_cell = (chi_mesh::CellPolygon*)cell;
         PolygonFEView* cell_fe_view =
@@ -134,7 +134,7 @@ CFEMInterpolate(Vec field, std::vector<int> &mapping)
       }//if polygon
 
       //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYHEDRON
-      if (typeid(*cell) == typeid(chi_mesh::CellPolyhedron))
+      if (cell->Type() == chi_mesh::POLYHEDRON_CELL)
       {
         chi_mesh::CellPolyhedron* polyh_cell = (chi_mesh::CellPolyhedron*)cell;
         PolyhedronFEView* cell_fe_view =
@@ -212,7 +212,7 @@ PWLDInterpolate(std::vector<double>& field, std::vector<int> &mapping)
     if (inside_logvolume)
     {
       //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% SLAB
-      if (typeid(*cell) == typeid(chi_mesh::CellSlab))
+      if (cell->Type() == chi_mesh::SLAB_CELL)
       {
         chi_mesh::CellSlab* slab_cell = (chi_mesh::CellSlab*)cell;
         SlabFEView* cell_fe_view =
@@ -243,7 +243,7 @@ PWLDInterpolate(std::vector<double>& field, std::vector<int> &mapping)
         }//for dof
       }//if slab
       //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYGON
-      if (typeid(*cell) == typeid(chi_mesh::CellPolygon))
+      if (cell->Type() == chi_mesh::POLYGON_CELL)
       {
         chi_mesh::CellPolygon* poly_cell = (chi_mesh::CellPolygon*)cell;
         PolygonFEView* cell_fe_view =
@@ -274,7 +274,7 @@ PWLDInterpolate(std::vector<double>& field, std::vector<int> &mapping)
         }//for dof
       }//if Polygon
       //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYHEDRON
-      if (typeid(*cell) == typeid(chi_mesh::CellPolyhedron))
+      if (cell->Type() == chi_mesh::POLYHEDRON_CELL)
       {
         chi_mesh::CellPolyhedron* polyh_cell = (chi_mesh::CellPolyhedron*)cell;
         PolyhedronFEView* cell_fe_view =

--- a/CHI_TECH/ChiMesh/FieldFunctionInterpolation/Volume/chi_ffinter_volume_execute.cc
+++ b/CHI_TECH/ChiMesh/FieldFunctionInterpolation/Volume/chi_ffinter_volume_execute.cc
@@ -69,7 +69,7 @@ CFEMInterpolate(Vec field, std::vector<int> &mapping)
     if (inside_logvolume)
     {
       //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% SLAB
-      if (cell->Type() == chi_mesh::SLAB_CELL)
+      if (cell->Type() == chi_mesh::CellTypes::SLAB_CELL)
       {
         chi_mesh::CellSlab* slab_cell = (chi_mesh::CellSlab*)cell;
         SlabFEView* cell_fe_view =
@@ -102,7 +102,7 @@ CFEMInterpolate(Vec field, std::vector<int> &mapping)
       }//if slab
 
       //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYGON
-      if (cell->Type() == chi_mesh::POLYGON_CELL)
+      if (cell->Type() == chi_mesh::CellTypes::POLYGON_CELL)
       {
         chi_mesh::CellPolygon* poly_cell = (chi_mesh::CellPolygon*)cell;
         PolygonFEView* cell_fe_view =
@@ -134,7 +134,7 @@ CFEMInterpolate(Vec field, std::vector<int> &mapping)
       }//if polygon
 
       //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYHEDRON
-      if (cell->Type() == chi_mesh::POLYHEDRON_CELL)
+      if (cell->Type() == chi_mesh::CellTypes::POLYHEDRON_CELL)
       {
         chi_mesh::CellPolyhedron* polyh_cell = (chi_mesh::CellPolyhedron*)cell;
         PolyhedronFEView* cell_fe_view =
@@ -212,7 +212,7 @@ PWLDInterpolate(std::vector<double>& field, std::vector<int> &mapping)
     if (inside_logvolume)
     {
       //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% SLAB
-      if (cell->Type() == chi_mesh::SLAB_CELL)
+      if (cell->Type() == chi_mesh::CellTypes::SLAB_CELL)
       {
         chi_mesh::CellSlab* slab_cell = (chi_mesh::CellSlab*)cell;
         SlabFEView* cell_fe_view =
@@ -243,7 +243,7 @@ PWLDInterpolate(std::vector<double>& field, std::vector<int> &mapping)
         }//for dof
       }//if slab
       //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYGON
-      if (cell->Type() == chi_mesh::POLYGON_CELL)
+      if (cell->Type() == chi_mesh::CellTypes::POLYGON_CELL)
       {
         chi_mesh::CellPolygon* poly_cell = (chi_mesh::CellPolygon*)cell;
         PolygonFEView* cell_fe_view =
@@ -274,7 +274,7 @@ PWLDInterpolate(std::vector<double>& field, std::vector<int> &mapping)
         }//for dof
       }//if Polygon
       //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYHEDRON
-      if (cell->Type() == chi_mesh::POLYHEDRON_CELL)
+      if (cell->Type() == chi_mesh::CellTypes::POLYHEDRON_CELL)
       {
         chi_mesh::CellPolyhedron* polyh_cell = (chi_mesh::CellPolyhedron*)cell;
         PolyhedronFEView* cell_fe_view =

--- a/CHI_TECH/ChiMesh/FieldFunctionInterpolation/Volume/chi_ffinter_volume_execute.cc
+++ b/CHI_TECH/ChiMesh/FieldFunctionInterpolation/Volume/chi_ffinter_volume_execute.cc
@@ -69,7 +69,7 @@ CFEMInterpolate(Vec field, std::vector<int> &mapping)
     if (inside_logvolume)
     {
       //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% SLAB
-      if (cell->Type() == chi_mesh::CellTypes::SLAB_CELL)
+      if (cell->Type() == chi_mesh::CellType::SLAB)
       {
         chi_mesh::CellSlab* slab_cell = (chi_mesh::CellSlab*)cell;
         SlabFEView* cell_fe_view =
@@ -102,7 +102,7 @@ CFEMInterpolate(Vec field, std::vector<int> &mapping)
       }//if slab
 
       //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYGON
-      if (cell->Type() == chi_mesh::CellTypes::POLYGON_CELL)
+      if (cell->Type() == chi_mesh::CellType::POLYGON)
       {
         chi_mesh::CellPolygon* poly_cell = (chi_mesh::CellPolygon*)cell;
         PolygonFEView* cell_fe_view =
@@ -134,7 +134,7 @@ CFEMInterpolate(Vec field, std::vector<int> &mapping)
       }//if polygon
 
       //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYHEDRON
-      if (cell->Type() == chi_mesh::CellTypes::POLYHEDRON_CELL)
+      if (cell->Type() == chi_mesh::CellType::POLYHEDRON)
       {
         chi_mesh::CellPolyhedron* polyh_cell = (chi_mesh::CellPolyhedron*)cell;
         PolyhedronFEView* cell_fe_view =
@@ -212,7 +212,7 @@ PWLDInterpolate(std::vector<double>& field, std::vector<int> &mapping)
     if (inside_logvolume)
     {
       //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% SLAB
-      if (cell->Type() == chi_mesh::CellTypes::SLAB_CELL)
+      if (cell->Type() == chi_mesh::CellType::SLAB)
       {
         chi_mesh::CellSlab* slab_cell = (chi_mesh::CellSlab*)cell;
         SlabFEView* cell_fe_view =
@@ -243,7 +243,7 @@ PWLDInterpolate(std::vector<double>& field, std::vector<int> &mapping)
         }//for dof
       }//if slab
       //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYGON
-      if (cell->Type() == chi_mesh::CellTypes::POLYGON_CELL)
+      if (cell->Type() == chi_mesh::CellType::POLYGON)
       {
         chi_mesh::CellPolygon* poly_cell = (chi_mesh::CellPolygon*)cell;
         PolygonFEView* cell_fe_view =
@@ -274,7 +274,7 @@ PWLDInterpolate(std::vector<double>& field, std::vector<int> &mapping)
         }//for dof
       }//if Polygon
       //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYHEDRON
-      if (cell->Type() == chi_mesh::CellTypes::POLYHEDRON_CELL)
+      if (cell->Type() == chi_mesh::CellType::POLYHEDRON)
       {
         chi_mesh::CellPolyhedron* polyh_cell = (chi_mesh::CellPolyhedron*)cell;
         PolyhedronFEView* cell_fe_view =

--- a/CHI_TECH/ChiMesh/FieldFunctionInterpolation/Volume/chi_ffinter_volume_initialize.cc
+++ b/CHI_TECH/ChiMesh/FieldFunctionInterpolation/Volume/chi_ffinter_volume_initialize.cc
@@ -39,7 +39,7 @@ void chi_mesh::FieldFunctionInterpolationVolume::Initialize()
     if (inside_logvolume)
     {
       //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% Slab
-      if (typeid(*cell) == typeid(chi_mesh::CellSlab))
+      if (cell->Type() == chi_mesh::SLAB_CELL)
       {
         chi_mesh::CellSlab* slab_cell = (chi_mesh::CellSlab*)cell;
 
@@ -52,7 +52,7 @@ void chi_mesh::FieldFunctionInterpolationVolume::Initialize()
       }
 
       //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYGON
-      if (typeid(*cell) == typeid(chi_mesh::CellPolygon))
+      if (cell->Type() == chi_mesh::POLYGON_CELL)
       {
         chi_mesh::CellPolygon* poly_cell = (chi_mesh::CellPolygon*)cell;
 
@@ -65,7 +65,7 @@ void chi_mesh::FieldFunctionInterpolationVolume::Initialize()
       }
 
       //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYHEDRON
-      if (typeid(*cell) == typeid(chi_mesh::CellPolyhedron))
+      if (cell->Type() == chi_mesh::POLYHEDRON_CELL)
       {
         chi_mesh::CellPolyhedron* polyh_cell = (chi_mesh::CellPolyhedron*)cell;
 

--- a/CHI_TECH/ChiMesh/FieldFunctionInterpolation/Volume/chi_ffinter_volume_initialize.cc
+++ b/CHI_TECH/ChiMesh/FieldFunctionInterpolation/Volume/chi_ffinter_volume_initialize.cc
@@ -39,7 +39,7 @@ void chi_mesh::FieldFunctionInterpolationVolume::Initialize()
     if (inside_logvolume)
     {
       //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% Slab
-      if (cell->Type() == chi_mesh::CellTypes::SLAB_CELL)
+      if (cell->Type() == chi_mesh::CellType::SLAB)
       {
         chi_mesh::CellSlab* slab_cell = (chi_mesh::CellSlab*)cell;
 
@@ -52,7 +52,7 @@ void chi_mesh::FieldFunctionInterpolationVolume::Initialize()
       }
 
       //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYGON
-      if (cell->Type() == chi_mesh::CellTypes::POLYGON_CELL)
+      if (cell->Type() == chi_mesh::CellType::POLYGON)
       {
         chi_mesh::CellPolygon* poly_cell = (chi_mesh::CellPolygon*)cell;
 
@@ -65,7 +65,7 @@ void chi_mesh::FieldFunctionInterpolationVolume::Initialize()
       }
 
       //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYHEDRON
-      if (cell->Type() == chi_mesh::CellTypes::POLYHEDRON_CELL)
+      if (cell->Type() == chi_mesh::CellType::POLYHEDRON)
       {
         chi_mesh::CellPolyhedron* polyh_cell = (chi_mesh::CellPolyhedron*)cell;
 

--- a/CHI_TECH/ChiMesh/FieldFunctionInterpolation/Volume/chi_ffinter_volume_initialize.cc
+++ b/CHI_TECH/ChiMesh/FieldFunctionInterpolation/Volume/chi_ffinter_volume_initialize.cc
@@ -39,7 +39,7 @@ void chi_mesh::FieldFunctionInterpolationVolume::Initialize()
     if (inside_logvolume)
     {
       //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% Slab
-      if (cell->Type() == chi_mesh::SLAB_CELL)
+      if (cell->Type() == chi_mesh::CellTypes::SLAB_CELL)
       {
         chi_mesh::CellSlab* slab_cell = (chi_mesh::CellSlab*)cell;
 
@@ -52,7 +52,7 @@ void chi_mesh::FieldFunctionInterpolationVolume::Initialize()
       }
 
       //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYGON
-      if (cell->Type() == chi_mesh::POLYGON_CELL)
+      if (cell->Type() == chi_mesh::CellTypes::POLYGON_CELL)
       {
         chi_mesh::CellPolygon* poly_cell = (chi_mesh::CellPolygon*)cell;
 
@@ -65,7 +65,7 @@ void chi_mesh::FieldFunctionInterpolationVolume::Initialize()
       }
 
       //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYHEDRON
-      if (cell->Type() == chi_mesh::POLYHEDRON_CELL)
+      if (cell->Type() == chi_mesh::CellTypes::POLYHEDRON_CELL)
       {
         chi_mesh::CellPolyhedron* polyh_cell = (chi_mesh::CellPolyhedron*)cell;
 

--- a/CHI_TECH/ChiMesh/MeshContinuum/chi_meshcontinuum_connectgrid.cc
+++ b/CHI_TECH/ChiMesh/MeshContinuum/chi_meshcontinuum_connectgrid.cc
@@ -138,7 +138,7 @@ int chi_mesh::MeshContinuum::FindAssociatedFace(chi_mesh::PolyFace *cur_face,
 
   chi_mesh::Cell* cell = cells[adj_cell_g_index];
 
-  if (cell->Type() != chi_mesh::CellTypes::POLYHEDRON_CELL)
+  if (cell->Type() != chi_mesh::CellType::POLYHEDRON)
   {
     chi_log.Log(LOG_ALLERROR)
       << "Invalid cell type encountered in "
@@ -251,7 +251,7 @@ int chi_mesh::MeshContinuum::FindAssociatedEdge(int* edgeinfo,
 
   chi_mesh::Cell* cell = cells[adj_cell_g_index];
 
-  if (cell->Type() != chi_mesh::CellTypes::POLYGON_CELL)
+  if (cell->Type() != chi_mesh::CellType::POLYGON)
   {
     chi_log.Log(LOG_ALLERROR)
       << "Invalid cell type encountered in "
@@ -348,7 +348,7 @@ void chi_mesh::MeshContinuum::
 
   chi_mesh::Cell* cell = cells[adj_cell_g_index];
 
-  if (cell->Type() != chi_mesh::CellTypes::POLYHEDRON_CELL)
+  if (cell->Type() != chi_mesh::CellType::POLYHEDRON)
   {
     chi_log.Log(LOG_ALLERROR)
       << "Invalid cell type encountered in "

--- a/CHI_TECH/ChiMesh/MeshContinuum/chi_meshcontinuum_connectgrid.cc
+++ b/CHI_TECH/ChiMesh/MeshContinuum/chi_meshcontinuum_connectgrid.cc
@@ -138,7 +138,7 @@ int chi_mesh::MeshContinuum::FindAssociatedFace(chi_mesh::PolyFace *cur_face,
 
   chi_mesh::Cell* cell = cells[adj_cell_g_index];
 
-  if (cell->Type() != chi_mesh::POLYHEDRON_CELL)
+  if (cell->Type() != chi_mesh::CellTypes::POLYHEDRON_CELL)
   {
     chi_log.Log(LOG_ALLERROR)
       << "Invalid cell type encountered in "
@@ -251,7 +251,7 @@ int chi_mesh::MeshContinuum::FindAssociatedEdge(int* edgeinfo,
 
   chi_mesh::Cell* cell = cells[adj_cell_g_index];
 
-  if (cell->Type() != chi_mesh::POLYGON_CELL)
+  if (cell->Type() != chi_mesh::CellTypes::POLYGON_CELL)
   {
     chi_log.Log(LOG_ALLERROR)
       << "Invalid cell type encountered in "
@@ -348,7 +348,7 @@ void chi_mesh::MeshContinuum::
 
   chi_mesh::Cell* cell = cells[adj_cell_g_index];
 
-  if (cell->Type() != chi_mesh::POLYHEDRON_CELL)
+  if (cell->Type() != chi_mesh::CellTypes::POLYHEDRON_CELL)
   {
     chi_log.Log(LOG_ALLERROR)
       << "Invalid cell type encountered in "

--- a/CHI_TECH/ChiMesh/MeshContinuum/chi_meshcontinuum_connectgrid.cc
+++ b/CHI_TECH/ChiMesh/MeshContinuum/chi_meshcontinuum_connectgrid.cc
@@ -138,7 +138,7 @@ int chi_mesh::MeshContinuum::FindAssociatedFace(chi_mesh::PolyFace *cur_face,
 
   chi_mesh::Cell* cell = cells[adj_cell_g_index];
 
-  if (typeid(*cell) != typeid(chi_mesh::CellPolyhedron))
+  if (cell->Type() != chi_mesh::POLYHEDRON_CELL)
   {
     chi_log.Log(LOG_ALLERROR)
       << "Invalid cell type encountered in "
@@ -251,7 +251,7 @@ int chi_mesh::MeshContinuum::FindAssociatedEdge(int* edgeinfo,
 
   chi_mesh::Cell* cell = cells[adj_cell_g_index];
 
-  if (typeid(*cell) != typeid(chi_mesh::CellPolygon))
+  if (cell->Type() != chi_mesh::POLYGON_CELL)
   {
     chi_log.Log(LOG_ALLERROR)
       << "Invalid cell type encountered in "
@@ -348,7 +348,7 @@ void chi_mesh::MeshContinuum::
 
   chi_mesh::Cell* cell = cells[adj_cell_g_index];
 
-  if (typeid(*cell) != typeid(chi_mesh::CellPolyhedron))
+  if (cell->Type() != chi_mesh::POLYHEDRON_CELL)
   {
     chi_log.Log(LOG_ALLERROR)
       << "Invalid cell type encountered in "

--- a/CHI_TECH/ChiMesh/MeshContinuum/chi_meshcontinuum_exportvtk.cc
+++ b/CHI_TECH/ChiMesh/MeshContinuum/chi_meshcontinuum_exportvtk.cc
@@ -74,7 +74,7 @@ void chi_mesh::MeshContinuum::ExportCellsToVTK(const char* baseName)
     int mat_id = cell->material_id;
 
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYGON
-    if (cell->Type() == chi_mesh::SLAB_CELL)
+    if (cell->Type() == chi_mesh::CellTypes::SLAB_CELL)
     {
       auto slab_cell = (chi_mesh::CellSlab*)cell;
 
@@ -91,7 +91,7 @@ void chi_mesh::MeshContinuum::ExportCellsToVTK(const char* baseName)
     }
 
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYGON
-    if (cell->Type() == chi_mesh::POLYGON_CELL)
+    if (cell->Type() == chi_mesh::CellTypes::POLYGON_CELL)
     {
       auto poly_cell = (chi_mesh::CellPolygon*)cell;
 
@@ -110,7 +110,7 @@ void chi_mesh::MeshContinuum::ExportCellsToVTK(const char* baseName)
     }
 
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYHEDRON
-    if (cell->Type() == chi_mesh::POLYHEDRON_CELL)
+    if (cell->Type() == chi_mesh::CellTypes::POLYHEDRON_CELL)
     {
       auto polyh_cell = (chi_mesh::CellPolyhedron*)cell;
 

--- a/CHI_TECH/ChiMesh/MeshContinuum/chi_meshcontinuum_exportvtk.cc
+++ b/CHI_TECH/ChiMesh/MeshContinuum/chi_meshcontinuum_exportvtk.cc
@@ -74,7 +74,7 @@ void chi_mesh::MeshContinuum::ExportCellsToVTK(const char* baseName)
     int mat_id = cell->material_id;
 
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYGON
-    if (cell->Type() == chi_mesh::CellTypes::SLAB_CELL)
+    if (cell->Type() == chi_mesh::CellType::SLAB)
     {
       auto slab_cell = (chi_mesh::CellSlab*)cell;
 
@@ -91,7 +91,7 @@ void chi_mesh::MeshContinuum::ExportCellsToVTK(const char* baseName)
     }
 
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYGON
-    if (cell->Type() == chi_mesh::CellTypes::POLYGON_CELL)
+    if (cell->Type() == chi_mesh::CellType::POLYGON)
     {
       auto poly_cell = (chi_mesh::CellPolygon*)cell;
 
@@ -110,7 +110,7 @@ void chi_mesh::MeshContinuum::ExportCellsToVTK(const char* baseName)
     }
 
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYHEDRON
-    if (cell->Type() == chi_mesh::CellTypes::POLYHEDRON_CELL)
+    if (cell->Type() == chi_mesh::CellType::POLYHEDRON)
     {
       auto polyh_cell = (chi_mesh::CellPolyhedron*)cell;
 

--- a/CHI_TECH/ChiMesh/MeshContinuum/chi_meshcontinuum_exportvtk.cc
+++ b/CHI_TECH/ChiMesh/MeshContinuum/chi_meshcontinuum_exportvtk.cc
@@ -74,7 +74,7 @@ void chi_mesh::MeshContinuum::ExportCellsToVTK(const char* baseName)
     int mat_id = cell->material_id;
 
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYGON
-    if (typeid(*cell) == typeid(chi_mesh::CellSlab))
+    if (cell->Type() == chi_mesh::SLAB_CELL)
     {
       auto slab_cell = (chi_mesh::CellSlab*)cell;
 
@@ -91,7 +91,7 @@ void chi_mesh::MeshContinuum::ExportCellsToVTK(const char* baseName)
     }
 
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYGON
-    if (typeid(*cell) == typeid(chi_mesh::CellPolygon))
+    if (cell->Type() == chi_mesh::POLYGON_CELL)
     {
       auto poly_cell = (chi_mesh::CellPolygon*)cell;
 
@@ -110,7 +110,7 @@ void chi_mesh::MeshContinuum::ExportCellsToVTK(const char* baseName)
     }
 
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYHEDRON
-    if (typeid(*cell) == typeid(chi_mesh::CellPolyhedron))
+    if (cell->Type() == chi_mesh::POLYHEDRON_CELL)
     {
       auto polyh_cell = (chi_mesh::CellPolyhedron*)cell;
 

--- a/CHI_TECH/ChiMesh/Raytrace/raytrace.cc
+++ b/CHI_TECH/ChiMesh/Raytrace/raytrace.cc
@@ -50,7 +50,7 @@ void chi_mesh::RayTrace(chi_mesh::MeshContinuum* grid,
   chi_mesh::Vector pos_f_line = pos_i_copy + omega_i_copy*extention_distance;
 
   //$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$ SLAB
-  if (cell->Type() == chi_mesh::CellTypes::SLAB_CELL)
+  if (cell->Type() == chi_mesh::CellType::SLAB)
   {
     auto slab_cell = (chi_mesh::CellSlab*)cell;
 
@@ -89,7 +89,7 @@ void chi_mesh::RayTrace(chi_mesh::MeshContinuum* grid,
 
   }//slab
   //$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$ POLYGON
-  else if (cell->Type() == chi_mesh::CellTypes::POLYGON_CELL)
+  else if (cell->Type() == chi_mesh::CellType::POLYGON)
   {
     auto poly_cell = (chi_mesh::CellPolygon*)cell;
 

--- a/CHI_TECH/ChiMesh/Raytrace/raytrace.cc
+++ b/CHI_TECH/ChiMesh/Raytrace/raytrace.cc
@@ -50,7 +50,7 @@ void chi_mesh::RayTrace(chi_mesh::MeshContinuum* grid,
   chi_mesh::Vector pos_f_line = pos_i_copy + omega_i_copy*extention_distance;
 
   //$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$ SLAB
-  if (cell->Type() == chi_mesh::SLAB_CELL)
+  if (cell->Type() == chi_mesh::CellTypes::SLAB_CELL)
   {
     auto slab_cell = (chi_mesh::CellSlab*)cell;
 
@@ -89,7 +89,7 @@ void chi_mesh::RayTrace(chi_mesh::MeshContinuum* grid,
 
   }//slab
   //$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$ POLYGON
-  else if (cell->Type() == chi_mesh::POLYGON_CELL)
+  else if (cell->Type() == chi_mesh::CellTypes::POLYGON_CELL)
   {
     auto poly_cell = (chi_mesh::CellPolygon*)cell;
 

--- a/CHI_TECH/ChiMesh/Raytrace/raytrace.cc
+++ b/CHI_TECH/ChiMesh/Raytrace/raytrace.cc
@@ -50,7 +50,7 @@ void chi_mesh::RayTrace(chi_mesh::MeshContinuum* grid,
   chi_mesh::Vector pos_f_line = pos_i_copy + omega_i_copy*extention_distance;
 
   //$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$ SLAB
-  if (typeid(*cell) == typeid(chi_mesh::CellSlab))
+  if (cell->Type() == chi_mesh::SLAB_CELL)
   {
     auto slab_cell = (chi_mesh::CellSlab*)cell;
 
@@ -89,7 +89,7 @@ void chi_mesh::RayTrace(chi_mesh::MeshContinuum* grid,
 
   }//slab
   //$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$ POLYGON
-  else if (typeid(*cell) == typeid(chi_mesh::CellPolygon))
+  else if (cell->Type() == chi_mesh::POLYGON_CELL)
   {
     auto poly_cell = (chi_mesh::CellPolygon*)cell;
 

--- a/CHI_TECH/ChiMesh/SweepUtilities/chi_FLUDS_01_alphapass.cc
+++ b/CHI_TECH/ChiMesh/SweepUtilities/chi_FLUDS_01_alphapass.cc
@@ -50,19 +50,19 @@ InitializeAlphaElements(chi_mesh::SweepManagement::SPDS* spds)
     std::vector<std::pair<int,std::vector<short>>> inco_face_dof_mapping;
 
     //$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$ SLAB
-    if (typeid(*cell) == typeid(chi_mesh::CellSlab))
+    if (cell->Type() == chi_mesh::SLAB_CELL)
     {
       TSlab* slab_cell = (TSlab*)cell;
       SlotDynamics(slab_cell,spds,lock_box,location_boundary_dependency_set);
     }//if slab
     // $$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$ POLYGON
-    else if (typeid(*cell) == typeid(chi_mesh::CellPolygon))
+    else if (cell->Type() == chi_mesh::POLYGON_CELL)
     {
       TPolygon* poly_cell = (TPolygon*)cell;
       SlotDynamics(poly_cell,spds,lock_box,location_boundary_dependency_set);
     }//if polygon
     // $$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$ POLYHEDRON
-    else if (typeid(*cell) == typeid(chi_mesh::CellPolyhedron))
+    else if (cell->Type() == chi_mesh::POLYHEDRON_CELL)
     {
       TPolyhedron* polyh_cell = (TPolyhedron*)cell;
       SlotDynamics(polyh_cell,spds,lock_box,location_boundary_dependency_set);
@@ -102,19 +102,19 @@ InitializeAlphaElements(chi_mesh::SweepManagement::SPDS* spds)
     auto cell         = grid->cells[cell_g_index];
 
     //$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$ SLAB
-    if (typeid(*cell) == typeid(chi_mesh::CellSlab))
+    if (cell->Type() == chi_mesh::SLAB_CELL)
     {
       TSlab* slab_cell = (TSlab*)cell;
       IncidentMapping(slab_cell,spds,local_so_cell_mapping);
     }//if slab
     // $$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$ POLYHEDRON
-    else if (typeid(*cell) == typeid(chi_mesh::CellPolygon))
+    else if (cell->Type() == chi_mesh::POLYGON_CELL)
     {
       TPolygon* poly_cell = (TPolygon*)cell;
       IncidentMapping(poly_cell,spds,local_so_cell_mapping);
     }//if polyhedron
     //$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$ POLYHEDRON
-    else if (typeid(*cell) == typeid(chi_mesh::CellPolyhedron))
+    else if (cell->Type() == chi_mesh::POLYHEDRON_CELL)
     {
       TPolyhedron* polyh_cell = (TPolyhedron*)cell;
       IncidentMapping(polyh_cell,spds,local_so_cell_mapping);

--- a/CHI_TECH/ChiMesh/SweepUtilities/chi_FLUDS_01_alphapass.cc
+++ b/CHI_TECH/ChiMesh/SweepUtilities/chi_FLUDS_01_alphapass.cc
@@ -50,19 +50,19 @@ InitializeAlphaElements(chi_mesh::SweepManagement::SPDS* spds)
     std::vector<std::pair<int,std::vector<short>>> inco_face_dof_mapping;
 
     //$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$ SLAB
-    if (cell->Type() == chi_mesh::SLAB_CELL)
+    if (cell->Type() == chi_mesh::CellTypes::SLAB_CELL)
     {
       TSlab* slab_cell = (TSlab*)cell;
       SlotDynamics(slab_cell,spds,lock_box,location_boundary_dependency_set);
     }//if slab
     // $$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$ POLYGON
-    else if (cell->Type() == chi_mesh::POLYGON_CELL)
+    else if (cell->Type() == chi_mesh::CellTypes::POLYGON_CELL)
     {
       TPolygon* poly_cell = (TPolygon*)cell;
       SlotDynamics(poly_cell,spds,lock_box,location_boundary_dependency_set);
     }//if polygon
     // $$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$ POLYHEDRON
-    else if (cell->Type() == chi_mesh::POLYHEDRON_CELL)
+    else if (cell->Type() == chi_mesh::CellTypes::POLYHEDRON_CELL)
     {
       TPolyhedron* polyh_cell = (TPolyhedron*)cell;
       SlotDynamics(polyh_cell,spds,lock_box,location_boundary_dependency_set);
@@ -102,19 +102,19 @@ InitializeAlphaElements(chi_mesh::SweepManagement::SPDS* spds)
     auto cell         = grid->cells[cell_g_index];
 
     //$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$ SLAB
-    if (cell->Type() == chi_mesh::SLAB_CELL)
+    if (cell->Type() == chi_mesh::CellTypes::SLAB_CELL)
     {
       TSlab* slab_cell = (TSlab*)cell;
       IncidentMapping(slab_cell,spds,local_so_cell_mapping);
     }//if slab
     // $$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$ POLYHEDRON
-    else if (cell->Type() == chi_mesh::POLYGON_CELL)
+    else if (cell->Type() == chi_mesh::CellTypes::POLYGON_CELL)
     {
       TPolygon* poly_cell = (TPolygon*)cell;
       IncidentMapping(poly_cell,spds,local_so_cell_mapping);
     }//if polyhedron
     //$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$ POLYHEDRON
-    else if (cell->Type() == chi_mesh::POLYHEDRON_CELL)
+    else if (cell->Type() == chi_mesh::CellTypes::POLYHEDRON_CELL)
     {
       TPolyhedron* polyh_cell = (TPolyhedron*)cell;
       IncidentMapping(polyh_cell,spds,local_so_cell_mapping);

--- a/CHI_TECH/ChiMesh/SweepUtilities/chi_FLUDS_01_alphapass.cc
+++ b/CHI_TECH/ChiMesh/SweepUtilities/chi_FLUDS_01_alphapass.cc
@@ -50,19 +50,19 @@ InitializeAlphaElements(chi_mesh::SweepManagement::SPDS* spds)
     std::vector<std::pair<int,std::vector<short>>> inco_face_dof_mapping;
 
     //$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$ SLAB
-    if (cell->Type() == chi_mesh::CellTypes::SLAB_CELL)
+    if (cell->Type() == chi_mesh::CellType::SLAB)
     {
       TSlab* slab_cell = (TSlab*)cell;
       SlotDynamics(slab_cell,spds,lock_box,location_boundary_dependency_set);
     }//if slab
     // $$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$ POLYGON
-    else if (cell->Type() == chi_mesh::CellTypes::POLYGON_CELL)
+    else if (cell->Type() == chi_mesh::CellType::POLYGON)
     {
       TPolygon* poly_cell = (TPolygon*)cell;
       SlotDynamics(poly_cell,spds,lock_box,location_boundary_dependency_set);
     }//if polygon
     // $$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$ POLYHEDRON
-    else if (cell->Type() == chi_mesh::CellTypes::POLYHEDRON_CELL)
+    else if (cell->Type() == chi_mesh::CellType::POLYHEDRON)
     {
       TPolyhedron* polyh_cell = (TPolyhedron*)cell;
       SlotDynamics(polyh_cell,spds,lock_box,location_boundary_dependency_set);
@@ -102,19 +102,19 @@ InitializeAlphaElements(chi_mesh::SweepManagement::SPDS* spds)
     auto cell         = grid->cells[cell_g_index];
 
     //$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$ SLAB
-    if (cell->Type() == chi_mesh::CellTypes::SLAB_CELL)
+    if (cell->Type() == chi_mesh::CellType::SLAB)
     {
       TSlab* slab_cell = (TSlab*)cell;
       IncidentMapping(slab_cell,spds,local_so_cell_mapping);
     }//if slab
     // $$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$ POLYHEDRON
-    else if (cell->Type() == chi_mesh::CellTypes::POLYGON_CELL)
+    else if (cell->Type() == chi_mesh::CellType::POLYGON)
     {
       TPolygon* poly_cell = (TPolygon*)cell;
       IncidentMapping(poly_cell,spds,local_so_cell_mapping);
     }//if polyhedron
     //$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$ POLYHEDRON
-    else if (cell->Type() == chi_mesh::CellTypes::POLYHEDRON_CELL)
+    else if (cell->Type() == chi_mesh::CellType::POLYHEDRON)
     {
       TPolyhedron* polyh_cell = (TPolyhedron*)cell;
       IncidentMapping(polyh_cell,spds,local_so_cell_mapping);

--- a/CHI_TECH/ChiMesh/SweepUtilities/chi_FLUDS_02_betapass.cc
+++ b/CHI_TECH/ChiMesh/SweepUtilities/chi_FLUDS_02_betapass.cc
@@ -87,19 +87,19 @@ InitializeBetaElements(chi_mesh::SweepManagement::SPDS* spds,int tag_index)
     auto cell         = grid->cells[cell_g_index];
 
     //$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$ SLAB
-    if (typeid(*cell) == typeid(chi_mesh::CellSlab))
+    if (cell->Type() == chi_mesh::SLAB_CELL)
     {
       TSlab* slab_cell = (TSlab*)cell;
       NLIncidentMapping(slab_cell,spds);
     }//if slab
     //$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$ POLYGON
-    else if (typeid(*cell) == typeid(chi_mesh::CellPolygon))
+    else if (cell->Type() == chi_mesh::POLYGON_CELL)
     {
       TPolygon* poly_cell = (TPolygon*)cell;
       NLIncidentMapping(poly_cell,spds);
     }//if polyhedron
     //$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$ POLYHEDRON
-    else if (typeid(*cell) == typeid(chi_mesh::CellPolyhedron))
+    else if (cell->Type() == chi_mesh::POLYHEDRON_CELL)
     {
       TPolyhedron* polyh_cell = (TPolyhedron*)cell;
       NLIncidentMapping(polyh_cell,spds);

--- a/CHI_TECH/ChiMesh/SweepUtilities/chi_FLUDS_02_betapass.cc
+++ b/CHI_TECH/ChiMesh/SweepUtilities/chi_FLUDS_02_betapass.cc
@@ -87,19 +87,19 @@ InitializeBetaElements(chi_mesh::SweepManagement::SPDS* spds,int tag_index)
     auto cell         = grid->cells[cell_g_index];
 
     //$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$ SLAB
-    if (cell->Type() == chi_mesh::CellTypes::SLAB_CELL)
+    if (cell->Type() == chi_mesh::CellType::SLAB)
     {
       TSlab* slab_cell = (TSlab*)cell;
       NLIncidentMapping(slab_cell,spds);
     }//if slab
     //$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$ POLYGON
-    else if (cell->Type() == chi_mesh::CellTypes::POLYGON_CELL)
+    else if (cell->Type() == chi_mesh::CellType::POLYGON)
     {
       TPolygon* poly_cell = (TPolygon*)cell;
       NLIncidentMapping(poly_cell,spds);
     }//if polyhedron
     //$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$ POLYHEDRON
-    else if (cell->Type() == chi_mesh::CellTypes::POLYHEDRON_CELL)
+    else if (cell->Type() == chi_mesh::CellType::POLYHEDRON)
     {
       TPolyhedron* polyh_cell = (TPolyhedron*)cell;
       NLIncidentMapping(polyh_cell,spds);

--- a/CHI_TECH/ChiMesh/SweepUtilities/chi_FLUDS_02_betapass.cc
+++ b/CHI_TECH/ChiMesh/SweepUtilities/chi_FLUDS_02_betapass.cc
@@ -87,19 +87,19 @@ InitializeBetaElements(chi_mesh::SweepManagement::SPDS* spds,int tag_index)
     auto cell         = grid->cells[cell_g_index];
 
     //$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$ SLAB
-    if (cell->Type() == chi_mesh::SLAB_CELL)
+    if (cell->Type() == chi_mesh::CellTypes::SLAB_CELL)
     {
       TSlab* slab_cell = (TSlab*)cell;
       NLIncidentMapping(slab_cell,spds);
     }//if slab
     //$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$ POLYGON
-    else if (cell->Type() == chi_mesh::POLYGON_CELL)
+    else if (cell->Type() == chi_mesh::CellTypes::POLYGON_CELL)
     {
       TPolygon* poly_cell = (TPolygon*)cell;
       NLIncidentMapping(poly_cell,spds);
     }//if polyhedron
     //$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$ POLYHEDRON
-    else if (cell->Type() == chi_mesh::POLYHEDRON_CELL)
+    else if (cell->Type() == chi_mesh::CellTypes::POLYHEDRON_CELL)
     {
       TPolyhedron* polyh_cell = (TPolyhedron*)cell;
       NLIncidentMapping(polyh_cell,spds);

--- a/CHI_TECH/ChiMesh/SweepUtilities/chi_sweep_01_createsweepordering.cc
+++ b/CHI_TECH/ChiMesh/SweepUtilities/chi_sweep_01_createsweepordering.cc
@@ -84,7 +84,7 @@ CreateSweepOrder(double polar, double azimuthal,
     chi_mesh::Cell* cell = vol_continuum->cells[cell_index];
 
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% SLAB
-    if (typeid(*cell) == typeid(chi_mesh::CellSlab))
+    if (cell->Type() == chi_mesh::SLAB_CELL)
     {
       auto slab_cell = (chi_mesh::CellSlab*)cell;
 
@@ -144,7 +144,7 @@ CreateSweepOrder(double polar, double azimuthal,
       }//for face
     }
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYGON
-    else if (typeid(*cell) == typeid(chi_mesh::CellPolygon))
+    else if (cell->Type() == chi_mesh::POLYGON_CELL)
     {
       auto poly_cell = (chi_mesh::CellPolygon*)cell;
 
@@ -203,7 +203,7 @@ CreateSweepOrder(double polar, double azimuthal,
       }//for edge
     } //If polygon
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYHEDRON
-    else if (typeid(*cell) == typeid(chi_mesh::CellPolyhedron))
+    else if (cell->Type() == chi_mesh::POLYHEDRON_CELL)
     {
       auto polyh_cell = (chi_mesh::CellPolyhedron*)cell;
 

--- a/CHI_TECH/ChiMesh/SweepUtilities/chi_sweep_01_createsweepordering.cc
+++ b/CHI_TECH/ChiMesh/SweepUtilities/chi_sweep_01_createsweepordering.cc
@@ -84,7 +84,7 @@ CreateSweepOrder(double polar, double azimuthal,
     chi_mesh::Cell* cell = vol_continuum->cells[cell_index];
 
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% SLAB
-    if (cell->Type() == chi_mesh::SLAB_CELL)
+    if (cell->Type() == chi_mesh::CellTypes::SLAB_CELL)
     {
       auto slab_cell = (chi_mesh::CellSlab*)cell;
 
@@ -144,7 +144,7 @@ CreateSweepOrder(double polar, double azimuthal,
       }//for face
     }
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYGON
-    else if (cell->Type() == chi_mesh::POLYGON_CELL)
+    else if (cell->Type() == chi_mesh::CellTypes::POLYGON_CELL)
     {
       auto poly_cell = (chi_mesh::CellPolygon*)cell;
 
@@ -203,7 +203,7 @@ CreateSweepOrder(double polar, double azimuthal,
       }//for edge
     } //If polygon
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYHEDRON
-    else if (cell->Type() == chi_mesh::POLYHEDRON_CELL)
+    else if (cell->Type() == chi_mesh::CellTypes::POLYHEDRON_CELL)
     {
       auto polyh_cell = (chi_mesh::CellPolyhedron*)cell;
 

--- a/CHI_TECH/ChiMesh/SweepUtilities/chi_sweep_01_createsweepordering.cc
+++ b/CHI_TECH/ChiMesh/SweepUtilities/chi_sweep_01_createsweepordering.cc
@@ -84,7 +84,7 @@ CreateSweepOrder(double polar, double azimuthal,
     chi_mesh::Cell* cell = vol_continuum->cells[cell_index];
 
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% SLAB
-    if (cell->Type() == chi_mesh::CellTypes::SLAB_CELL)
+    if (cell->Type() == chi_mesh::CellType::SLAB)
     {
       auto slab_cell = (chi_mesh::CellSlab*)cell;
 
@@ -144,7 +144,7 @@ CreateSweepOrder(double polar, double azimuthal,
       }//for face
     }
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYGON
-    else if (cell->Type() == chi_mesh::CellTypes::POLYGON_CELL)
+    else if (cell->Type() == chi_mesh::CellType::POLYGON)
     {
       auto poly_cell = (chi_mesh::CellPolygon*)cell;
 
@@ -203,7 +203,7 @@ CreateSweepOrder(double polar, double azimuthal,
       }//for edge
     } //If polygon
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYHEDRON
-    else if (cell->Type() == chi_mesh::CellTypes::POLYHEDRON_CELL)
+    else if (cell->Type() == chi_mesh::CellType::POLYHEDRON)
     {
       auto polyh_cell = (chi_mesh::CellPolyhedron*)cell;
 

--- a/CHI_TECH/ChiMesh/SweepUtilities/chi_sweep_03_printsweepordering.cc
+++ b/CHI_TECH/ChiMesh/SweepUtilities/chi_sweep_03_printsweepordering.cc
@@ -45,7 +45,7 @@ void chi_mesh::SweepManagement::
     int cell_index = sweep_order->spls->item_id[ci];
     chi_mesh::Cell* cell =  vol_continuum->cells[cell_index];
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYGON
-    if (cell->Type() == chi_mesh::POLYGON_CELL)
+    if (cell->Type() == chi_mesh::CellTypes::POLYGON_CELL)
     {
       auto poly_cell = (chi_mesh::CellPolygon*)cell;
 

--- a/CHI_TECH/ChiMesh/SweepUtilities/chi_sweep_03_printsweepordering.cc
+++ b/CHI_TECH/ChiMesh/SweepUtilities/chi_sweep_03_printsweepordering.cc
@@ -45,7 +45,7 @@ void chi_mesh::SweepManagement::
     int cell_index = sweep_order->spls->item_id[ci];
     chi_mesh::Cell* cell =  vol_continuum->cells[cell_index];
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYGON
-    if (cell->Type() == chi_mesh::CellTypes::POLYGON_CELL)
+    if (cell->Type() == chi_mesh::CellType::POLYGON)
     {
       auto poly_cell = (chi_mesh::CellPolygon*)cell;
 

--- a/CHI_TECH/ChiMesh/SweepUtilities/chi_sweep_03_printsweepordering.cc
+++ b/CHI_TECH/ChiMesh/SweepUtilities/chi_sweep_03_printsweepordering.cc
@@ -45,7 +45,7 @@ void chi_mesh::SweepManagement::
     int cell_index = sweep_order->spls->item_id[ci];
     chi_mesh::Cell* cell =  vol_continuum->cells[cell_index];
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYGON
-    if (typeid(*cell) == typeid(chi_mesh::CellPolygon))
+    if (cell->Type() == chi_mesh::POLYGON_CELL)
     {
       auto poly_cell = (chi_mesh::CellPolygon*)cell;
 

--- a/CHI_TECH/ChiMesh/VolumeMesher/Extruder/volmesher_extruder_05_extrudecells.cc
+++ b/CHI_TECH/ChiMesh/VolumeMesher/Extruder/volmesher_extruder_05_extrudecells.cc
@@ -46,7 +46,7 @@ ExtrudeCells(chi_mesh::MeshContinuum *template_continuum,
 
       //========================================= Create a template empty
       //                                          cell
-      chi_mesh::Cell *tcell = new chi_mesh::Cell;
+      chi_mesh::Cell *tcell = new chi_mesh::Cell(chi_mesh::CellTypes::GHOST_CELL);
       tcell->centroid = centroid_precompd;
 
       //========================================= Get the partition id

--- a/CHI_TECH/ChiMesh/VolumeMesher/Extruder/volmesher_extruder_05_extrudecells.cc
+++ b/CHI_TECH/ChiMesh/VolumeMesher/Extruder/volmesher_extruder_05_extrudecells.cc
@@ -46,7 +46,7 @@ ExtrudeCells(chi_mesh::MeshContinuum *template_continuum,
 
       //========================================= Create a template empty
       //                                          cell
-      chi_mesh::Cell *tcell = new chi_mesh::Cell(chi_mesh::CellTypes::GHOST_CELL);
+      chi_mesh::Cell *tcell = new chi_mesh::Cell(chi_mesh::CellType::GHOST);
       tcell->centroid = centroid_precompd;
 
       //========================================= Get the partition id

--- a/CHI_TECH/ChiMesh/VolumeMesher/chi_volumemesher_01_utils.cc
+++ b/CHI_TECH/ChiMesh/VolumeMesher/chi_volumemesher_01_utils.cc
@@ -433,7 +433,7 @@ void chi_mesh::VolumeMesher::
     chi_mesh::Cell* cell = vol_continuum->cells[c];
 
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYGON
-    if (typeid(*cell) == typeid(chi_mesh::CellPolygon))
+    if (cell->Type() == chi_mesh::POLYGON_CELL)
     {
       chi_mesh::CellPolygon* poly_cell =
         (chi_mesh::CellPolygon*)cell;
@@ -449,7 +449,7 @@ void chi_mesh::VolumeMesher::
     }//if typeid
 
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYHEDRON
-    if (typeid(*cell) == typeid(chi_mesh::CellPolyhedron))
+    if (cell->Type() == chi_mesh::POLYHEDRON_CELL)
     {
       chi_mesh::CellPolyhedron* polyh_cell =
         (chi_mesh::CellPolyhedron*)cell;

--- a/CHI_TECH/ChiMesh/VolumeMesher/chi_volumemesher_01_utils.cc
+++ b/CHI_TECH/ChiMesh/VolumeMesher/chi_volumemesher_01_utils.cc
@@ -433,7 +433,7 @@ void chi_mesh::VolumeMesher::
     chi_mesh::Cell* cell = vol_continuum->cells[c];
 
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYGON
-    if (cell->Type() == chi_mesh::POLYGON_CELL)
+    if (cell->Type() == chi_mesh::CellTypes::POLYGON_CELL)
     {
       chi_mesh::CellPolygon* poly_cell =
         (chi_mesh::CellPolygon*)cell;
@@ -449,7 +449,7 @@ void chi_mesh::VolumeMesher::
     }//if typeid
 
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYHEDRON
-    if (cell->Type() == chi_mesh::POLYHEDRON_CELL)
+    if (cell->Type() == chi_mesh::CellTypes::POLYHEDRON_CELL)
     {
       chi_mesh::CellPolyhedron* polyh_cell =
         (chi_mesh::CellPolyhedron*)cell;

--- a/CHI_TECH/ChiMesh/VolumeMesher/chi_volumemesher_01_utils.cc
+++ b/CHI_TECH/ChiMesh/VolumeMesher/chi_volumemesher_01_utils.cc
@@ -433,7 +433,7 @@ void chi_mesh::VolumeMesher::
     chi_mesh::Cell* cell = vol_continuum->cells[c];
 
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYGON
-    if (cell->Type() == chi_mesh::CellTypes::POLYGON_CELL)
+    if (cell->Type() == chi_mesh::CellType::POLYGON)
     {
       chi_mesh::CellPolygon* poly_cell =
         (chi_mesh::CellPolygon*)cell;
@@ -449,7 +449,7 @@ void chi_mesh::VolumeMesher::
     }//if typeid
 
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYHEDRON
-    if (cell->Type() == chi_mesh::CellTypes::POLYHEDRON_CELL)
+    if (cell->Type() == chi_mesh::CellType::POLYHEDRON)
     {
       chi_mesh::CellPolyhedron* polyh_cell =
         (chi_mesh::CellPolyhedron*)cell;

--- a/CHI_TECH/ChiPhysics/FieldFunction/fieldfunction_vtkfv.cc
+++ b/CHI_TECH/ChiPhysics/FieldFunction/fieldfunction_vtkfv.cc
@@ -100,7 +100,7 @@ void chi_physics::FieldFunction::ExportToVTKFV(std::string base_name,
     int mat_id = cell->material_id;
 
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYGON
-    if (cell->Type() == chi_mesh::SLAB_CELL)
+    if (cell->Type() == chi_mesh::CellTypes::SLAB_CELL)
     {
       auto slab_cell = (chi_mesh::CellSlab*)cell;
 
@@ -120,7 +120,7 @@ void chi_physics::FieldFunction::ExportToVTKFV(std::string base_name,
     }
 
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYGON
-    if (cell->Type() == chi_mesh::POLYGON_CELL)
+    if (cell->Type() == chi_mesh::CellTypes::POLYGON_CELL)
     {
       auto poly_cell = (chi_mesh::CellPolygon*)cell;
 
@@ -142,7 +142,7 @@ void chi_physics::FieldFunction::ExportToVTKFV(std::string base_name,
     }
 
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYHEDRON
-    if (cell->Type() == chi_mesh::POLYHEDRON_CELL)
+    if (cell->Type() == chi_mesh::CellTypes::POLYHEDRON_CELL)
     {
       auto polyh_cell = (chi_mesh::CellPolyhedron*)cell;
 
@@ -277,7 +277,7 @@ void chi_physics::FieldFunction::ExportToVTKFVG(std::string base_name,
     int mat_id = cell->material_id;
 
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYGON
-    if (cell->Type() == chi_mesh::SLAB_CELL)
+    if (cell->Type() == chi_mesh::CellTypes::SLAB_CELL)
     {
       auto slab_cell = (chi_mesh::CellSlab*)cell;
 
@@ -301,7 +301,7 @@ void chi_physics::FieldFunction::ExportToVTKFVG(std::string base_name,
     }
 
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYGON
-    if (cell->Type() == chi_mesh::POLYGON_CELL)
+    if (cell->Type() == chi_mesh::CellTypes::POLYGON_CELL)
     {
       auto poly_cell = (chi_mesh::CellPolygon*)cell;
 
@@ -326,7 +326,7 @@ void chi_physics::FieldFunction::ExportToVTKFVG(std::string base_name,
     }
 
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYHEDRON
-    if (cell->Type() == chi_mesh::POLYHEDRON_CELL)
+    if (cell->Type() == chi_mesh::CellTypes::POLYHEDRON_CELL)
     {
       auto polyh_cell = (chi_mesh::CellPolyhedron*)cell;
 

--- a/CHI_TECH/ChiPhysics/FieldFunction/fieldfunction_vtkfv.cc
+++ b/CHI_TECH/ChiPhysics/FieldFunction/fieldfunction_vtkfv.cc
@@ -100,7 +100,7 @@ void chi_physics::FieldFunction::ExportToVTKFV(std::string base_name,
     int mat_id = cell->material_id;
 
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYGON
-    if (cell->Type() == chi_mesh::CellTypes::SLAB_CELL)
+    if (cell->Type() == chi_mesh::CellType::SLAB)
     {
       auto slab_cell = (chi_mesh::CellSlab*)cell;
 
@@ -120,7 +120,7 @@ void chi_physics::FieldFunction::ExportToVTKFV(std::string base_name,
     }
 
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYGON
-    if (cell->Type() == chi_mesh::CellTypes::POLYGON_CELL)
+    if (cell->Type() == chi_mesh::CellType::POLYGON)
     {
       auto poly_cell = (chi_mesh::CellPolygon*)cell;
 
@@ -142,7 +142,7 @@ void chi_physics::FieldFunction::ExportToVTKFV(std::string base_name,
     }
 
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYHEDRON
-    if (cell->Type() == chi_mesh::CellTypes::POLYHEDRON_CELL)
+    if (cell->Type() == chi_mesh::CellType::POLYHEDRON)
     {
       auto polyh_cell = (chi_mesh::CellPolyhedron*)cell;
 
@@ -277,7 +277,7 @@ void chi_physics::FieldFunction::ExportToVTKFVG(std::string base_name,
     int mat_id = cell->material_id;
 
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYGON
-    if (cell->Type() == chi_mesh::CellTypes::SLAB_CELL)
+    if (cell->Type() == chi_mesh::CellType::SLAB)
     {
       auto slab_cell = (chi_mesh::CellSlab*)cell;
 
@@ -301,7 +301,7 @@ void chi_physics::FieldFunction::ExportToVTKFVG(std::string base_name,
     }
 
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYGON
-    if (cell->Type() == chi_mesh::CellTypes::POLYGON_CELL)
+    if (cell->Type() == chi_mesh::CellType::POLYGON)
     {
       auto poly_cell = (chi_mesh::CellPolygon*)cell;
 
@@ -326,7 +326,7 @@ void chi_physics::FieldFunction::ExportToVTKFVG(std::string base_name,
     }
 
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYHEDRON
-    if (cell->Type() == chi_mesh::CellTypes::POLYHEDRON_CELL)
+    if (cell->Type() == chi_mesh::CellType::POLYHEDRON)
     {
       auto polyh_cell = (chi_mesh::CellPolyhedron*)cell;
 

--- a/CHI_TECH/ChiPhysics/FieldFunction/fieldfunction_vtkfv.cc
+++ b/CHI_TECH/ChiPhysics/FieldFunction/fieldfunction_vtkfv.cc
@@ -100,7 +100,7 @@ void chi_physics::FieldFunction::ExportToVTKFV(std::string base_name,
     int mat_id = cell->material_id;
 
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYGON
-    if (typeid(*cell) == typeid(chi_mesh::CellSlab))
+    if (cell->Type() == chi_mesh::SLAB_CELL)
     {
       auto slab_cell = (chi_mesh::CellSlab*)cell;
 
@@ -120,7 +120,7 @@ void chi_physics::FieldFunction::ExportToVTKFV(std::string base_name,
     }
 
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYGON
-    if (typeid(*cell) == typeid(chi_mesh::CellPolygon))
+    if (cell->Type() == chi_mesh::POLYGON_CELL)
     {
       auto poly_cell = (chi_mesh::CellPolygon*)cell;
 
@@ -142,7 +142,7 @@ void chi_physics::FieldFunction::ExportToVTKFV(std::string base_name,
     }
 
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYHEDRON
-    if (typeid(*cell) == typeid(chi_mesh::CellPolyhedron))
+    if (cell->Type() == chi_mesh::POLYHEDRON_CELL)
     {
       auto polyh_cell = (chi_mesh::CellPolyhedron*)cell;
 
@@ -277,7 +277,7 @@ void chi_physics::FieldFunction::ExportToVTKFVG(std::string base_name,
     int mat_id = cell->material_id;
 
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYGON
-    if (typeid(*cell) == typeid(chi_mesh::CellSlab))
+    if (cell->Type() == chi_mesh::SLAB_CELL)
     {
       auto slab_cell = (chi_mesh::CellSlab*)cell;
 
@@ -301,7 +301,7 @@ void chi_physics::FieldFunction::ExportToVTKFVG(std::string base_name,
     }
 
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYGON
-    if (typeid(*cell) == typeid(chi_mesh::CellPolygon))
+    if (cell->Type() == chi_mesh::POLYGON_CELL)
     {
       auto poly_cell = (chi_mesh::CellPolygon*)cell;
 
@@ -326,7 +326,7 @@ void chi_physics::FieldFunction::ExportToVTKFVG(std::string base_name,
     }
 
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYHEDRON
-    if (typeid(*cell) == typeid(chi_mesh::CellPolyhedron))
+    if (cell->Type() == chi_mesh::POLYHEDRON_CELL)
     {
       auto polyh_cell = (chi_mesh::CellPolyhedron*)cell;
 

--- a/CHI_TECH/ChiPhysics/FieldFunction/fieldfunction_vtkpwlc.cc
+++ b/CHI_TECH/ChiPhysics/FieldFunction/fieldfunction_vtkpwlc.cc
@@ -85,7 +85,7 @@ void chi_physics::FieldFunction::ExportToVTKPWLC(std::string base_name,
     int mat_id = cell->material_id;
 
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYGON
-    if (cell->Type() == chi_mesh::SLAB_CELL)
+    if (cell->Type() == chi_mesh::CellTypes::SLAB_CELL)
     {
       auto slab_cell = (chi_mesh::CellSlab*)cell;
 
@@ -95,7 +95,7 @@ void chi_physics::FieldFunction::ExportToVTKPWLC(std::string base_name,
     }
 
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYGON
-    if (cell->Type() == chi_mesh::POLYGON_CELL)
+    if (cell->Type() == chi_mesh::CellTypes::POLYGON_CELL)
     {
       auto poly_cell = (chi_mesh::CellPolygon*)cell;
 
@@ -105,7 +105,7 @@ void chi_physics::FieldFunction::ExportToVTKPWLC(std::string base_name,
     }
 
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYHEDRON
-    if (cell->Type() == chi_mesh::POLYHEDRON_CELL)
+    if (cell->Type() == chi_mesh::CellTypes::POLYHEDRON_CELL)
     {
       auto polyh_cell = (chi_mesh::CellPolyhedron*)cell;
 
@@ -132,7 +132,7 @@ void chi_physics::FieldFunction::ExportToVTKPWLC(std::string base_name,
     int mat_id = cell->material_id;
 
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYGON
-    if (cell->Type() == chi_mesh::SLAB_CELL)
+    if (cell->Type() == chi_mesh::CellTypes::SLAB_CELL)
     {
       auto slab_cell = (chi_mesh::CellSlab*)cell;
 
@@ -172,7 +172,7 @@ void chi_physics::FieldFunction::ExportToVTKPWLC(std::string base_name,
     }
 
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYGON
-    if (cell->Type() == chi_mesh::POLYGON_CELL)
+    if (cell->Type() == chi_mesh::CellTypes::POLYGON_CELL)
     {
       auto poly_cell = (chi_mesh::CellPolygon*)cell;
 
@@ -211,7 +211,7 @@ void chi_physics::FieldFunction::ExportToVTKPWLC(std::string base_name,
     }
 
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYHEDRON
-    if (cell->Type() == chi_mesh::POLYHEDRON_CELL)
+    if (cell->Type() == chi_mesh::CellTypes::POLYHEDRON_CELL)
     {
       auto polyh_cell = (chi_mesh::CellPolyhedron*)cell;
       auto cell_fe_view = (PolyhedronFEView*)pwl_sdm->MapFeView(cell_g_ind);
@@ -348,7 +348,7 @@ void chi_physics::FieldFunction::ExportToVTKPWLCG(std::string base_name,
     int mat_id = cell->material_id;
 
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYGON
-    if (cell->Type() == chi_mesh::SLAB_CELL)
+    if (cell->Type() == chi_mesh::CellTypes::SLAB_CELL)
     {
       auto slab_cell = (chi_mesh::CellSlab*)cell;
 
@@ -359,7 +359,7 @@ void chi_physics::FieldFunction::ExportToVTKPWLCG(std::string base_name,
     }
 
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYGON
-    if (cell->Type() == chi_mesh::POLYGON_CELL)
+    if (cell->Type() == chi_mesh::CellTypes::POLYGON_CELL)
     {
       auto poly_cell = (chi_mesh::CellPolygon*)cell;
 
@@ -370,7 +370,7 @@ void chi_physics::FieldFunction::ExportToVTKPWLCG(std::string base_name,
     }
 
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYHEDRON
-    if (cell->Type() == chi_mesh::POLYHEDRON_CELL)
+    if (cell->Type() == chi_mesh::CellTypes::POLYHEDRON_CELL)
     {
       auto polyh_cell = (chi_mesh::CellPolyhedron*)cell;
 
@@ -398,7 +398,7 @@ void chi_physics::FieldFunction::ExportToVTKPWLCG(std::string base_name,
     int mat_id = cell->material_id;
 
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYGON
-    if (cell->Type() == chi_mesh::SLAB_CELL)
+    if (cell->Type() == chi_mesh::CellTypes::SLAB_CELL)
     {
       auto slab_cell = (chi_mesh::CellSlab*)cell;
 
@@ -438,7 +438,7 @@ void chi_physics::FieldFunction::ExportToVTKPWLCG(std::string base_name,
     }
 
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYGON
-    if (cell->Type() == chi_mesh::POLYGON_CELL)
+    if (cell->Type() == chi_mesh::CellTypes::POLYGON_CELL)
     {
       auto poly_cell = (chi_mesh::CellPolygon*)cell;
 
@@ -477,7 +477,7 @@ void chi_physics::FieldFunction::ExportToVTKPWLCG(std::string base_name,
     }
 
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYHEDRON
-    if (cell->Type() == chi_mesh::POLYHEDRON_CELL)
+    if (cell->Type() == chi_mesh::CellTypes::POLYHEDRON_CELL)
     {
       auto polyh_cell = (chi_mesh::CellPolyhedron*)cell;
       auto cell_fe_view = (PolyhedronFEView*)pwl_sdm->MapFeView(cell_g_ind);

--- a/CHI_TECH/ChiPhysics/FieldFunction/fieldfunction_vtkpwlc.cc
+++ b/CHI_TECH/ChiPhysics/FieldFunction/fieldfunction_vtkpwlc.cc
@@ -85,7 +85,7 @@ void chi_physics::FieldFunction::ExportToVTKPWLC(std::string base_name,
     int mat_id = cell->material_id;
 
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYGON
-    if (typeid(*cell) == typeid(chi_mesh::CellSlab))
+    if (cell->Type() == chi_mesh::SLAB_CELL)
     {
       auto slab_cell = (chi_mesh::CellSlab*)cell;
 
@@ -95,7 +95,7 @@ void chi_physics::FieldFunction::ExportToVTKPWLC(std::string base_name,
     }
 
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYGON
-    if (typeid(*cell) == typeid(chi_mesh::CellPolygon))
+    if (cell->Type() == chi_mesh::POLYGON_CELL)
     {
       auto poly_cell = (chi_mesh::CellPolygon*)cell;
 
@@ -105,7 +105,7 @@ void chi_physics::FieldFunction::ExportToVTKPWLC(std::string base_name,
     }
 
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYHEDRON
-    if (typeid(*cell) == typeid(chi_mesh::CellPolyhedron))
+    if (cell->Type() == chi_mesh::POLYHEDRON_CELL)
     {
       auto polyh_cell = (chi_mesh::CellPolyhedron*)cell;
 
@@ -132,7 +132,7 @@ void chi_physics::FieldFunction::ExportToVTKPWLC(std::string base_name,
     int mat_id = cell->material_id;
 
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYGON
-    if (typeid(*cell) == typeid(chi_mesh::CellSlab))
+    if (cell->Type() == chi_mesh::SLAB_CELL)
     {
       auto slab_cell = (chi_mesh::CellSlab*)cell;
 
@@ -172,7 +172,7 @@ void chi_physics::FieldFunction::ExportToVTKPWLC(std::string base_name,
     }
 
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYGON
-    if (typeid(*cell) == typeid(chi_mesh::CellPolygon))
+    if (cell->Type() == chi_mesh::POLYGON_CELL)
     {
       auto poly_cell = (chi_mesh::CellPolygon*)cell;
 
@@ -211,7 +211,7 @@ void chi_physics::FieldFunction::ExportToVTKPWLC(std::string base_name,
     }
 
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYHEDRON
-    if (typeid(*cell) == typeid(chi_mesh::CellPolyhedron))
+    if (cell->Type() == chi_mesh::POLYHEDRON_CELL)
     {
       auto polyh_cell = (chi_mesh::CellPolyhedron*)cell;
       auto cell_fe_view = (PolyhedronFEView*)pwl_sdm->MapFeView(cell_g_ind);
@@ -348,7 +348,7 @@ void chi_physics::FieldFunction::ExportToVTKPWLCG(std::string base_name,
     int mat_id = cell->material_id;
 
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYGON
-    if (typeid(*cell) == typeid(chi_mesh::CellSlab))
+    if (cell->Type() == chi_mesh::SLAB_CELL)
     {
       auto slab_cell = (chi_mesh::CellSlab*)cell;
 
@@ -359,7 +359,7 @@ void chi_physics::FieldFunction::ExportToVTKPWLCG(std::string base_name,
     }
 
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYGON
-    if (typeid(*cell) == typeid(chi_mesh::CellPolygon))
+    if (cell->Type() == chi_mesh::POLYGON_CELL)
     {
       auto poly_cell = (chi_mesh::CellPolygon*)cell;
 
@@ -370,7 +370,7 @@ void chi_physics::FieldFunction::ExportToVTKPWLCG(std::string base_name,
     }
 
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYHEDRON
-    if (typeid(*cell) == typeid(chi_mesh::CellPolyhedron))
+    if (cell->Type() == chi_mesh::POLYHEDRON_CELL)
     {
       auto polyh_cell = (chi_mesh::CellPolyhedron*)cell;
 
@@ -398,7 +398,7 @@ void chi_physics::FieldFunction::ExportToVTKPWLCG(std::string base_name,
     int mat_id = cell->material_id;
 
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYGON
-    if (typeid(*cell) == typeid(chi_mesh::CellSlab))
+    if (cell->Type() == chi_mesh::SLAB_CELL)
     {
       auto slab_cell = (chi_mesh::CellSlab*)cell;
 
@@ -438,7 +438,7 @@ void chi_physics::FieldFunction::ExportToVTKPWLCG(std::string base_name,
     }
 
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYGON
-    if (typeid(*cell) == typeid(chi_mesh::CellPolygon))
+    if (cell->Type() == chi_mesh::POLYGON_CELL)
     {
       auto poly_cell = (chi_mesh::CellPolygon*)cell;
 
@@ -477,7 +477,7 @@ void chi_physics::FieldFunction::ExportToVTKPWLCG(std::string base_name,
     }
 
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYHEDRON
-    if (typeid(*cell) == typeid(chi_mesh::CellPolyhedron))
+    if (cell->Type() == chi_mesh::POLYHEDRON_CELL)
     {
       auto polyh_cell = (chi_mesh::CellPolyhedron*)cell;
       auto cell_fe_view = (PolyhedronFEView*)pwl_sdm->MapFeView(cell_g_ind);

--- a/CHI_TECH/ChiPhysics/FieldFunction/fieldfunction_vtkpwlc.cc
+++ b/CHI_TECH/ChiPhysics/FieldFunction/fieldfunction_vtkpwlc.cc
@@ -85,7 +85,7 @@ void chi_physics::FieldFunction::ExportToVTKPWLC(std::string base_name,
     int mat_id = cell->material_id;
 
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYGON
-    if (cell->Type() == chi_mesh::CellTypes::SLAB_CELL)
+    if (cell->Type() == chi_mesh::CellType::SLAB)
     {
       auto slab_cell = (chi_mesh::CellSlab*)cell;
 
@@ -95,7 +95,7 @@ void chi_physics::FieldFunction::ExportToVTKPWLC(std::string base_name,
     }
 
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYGON
-    if (cell->Type() == chi_mesh::CellTypes::POLYGON_CELL)
+    if (cell->Type() == chi_mesh::CellType::POLYGON)
     {
       auto poly_cell = (chi_mesh::CellPolygon*)cell;
 
@@ -105,7 +105,7 @@ void chi_physics::FieldFunction::ExportToVTKPWLC(std::string base_name,
     }
 
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYHEDRON
-    if (cell->Type() == chi_mesh::CellTypes::POLYHEDRON_CELL)
+    if (cell->Type() == chi_mesh::CellType::POLYHEDRON)
     {
       auto polyh_cell = (chi_mesh::CellPolyhedron*)cell;
 
@@ -132,7 +132,7 @@ void chi_physics::FieldFunction::ExportToVTKPWLC(std::string base_name,
     int mat_id = cell->material_id;
 
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYGON
-    if (cell->Type() == chi_mesh::CellTypes::SLAB_CELL)
+    if (cell->Type() == chi_mesh::CellType::SLAB)
     {
       auto slab_cell = (chi_mesh::CellSlab*)cell;
 
@@ -172,7 +172,7 @@ void chi_physics::FieldFunction::ExportToVTKPWLC(std::string base_name,
     }
 
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYGON
-    if (cell->Type() == chi_mesh::CellTypes::POLYGON_CELL)
+    if (cell->Type() == chi_mesh::CellType::POLYGON)
     {
       auto poly_cell = (chi_mesh::CellPolygon*)cell;
 
@@ -211,7 +211,7 @@ void chi_physics::FieldFunction::ExportToVTKPWLC(std::string base_name,
     }
 
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYHEDRON
-    if (cell->Type() == chi_mesh::CellTypes::POLYHEDRON_CELL)
+    if (cell->Type() == chi_mesh::CellType::POLYHEDRON)
     {
       auto polyh_cell = (chi_mesh::CellPolyhedron*)cell;
       auto cell_fe_view = (PolyhedronFEView*)pwl_sdm->MapFeView(cell_g_ind);
@@ -348,7 +348,7 @@ void chi_physics::FieldFunction::ExportToVTKPWLCG(std::string base_name,
     int mat_id = cell->material_id;
 
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYGON
-    if (cell->Type() == chi_mesh::CellTypes::SLAB_CELL)
+    if (cell->Type() == chi_mesh::CellType::SLAB)
     {
       auto slab_cell = (chi_mesh::CellSlab*)cell;
 
@@ -359,7 +359,7 @@ void chi_physics::FieldFunction::ExportToVTKPWLCG(std::string base_name,
     }
 
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYGON
-    if (cell->Type() == chi_mesh::CellTypes::POLYGON_CELL)
+    if (cell->Type() == chi_mesh::CellType::POLYGON)
     {
       auto poly_cell = (chi_mesh::CellPolygon*)cell;
 
@@ -370,7 +370,7 @@ void chi_physics::FieldFunction::ExportToVTKPWLCG(std::string base_name,
     }
 
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYHEDRON
-    if (cell->Type() == chi_mesh::CellTypes::POLYHEDRON_CELL)
+    if (cell->Type() == chi_mesh::CellType::POLYHEDRON)
     {
       auto polyh_cell = (chi_mesh::CellPolyhedron*)cell;
 
@@ -398,7 +398,7 @@ void chi_physics::FieldFunction::ExportToVTKPWLCG(std::string base_name,
     int mat_id = cell->material_id;
 
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYGON
-    if (cell->Type() == chi_mesh::CellTypes::SLAB_CELL)
+    if (cell->Type() == chi_mesh::CellType::SLAB)
     {
       auto slab_cell = (chi_mesh::CellSlab*)cell;
 
@@ -438,7 +438,7 @@ void chi_physics::FieldFunction::ExportToVTKPWLCG(std::string base_name,
     }
 
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYGON
-    if (cell->Type() == chi_mesh::CellTypes::POLYGON_CELL)
+    if (cell->Type() == chi_mesh::CellType::POLYGON)
     {
       auto poly_cell = (chi_mesh::CellPolygon*)cell;
 
@@ -477,7 +477,7 @@ void chi_physics::FieldFunction::ExportToVTKPWLCG(std::string base_name,
     }
 
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYHEDRON
-    if (cell->Type() == chi_mesh::CellTypes::POLYHEDRON_CELL)
+    if (cell->Type() == chi_mesh::CellType::POLYHEDRON)
     {
       auto polyh_cell = (chi_mesh::CellPolyhedron*)cell;
       auto cell_fe_view = (PolyhedronFEView*)pwl_sdm->MapFeView(cell_g_ind);

--- a/CHI_TECH/ChiPhysics/FieldFunction/fieldfunction_vtkpwld.cc
+++ b/CHI_TECH/ChiPhysics/FieldFunction/fieldfunction_vtkpwld.cc
@@ -82,7 +82,7 @@ void chi_physics::FieldFunction::ExportToVTKPWLD(std::string base_name,
     int mat_id = cell->material_id;
 
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYGON
-    if (cell->Type() == chi_mesh::CellTypes::SLAB_CELL)
+    if (cell->Type() == chi_mesh::CellType::SLAB)
     {
       auto slab_cell = (chi_mesh::CellSlab*)cell;
 
@@ -130,7 +130,7 @@ void chi_physics::FieldFunction::ExportToVTKPWLD(std::string base_name,
     }
 
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYGON
-    if (cell->Type() == chi_mesh::CellTypes::POLYGON_CELL)
+    if (cell->Type() == chi_mesh::CellType::POLYGON)
     {
       auto poly_cell = (chi_mesh::CellPolygon*)cell;
 
@@ -177,7 +177,7 @@ void chi_physics::FieldFunction::ExportToVTKPWLD(std::string base_name,
     }
 
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYHEDRON
-    if (cell->Type() == chi_mesh::CellTypes::POLYHEDRON_CELL)
+    if (cell->Type() == chi_mesh::CellType::POLYHEDRON)
     {
       auto polyh_cell = (chi_mesh::CellPolyhedron*)cell;
       auto cell_fe_view = (PolyhedronFEView*)pwl_sdm->MapFeView(cell_g_ind);
@@ -335,7 +335,7 @@ void chi_physics::FieldFunction::ExportToVTKPWLDG(std::string base_name,
     int mat_id = cell->material_id;
 
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYGON
-    if (cell->Type() == chi_mesh::CellTypes::SLAB_CELL)
+    if (cell->Type() == chi_mesh::CellType::SLAB)
     {
       auto slab_cell = (chi_mesh::CellSlab*)cell;
 
@@ -387,7 +387,7 @@ void chi_physics::FieldFunction::ExportToVTKPWLDG(std::string base_name,
     }
 
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYGON
-    if (cell->Type() == chi_mesh::CellTypes::POLYGON_CELL)
+    if (cell->Type() == chi_mesh::CellType::POLYGON)
     {
       auto poly_cell = (chi_mesh::CellPolygon*)cell;
 
@@ -437,7 +437,7 @@ void chi_physics::FieldFunction::ExportToVTKPWLDG(std::string base_name,
     }
 
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYHEDRON
-    if (cell->Type() == chi_mesh::CellTypes::POLYHEDRON_CELL)
+    if (cell->Type() == chi_mesh::CellType::POLYHEDRON)
     {
       auto polyh_cell = (chi_mesh::CellPolyhedron*)cell;
       auto cell_fe_view = (PolyhedronFEView*)pwl_sdm->MapFeView(cell_g_ind);

--- a/CHI_TECH/ChiPhysics/FieldFunction/fieldfunction_vtkpwld.cc
+++ b/CHI_TECH/ChiPhysics/FieldFunction/fieldfunction_vtkpwld.cc
@@ -82,7 +82,7 @@ void chi_physics::FieldFunction::ExportToVTKPWLD(std::string base_name,
     int mat_id = cell->material_id;
 
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYGON
-    if (cell->Type() == chi_mesh::SLAB_CELL)
+    if (cell->Type() == chi_mesh::CellTypes::SLAB_CELL)
     {
       auto slab_cell = (chi_mesh::CellSlab*)cell;
 
@@ -130,7 +130,7 @@ void chi_physics::FieldFunction::ExportToVTKPWLD(std::string base_name,
     }
 
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYGON
-    if (cell->Type() == chi_mesh::POLYGON_CELL)
+    if (cell->Type() == chi_mesh::CellTypes::POLYGON_CELL)
     {
       auto poly_cell = (chi_mesh::CellPolygon*)cell;
 
@@ -177,7 +177,7 @@ void chi_physics::FieldFunction::ExportToVTKPWLD(std::string base_name,
     }
 
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYHEDRON
-    if (cell->Type() == chi_mesh::POLYHEDRON_CELL)
+    if (cell->Type() == chi_mesh::CellTypes::POLYHEDRON_CELL)
     {
       auto polyh_cell = (chi_mesh::CellPolyhedron*)cell;
       auto cell_fe_view = (PolyhedronFEView*)pwl_sdm->MapFeView(cell_g_ind);
@@ -335,7 +335,7 @@ void chi_physics::FieldFunction::ExportToVTKPWLDG(std::string base_name,
     int mat_id = cell->material_id;
 
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYGON
-    if (cell->Type() == chi_mesh::SLAB_CELL)
+    if (cell->Type() == chi_mesh::CellTypes::SLAB_CELL)
     {
       auto slab_cell = (chi_mesh::CellSlab*)cell;
 
@@ -387,7 +387,7 @@ void chi_physics::FieldFunction::ExportToVTKPWLDG(std::string base_name,
     }
 
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYGON
-    if (cell->Type() == chi_mesh::POLYGON_CELL)
+    if (cell->Type() == chi_mesh::CellTypes::POLYGON_CELL)
     {
       auto poly_cell = (chi_mesh::CellPolygon*)cell;
 
@@ -437,7 +437,7 @@ void chi_physics::FieldFunction::ExportToVTKPWLDG(std::string base_name,
     }
 
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYHEDRON
-    if (cell->Type() == chi_mesh::POLYHEDRON_CELL)
+    if (cell->Type() == chi_mesh::CellTypes::POLYHEDRON_CELL)
     {
       auto polyh_cell = (chi_mesh::CellPolyhedron*)cell;
       auto cell_fe_view = (PolyhedronFEView*)pwl_sdm->MapFeView(cell_g_ind);

--- a/CHI_TECH/ChiPhysics/FieldFunction/fieldfunction_vtkpwld.cc
+++ b/CHI_TECH/ChiPhysics/FieldFunction/fieldfunction_vtkpwld.cc
@@ -82,7 +82,7 @@ void chi_physics::FieldFunction::ExportToVTKPWLD(std::string base_name,
     int mat_id = cell->material_id;
 
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYGON
-    if (typeid(*cell) == typeid(chi_mesh::CellSlab))
+    if (cell->Type() == chi_mesh::SLAB_CELL)
     {
       auto slab_cell = (chi_mesh::CellSlab*)cell;
 
@@ -130,7 +130,7 @@ void chi_physics::FieldFunction::ExportToVTKPWLD(std::string base_name,
     }
 
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYGON
-    if (typeid(*cell) == typeid(chi_mesh::CellPolygon))
+    if (cell->Type() == chi_mesh::POLYGON_CELL)
     {
       auto poly_cell = (chi_mesh::CellPolygon*)cell;
 
@@ -177,7 +177,7 @@ void chi_physics::FieldFunction::ExportToVTKPWLD(std::string base_name,
     }
 
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYHEDRON
-    if (typeid(*cell) == typeid(chi_mesh::CellPolyhedron))
+    if (cell->Type() == chi_mesh::POLYHEDRON_CELL)
     {
       auto polyh_cell = (chi_mesh::CellPolyhedron*)cell;
       auto cell_fe_view = (PolyhedronFEView*)pwl_sdm->MapFeView(cell_g_ind);
@@ -335,7 +335,7 @@ void chi_physics::FieldFunction::ExportToVTKPWLDG(std::string base_name,
     int mat_id = cell->material_id;
 
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYGON
-    if (typeid(*cell) == typeid(chi_mesh::CellSlab))
+    if (cell->Type() == chi_mesh::SLAB_CELL)
     {
       auto slab_cell = (chi_mesh::CellSlab*)cell;
 
@@ -387,7 +387,7 @@ void chi_physics::FieldFunction::ExportToVTKPWLDG(std::string base_name,
     }
 
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYGON
-    if (typeid(*cell) == typeid(chi_mesh::CellPolygon))
+    if (cell->Type() == chi_mesh::POLYGON_CELL)
     {
       auto poly_cell = (chi_mesh::CellPolygon*)cell;
 
@@ -437,7 +437,7 @@ void chi_physics::FieldFunction::ExportToVTKPWLDG(std::string base_name,
     }
 
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYHEDRON
-    if (typeid(*cell) == typeid(chi_mesh::CellPolyhedron))
+    if (cell->Type() == chi_mesh::POLYHEDRON_CELL)
     {
       auto polyh_cell = (chi_mesh::CellPolyhedron*)cell;
       auto cell_fe_view = (PolyhedronFEView*)pwl_sdm->MapFeView(cell_g_ind);

--- a/Modules/DiffusionSolver/Solver/assemble_utils_plwd.cc
+++ b/Modules/DiffusionSolver/Solver/assemble_utils_plwd.cc
@@ -49,20 +49,20 @@ void chi_diffusion::Solver::ReorderNodesPWLD()
     auto cell = vol_continuum->cells[cell_glob_index];
 
     // %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% SLAB
-    if (cell->Type() == chi_mesh::CellTypes::SLAB_CELL)
+    if (cell->Type() == chi_mesh::CellType::SLAB)
     {
       pwld_local_dof_count += 2;
     }
 
     // %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYGON
-    if (cell->Type() == chi_mesh::CellTypes::POLYGON_CELL)
+    if (cell->Type() == chi_mesh::CellType::POLYGON)
     {
       auto poly_cell = (chi_mesh::CellPolygon*)cell;
       pwld_local_dof_count += poly_cell->v_indices.size();
     }
 
     // %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYHEDRON
-    if (cell->Type() == chi_mesh::CellTypes::POLYHEDRON_CELL)
+    if (cell->Type() == chi_mesh::CellType::POLYHEDRON)
     {
       auto polyh_cell = (chi_mesh::CellPolyhedron*)cell;
       pwld_local_dof_count += polyh_cell->v_indices.size();

--- a/Modules/DiffusionSolver/Solver/assemble_utils_plwd.cc
+++ b/Modules/DiffusionSolver/Solver/assemble_utils_plwd.cc
@@ -49,20 +49,20 @@ void chi_diffusion::Solver::ReorderNodesPWLD()
     auto cell = vol_continuum->cells[cell_glob_index];
 
     // %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% SLAB
-    if (cell->Type() == chi_mesh::SLAB_CELL)
+    if (cell->Type() == chi_mesh::CellTypes::SLAB_CELL)
     {
       pwld_local_dof_count += 2;
     }
 
     // %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYGON
-    if (cell->Type() == chi_mesh::POLYGON_CELL)
+    if (cell->Type() == chi_mesh::CellTypes::POLYGON_CELL)
     {
       auto poly_cell = (chi_mesh::CellPolygon*)cell;
       pwld_local_dof_count += poly_cell->v_indices.size();
     }
 
     // %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYHEDRON
-    if (cell->Type() == chi_mesh::POLYHEDRON_CELL)
+    if (cell->Type() == chi_mesh::CellTypes::POLYHEDRON_CELL)
     {
       auto polyh_cell = (chi_mesh::CellPolyhedron*)cell;
       pwld_local_dof_count += polyh_cell->v_indices.size();

--- a/Modules/DiffusionSolver/Solver/assemble_utils_plwd.cc
+++ b/Modules/DiffusionSolver/Solver/assemble_utils_plwd.cc
@@ -49,20 +49,20 @@ void chi_diffusion::Solver::ReorderNodesPWLD()
     auto cell = vol_continuum->cells[cell_glob_index];
 
     // %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% SLAB
-    if (typeid(*cell) == typeid(chi_mesh::CellSlab))
+    if (cell->Type() == chi_mesh::SLAB_CELL)
     {
       pwld_local_dof_count += 2;
     }
 
     // %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYGON
-    if (typeid(*cell) == typeid(chi_mesh::CellPolygon))
+    if (cell->Type() == chi_mesh::POLYGON_CELL)
     {
       auto poly_cell = (chi_mesh::CellPolygon*)cell;
       pwld_local_dof_count += poly_cell->v_indices.size();
     }
 
     // %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYHEDRON
-    if (typeid(*cell) == typeid(chi_mesh::CellPolyhedron))
+    if (cell->Type() == chi_mesh::POLYHEDRON_CELL)
     {
       auto polyh_cell = (chi_mesh::CellPolyhedron*)cell;
       pwld_local_dof_count += polyh_cell->v_indices.size();

--- a/Modules/DiffusionSolver/Solver/assemble_utils_pwlc.cc
+++ b/Modules/DiffusionSolver/Solver/assemble_utils_pwlc.cc
@@ -50,7 +50,7 @@ void chi_diffusion::Solver::ReorderNodesPWLC()
     auto cell = vol_continuum->cells[cell_glob_index];
 
     // %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% SLAB
-    if (cell->Type() == chi_mesh::SLAB_CELL)
+    if (cell->Type() == chi_mesh::CellTypes::SLAB_CELL)
     {
       auto slab_cell = (chi_mesh::CellSlab*)cell;
       for (int v=0; v<2; v++)
@@ -60,7 +60,7 @@ void chi_diffusion::Solver::ReorderNodesPWLC()
     }
 
     // %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYGON
-    if (cell->Type() == chi_mesh::POLYGON_CELL)
+    if (cell->Type() == chi_mesh::CellTypes::POLYGON_CELL)
     {
       auto poly_cell = (chi_mesh::CellPolygon*)cell;
       for (int v=0; v<poly_cell->v_indices.size(); v++)
@@ -70,7 +70,7 @@ void chi_diffusion::Solver::ReorderNodesPWLC()
     }
 
     // %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYHEDRON
-    if (cell->Type() == chi_mesh::POLYHEDRON_CELL)
+    if (cell->Type() == chi_mesh::CellTypes::POLYHEDRON_CELL)
     {
       auto polyh_cell = (chi_mesh::CellPolyhedron*)cell;
       for (int v=0; v<polyh_cell->v_indices.size(); v++)
@@ -106,7 +106,7 @@ void chi_diffusion::Solver::ReorderNodesPWLC()
     auto cell = vol_continuum->cells[cell_glob_index];
 
     // %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% SLAB
-    if (cell->Type() == chi_mesh::SLAB_CELL)
+    if (cell->Type() == chi_mesh::CellTypes::SLAB_CELL)
     {
       auto slab_cell = (chi_mesh::CellSlab*)cell;
       for (int e=0; e<2; e++)
@@ -133,7 +133,7 @@ void chi_diffusion::Solver::ReorderNodesPWLC()
     }//if slab
 
     // %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYGON
-    if (cell->Type() == chi_mesh::POLYGON_CELL)
+    if (cell->Type() == chi_mesh::CellTypes::POLYGON_CELL)
     {
       auto poly_cell = (chi_mesh::CellPolygon*)cell;
       for (int e=0; e<poly_cell->edges.size(); e++)
@@ -160,7 +160,7 @@ void chi_diffusion::Solver::ReorderNodesPWLC()
     }//if polygon
 
     // %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYHEDRON
-    if (cell->Type() == chi_mesh::POLYHEDRON_CELL)
+    if (cell->Type() == chi_mesh::CellTypes::POLYHEDRON_CELL)
     {
       auto polyh_cell = (chi_mesh::CellPolyhedron*)cell;
       for (int f=0; f<polyh_cell->faces.size(); f++)

--- a/Modules/DiffusionSolver/Solver/assemble_utils_pwlc.cc
+++ b/Modules/DiffusionSolver/Solver/assemble_utils_pwlc.cc
@@ -50,7 +50,7 @@ void chi_diffusion::Solver::ReorderNodesPWLC()
     auto cell = vol_continuum->cells[cell_glob_index];
 
     // %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% SLAB
-    if (cell->Type() == chi_mesh::CellTypes::SLAB_CELL)
+    if (cell->Type() == chi_mesh::CellType::SLAB)
     {
       auto slab_cell = (chi_mesh::CellSlab*)cell;
       for (int v=0; v<2; v++)
@@ -60,7 +60,7 @@ void chi_diffusion::Solver::ReorderNodesPWLC()
     }
 
     // %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYGON
-    if (cell->Type() == chi_mesh::CellTypes::POLYGON_CELL)
+    if (cell->Type() == chi_mesh::CellType::POLYGON)
     {
       auto poly_cell = (chi_mesh::CellPolygon*)cell;
       for (int v=0; v<poly_cell->v_indices.size(); v++)
@@ -70,7 +70,7 @@ void chi_diffusion::Solver::ReorderNodesPWLC()
     }
 
     // %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYHEDRON
-    if (cell->Type() == chi_mesh::CellTypes::POLYHEDRON_CELL)
+    if (cell->Type() == chi_mesh::CellType::POLYHEDRON)
     {
       auto polyh_cell = (chi_mesh::CellPolyhedron*)cell;
       for (int v=0; v<polyh_cell->v_indices.size(); v++)
@@ -106,7 +106,7 @@ void chi_diffusion::Solver::ReorderNodesPWLC()
     auto cell = vol_continuum->cells[cell_glob_index];
 
     // %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% SLAB
-    if (cell->Type() == chi_mesh::CellTypes::SLAB_CELL)
+    if (cell->Type() == chi_mesh::CellType::SLAB)
     {
       auto slab_cell = (chi_mesh::CellSlab*)cell;
       for (int e=0; e<2; e++)
@@ -133,7 +133,7 @@ void chi_diffusion::Solver::ReorderNodesPWLC()
     }//if slab
 
     // %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYGON
-    if (cell->Type() == chi_mesh::CellTypes::POLYGON_CELL)
+    if (cell->Type() == chi_mesh::CellType::POLYGON)
     {
       auto poly_cell = (chi_mesh::CellPolygon*)cell;
       for (int e=0; e<poly_cell->edges.size(); e++)
@@ -160,7 +160,7 @@ void chi_diffusion::Solver::ReorderNodesPWLC()
     }//if polygon
 
     // %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYHEDRON
-    if (cell->Type() == chi_mesh::CellTypes::POLYHEDRON_CELL)
+    if (cell->Type() == chi_mesh::CellType::POLYHEDRON)
     {
       auto polyh_cell = (chi_mesh::CellPolyhedron*)cell;
       for (int f=0; f<polyh_cell->faces.size(); f++)

--- a/Modules/DiffusionSolver/Solver/assemble_utils_pwlc.cc
+++ b/Modules/DiffusionSolver/Solver/assemble_utils_pwlc.cc
@@ -50,7 +50,7 @@ void chi_diffusion::Solver::ReorderNodesPWLC()
     auto cell = vol_continuum->cells[cell_glob_index];
 
     // %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% SLAB
-    if (typeid(*cell) == typeid(chi_mesh::CellSlab))
+    if (cell->Type() == chi_mesh::SLAB_CELL)
     {
       auto slab_cell = (chi_mesh::CellSlab*)cell;
       for (int v=0; v<2; v++)
@@ -60,7 +60,7 @@ void chi_diffusion::Solver::ReorderNodesPWLC()
     }
 
     // %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYGON
-    if (typeid(*cell) == typeid(chi_mesh::CellPolygon))
+    if (cell->Type() == chi_mesh::POLYGON_CELL)
     {
       auto poly_cell = (chi_mesh::CellPolygon*)cell;
       for (int v=0; v<poly_cell->v_indices.size(); v++)
@@ -70,7 +70,7 @@ void chi_diffusion::Solver::ReorderNodesPWLC()
     }
 
     // %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYHEDRON
-    if (typeid(*cell) == typeid(chi_mesh::CellPolyhedron))
+    if (cell->Type() == chi_mesh::POLYHEDRON_CELL)
     {
       auto polyh_cell = (chi_mesh::CellPolyhedron*)cell;
       for (int v=0; v<polyh_cell->v_indices.size(); v++)
@@ -106,7 +106,7 @@ void chi_diffusion::Solver::ReorderNodesPWLC()
     auto cell = vol_continuum->cells[cell_glob_index];
 
     // %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% SLAB
-    if (typeid(*cell) == typeid(chi_mesh::CellSlab))
+    if (cell->Type() == chi_mesh::SLAB_CELL)
     {
       auto slab_cell = (chi_mesh::CellSlab*)cell;
       for (int e=0; e<2; e++)
@@ -133,7 +133,7 @@ void chi_diffusion::Solver::ReorderNodesPWLC()
     }//if slab
 
     // %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYGON
-    if (typeid(*cell) == typeid(chi_mesh::CellPolygon))
+    if (cell->Type() == chi_mesh::POLYGON_CELL)
     {
       auto poly_cell = (chi_mesh::CellPolygon*)cell;
       for (int e=0; e<poly_cell->edges.size(); e++)
@@ -160,7 +160,7 @@ void chi_diffusion::Solver::ReorderNodesPWLC()
     }//if polygon
 
     // %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYHEDRON
-    if (typeid(*cell) == typeid(chi_mesh::CellPolyhedron))
+    if (cell->Type() == chi_mesh::POLYHEDRON_CELL)
     {
       auto polyh_cell = (chi_mesh::CellPolyhedron*)cell;
       for (int f=0; f<polyh_cell->faces.size(); f++)

--- a/Modules/DiffusionSolver/Solver/exec_pwlc.cc
+++ b/Modules/DiffusionSolver/Solver/exec_pwlc.cc
@@ -75,7 +75,7 @@ int chi_diffusion::Solver::ExecutePWLC(bool suppress_assembly,
     else
     {
       chi_log.Log(LOG_ALLERROR)
-        << "Invalid cell-type encountered in chi_diffusion::Solver::ExecuteS";
+        << "Invalid cell-type encountered in chi_diffusion::Solver::ExecutePWLC";
     }
   }
 

--- a/Modules/DiffusionSolver/Solver/exec_pwlc.cc
+++ b/Modules/DiffusionSolver/Solver/exec_pwlc.cc
@@ -56,18 +56,18 @@ int chi_diffusion::Solver::ExecutePWLC(bool suppress_assembly,
     chi_mesh::Cell* cell = grid->cells[glob_cell_index];
 
     //====================================== Process cells
-    if (cell->Type() == chi_mesh::CellTypes::SLAB_CELL)
+    if (cell->Type() == chi_mesh::CellType::SLAB)
     {
       if (!suppress_assembly)
         CFEM_Ab_Slab(glob_cell_index, cell, gi);
 
     }
-    else if (cell->Type() == chi_mesh::CellTypes::POLYGON_CELL)
+    else if (cell->Type() == chi_mesh::CellType::POLYGON)
     {
       if (!suppress_assembly)
         CFEM_Ab_Polygon(glob_cell_index, cell, gi);
     }
-    else if (cell->Type() == chi_mesh::CellTypes::POLYHEDRON_CELL)
+    else if (cell->Type() == chi_mesh::CellType::POLYHEDRON)
     {
       if (!suppress_assembly)
         CFEM_Ab_Polyhedron(glob_cell_index, cell, gi);

--- a/Modules/DiffusionSolver/Solver/exec_pwlc.cc
+++ b/Modules/DiffusionSolver/Solver/exec_pwlc.cc
@@ -56,18 +56,18 @@ int chi_diffusion::Solver::ExecutePWLC(bool suppress_assembly,
     chi_mesh::Cell* cell = grid->cells[glob_cell_index];
 
     //====================================== Process cells
-    if (cell->Type() == chi_mesh::SLAB_CELL)
+    if (cell->Type() == chi_mesh::CellTypes::SLAB_CELL)
     {
       if (!suppress_assembly)
         CFEM_Ab_Slab(glob_cell_index, cell, gi);
 
     }
-    else if (cell->Type() == chi_mesh::POLYGON_CELL)
+    else if (cell->Type() == chi_mesh::CellTypes::POLYGON_CELL)
     {
       if (!suppress_assembly)
         CFEM_Ab_Polygon(glob_cell_index, cell, gi);
     }
-    else if (cell->Type() == chi_mesh::POLYHEDRON_CELL)
+    else if (cell->Type() == chi_mesh::CellTypes::POLYHEDRON_CELL)
     {
       if (!suppress_assembly)
         CFEM_Ab_Polyhedron(glob_cell_index, cell, gi);

--- a/Modules/DiffusionSolver/Solver/exec_pwlc.cc
+++ b/Modules/DiffusionSolver/Solver/exec_pwlc.cc
@@ -56,18 +56,18 @@ int chi_diffusion::Solver::ExecutePWLC(bool suppress_assembly,
     chi_mesh::Cell* cell = grid->cells[glob_cell_index];
 
     //====================================== Process cells
-    if (typeid(*cell) == typeid(chi_mesh::CellSlab))
+    if (cell->Type() == chi_mesh::SLAB_CELL)
     {
       if (!suppress_assembly)
         CFEM_Ab_Slab(glob_cell_index, cell, gi);
 
     }
-    else if (typeid(*cell) == typeid(chi_mesh::CellPolygon))
+    else if (cell->Type() == chi_mesh::POLYGON_CELL)
     {
       if (!suppress_assembly)
         CFEM_Ab_Polygon(glob_cell_index, cell, gi);
     }
-    else if (typeid(*cell) == typeid(chi_mesh::CellPolyhedron))
+    else if (cell->Type() == chi_mesh::POLYHEDRON_CELL)
     {
       if (!suppress_assembly)
         CFEM_Ab_Polyhedron(glob_cell_index, cell, gi);

--- a/Modules/DiffusionSolver/Solver/exec_pwld_mip.cc
+++ b/Modules/DiffusionSolver/Solver/exec_pwld_mip.cc
@@ -84,7 +84,7 @@ int chi_diffusion::Solver::ExecutePWLD_MIP(bool suppress_assembly,
     DiffusionIPCellView* cell_ip_view = ip_cell_views[lc];
 
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% If SLAB
-    if (cell->Type() == chi_mesh::CellTypes::SLAB_CELL)
+    if (cell->Type() == chi_mesh::CellType::SLAB)
     {
       if (!suppress_assembly)
         PWLD_Ab_Slab(glob_cell_index,cell,cell_ip_view,gi);
@@ -94,7 +94,7 @@ int chi_diffusion::Solver::ExecutePWLD_MIP(bool suppress_assembly,
 
 
       //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% If POLYGON
-    else if (cell->Type() == chi_mesh::CellTypes::POLYGON_CELL)
+    else if (cell->Type() == chi_mesh::CellType::POLYGON)
     {
       if (!suppress_assembly)
         PWLD_Ab_Polygon(glob_cell_index,cell,cell_ip_view,gi);
@@ -103,7 +103,7 @@ int chi_diffusion::Solver::ExecutePWLD_MIP(bool suppress_assembly,
     }//if typeid %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% If POLYHEDRON
-    else if (cell->Type() == chi_mesh::CellTypes::POLYHEDRON_CELL)
+    else if (cell->Type() == chi_mesh::CellType::POLYHEDRON)
     {
       if (!suppress_assembly)
         PWLD_Ab_Polyhedron(glob_cell_index,cell,cell_ip_view,gi);

--- a/Modules/DiffusionSolver/Solver/exec_pwld_mip.cc
+++ b/Modules/DiffusionSolver/Solver/exec_pwld_mip.cc
@@ -84,7 +84,7 @@ int chi_diffusion::Solver::ExecutePWLD_MIP(bool suppress_assembly,
     DiffusionIPCellView* cell_ip_view = ip_cell_views[lc];
 
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% If SLAB
-    if (cell->Type() == chi_mesh::SLAB_CELL)
+    if (cell->Type() == chi_mesh::CellTypes::SLAB_CELL)
     {
       if (!suppress_assembly)
         PWLD_Ab_Slab(glob_cell_index,cell,cell_ip_view,gi);
@@ -94,7 +94,7 @@ int chi_diffusion::Solver::ExecutePWLD_MIP(bool suppress_assembly,
 
 
       //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% If POLYGON
-    else if (cell->Type() == chi_mesh::POLYGON_CELL)
+    else if (cell->Type() == chi_mesh::CellTypes::POLYGON_CELL)
     {
       if (!suppress_assembly)
         PWLD_Ab_Polygon(glob_cell_index,cell,cell_ip_view,gi);
@@ -103,7 +103,7 @@ int chi_diffusion::Solver::ExecutePWLD_MIP(bool suppress_assembly,
     }//if typeid %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% If POLYHEDRON
-    else if (cell->Type() == chi_mesh::POLYHEDRON_CELL)
+    else if (cell->Type() == chi_mesh::CellTypes::POLYHEDRON_CELL)
     {
       if (!suppress_assembly)
         PWLD_Ab_Polyhedron(glob_cell_index,cell,cell_ip_view,gi);

--- a/Modules/DiffusionSolver/Solver/exec_pwld_mip.cc
+++ b/Modules/DiffusionSolver/Solver/exec_pwld_mip.cc
@@ -84,7 +84,7 @@ int chi_diffusion::Solver::ExecutePWLD_MIP(bool suppress_assembly,
     DiffusionIPCellView* cell_ip_view = ip_cell_views[lc];
 
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% If SLAB
-    if (typeid(*cell) == typeid(chi_mesh::CellSlab))
+    if (cell->Type() == chi_mesh::SLAB_CELL)
     {
       if (!suppress_assembly)
         PWLD_Ab_Slab(glob_cell_index,cell,cell_ip_view,gi);
@@ -94,7 +94,7 @@ int chi_diffusion::Solver::ExecutePWLD_MIP(bool suppress_assembly,
 
 
       //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% If POLYGON
-    else if (typeid(*cell) == typeid(chi_mesh::CellPolygon))
+    else if (cell->Type() == chi_mesh::POLYGON_CELL)
     {
       if (!suppress_assembly)
         PWLD_Ab_Polygon(glob_cell_index,cell,cell_ip_view,gi);
@@ -103,7 +103,7 @@ int chi_diffusion::Solver::ExecutePWLD_MIP(bool suppress_assembly,
     }//if typeid %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% If POLYHEDRON
-    else if (typeid(*cell) == typeid(chi_mesh::CellPolyhedron))
+    else if (cell->Type() == chi_mesh::POLYHEDRON_CELL)
     {
       if (!suppress_assembly)
         PWLD_Ab_Polyhedron(glob_cell_index,cell,cell_ip_view,gi);

--- a/Modules/DiffusionSolver/Solver/exec_pwld_mip.cc
+++ b/Modules/DiffusionSolver/Solver/exec_pwld_mip.cc
@@ -113,7 +113,7 @@ int chi_diffusion::Solver::ExecutePWLD_MIP(bool suppress_assembly,
     else
     {
       chi_log.Log(LOG_ALLERROR)
-        << "Invalid cell-type encountered in chi_diffusion::Solver::ExecuteS";
+        << "Invalid cell-type encountered in chi_diffusion::Solver::ExecutePWLD_MIP";
     }
   }
 

--- a/Modules/DiffusionSolver/Solver/exec_pwld_mip_gagg.cc
+++ b/Modules/DiffusionSolver/Solver/exec_pwld_mip_gagg.cc
@@ -112,7 +112,7 @@ int chi_diffusion::Solver::ExecutePWLD_MIP_GAGG(bool suppress_assembly,
     else
     {
       chi_log.Log(LOG_ALLERROR)
-        << "Invalid cell-type encountered in chi_diffusion::Solver::ExecuteS";
+        << "Invalid cell-type encountered in chi_diffusion::Solver::ExecutePWLD_MIP_GAGG";
     }
   }
 

--- a/Modules/DiffusionSolver/Solver/exec_pwld_mip_gagg.cc
+++ b/Modules/DiffusionSolver/Solver/exec_pwld_mip_gagg.cc
@@ -83,7 +83,7 @@ int chi_diffusion::Solver::ExecutePWLD_MIP_GAGG(bool suppress_assembly,
     DiffusionIPCellView* cell_ip_view = ip_cell_views[lc];
 
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% If SLAB
-    if (cell->Type() == chi_mesh::CellTypes::SLAB_CELL)
+    if (cell->Type() == chi_mesh::CellType::SLAB)
     {
       if (!suppress_assembly)
         PWLD_Ab_Slab_GAGG(glob_cell_index,cell,cell_ip_view);
@@ -93,7 +93,7 @@ int chi_diffusion::Solver::ExecutePWLD_MIP_GAGG(bool suppress_assembly,
 
 
       //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% If POLYGON
-    else if (cell->Type() == chi_mesh::CellTypes::POLYGON_CELL)
+    else if (cell->Type() == chi_mesh::CellType::POLYGON)
     {
       if (!suppress_assembly)
         PWLD_Ab_Polygon_GAGG(glob_cell_index,cell,cell_ip_view);
@@ -102,7 +102,7 @@ int chi_diffusion::Solver::ExecutePWLD_MIP_GAGG(bool suppress_assembly,
     }//if typeid %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
       //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% If POLYHEDRON
-    else if (cell->Type() == chi_mesh::CellTypes::POLYHEDRON_CELL)
+    else if (cell->Type() == chi_mesh::CellType::POLYHEDRON)
     {
       if (!suppress_assembly)
         PWLD_Ab_Polyhedron_GAGG(glob_cell_index, cell, cell_ip_view);

--- a/Modules/DiffusionSolver/Solver/exec_pwld_mip_gagg.cc
+++ b/Modules/DiffusionSolver/Solver/exec_pwld_mip_gagg.cc
@@ -83,7 +83,7 @@ int chi_diffusion::Solver::ExecutePWLD_MIP_GAGG(bool suppress_assembly,
     DiffusionIPCellView* cell_ip_view = ip_cell_views[lc];
 
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% If SLAB
-    if (typeid(*cell) == typeid(chi_mesh::CellSlab))
+    if (cell->Type() == chi_mesh::SLAB_CELL)
     {
       if (!suppress_assembly)
         PWLD_Ab_Slab_GAGG(glob_cell_index,cell,cell_ip_view);
@@ -93,7 +93,7 @@ int chi_diffusion::Solver::ExecutePWLD_MIP_GAGG(bool suppress_assembly,
 
 
       //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% If POLYGON
-    else if (typeid(*cell) == typeid(chi_mesh::CellPolygon))
+    else if (cell->Type() == chi_mesh::POLYGON_CELL)
     {
       if (!suppress_assembly)
         PWLD_Ab_Polygon_GAGG(glob_cell_index,cell,cell_ip_view);
@@ -102,7 +102,7 @@ int chi_diffusion::Solver::ExecutePWLD_MIP_GAGG(bool suppress_assembly,
     }//if typeid %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
       //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% If POLYHEDRON
-    else if (typeid(*cell) == typeid(chi_mesh::CellPolyhedron))
+    else if (cell->Type() == chi_mesh::POLYHEDRON_CELL)
     {
       if (!suppress_assembly)
         PWLD_Ab_Polyhedron_GAGG(glob_cell_index, cell, cell_ip_view);

--- a/Modules/DiffusionSolver/Solver/exec_pwld_mip_gagg.cc
+++ b/Modules/DiffusionSolver/Solver/exec_pwld_mip_gagg.cc
@@ -83,7 +83,7 @@ int chi_diffusion::Solver::ExecutePWLD_MIP_GAGG(bool suppress_assembly,
     DiffusionIPCellView* cell_ip_view = ip_cell_views[lc];
 
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% If SLAB
-    if (cell->Type() == chi_mesh::SLAB_CELL)
+    if (cell->Type() == chi_mesh::CellTypes::SLAB_CELL)
     {
       if (!suppress_assembly)
         PWLD_Ab_Slab_GAGG(glob_cell_index,cell,cell_ip_view);
@@ -93,7 +93,7 @@ int chi_diffusion::Solver::ExecutePWLD_MIP_GAGG(bool suppress_assembly,
 
 
       //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% If POLYGON
-    else if (cell->Type() == chi_mesh::POLYGON_CELL)
+    else if (cell->Type() == chi_mesh::CellTypes::POLYGON_CELL)
     {
       if (!suppress_assembly)
         PWLD_Ab_Polygon_GAGG(glob_cell_index,cell,cell_ip_view);
@@ -102,7 +102,7 @@ int chi_diffusion::Solver::ExecutePWLD_MIP_GAGG(bool suppress_assembly,
     }//if typeid %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
       //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% If POLYHEDRON
-    else if (cell->Type() == chi_mesh::POLYHEDRON_CELL)
+    else if (cell->Type() == chi_mesh::CellTypes::POLYHEDRON_CELL)
     {
       if (!suppress_assembly)
         PWLD_Ab_Polyhedron_GAGG(glob_cell_index, cell, cell_ip_view);

--- a/Modules/DiffusionSolver/Solver/exec_pwld_mip_grps.cc
+++ b/Modules/DiffusionSolver/Solver/exec_pwld_mip_grps.cc
@@ -77,7 +77,7 @@ int chi_diffusion::Solver::ExecutePWLD_MIP_GRPS(bool suppress_assembly,
       DiffusionIPCellView* cell_ip_view = ip_cell_views[lc];
 
       //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% If SLAB
-      if (cell->Type() == chi_mesh::CellTypes::SLAB_CELL)
+      if (cell->Type() == chi_mesh::CellType::SLAB)
       {
         if (!suppress_assembly)
         {
@@ -89,7 +89,7 @@ int chi_diffusion::Solver::ExecutePWLD_MIP_GRPS(bool suppress_assembly,
 
 
         //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% If POLYGON
-      else if (cell->Type() == chi_mesh::CellTypes::POLYGON_CELL)
+      else if (cell->Type() == chi_mesh::CellType::POLYGON)
       {
         if (!suppress_assembly)
         {
@@ -101,7 +101,7 @@ int chi_diffusion::Solver::ExecutePWLD_MIP_GRPS(bool suppress_assembly,
       }//if typeid %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
         //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% If POLYHEDRON
-      else if (cell->Type() == chi_mesh::CellTypes::POLYHEDRON_CELL)
+      else if (cell->Type() == chi_mesh::CellType::POLYHEDRON)
       {
         if (!suppress_assembly)
           PWLD_Ab_Polyhedron(glob_cell_index, cell, cell_ip_view, gi+gr);

--- a/Modules/DiffusionSolver/Solver/exec_pwld_mip_grps.cc
+++ b/Modules/DiffusionSolver/Solver/exec_pwld_mip_grps.cc
@@ -77,7 +77,7 @@ int chi_diffusion::Solver::ExecutePWLD_MIP_GRPS(bool suppress_assembly,
       DiffusionIPCellView* cell_ip_view = ip_cell_views[lc];
 
       //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% If SLAB
-      if (typeid(*cell) == typeid(chi_mesh::CellSlab))
+      if (cell->Type() == chi_mesh::SLAB_CELL)
       {
         if (!suppress_assembly)
         {
@@ -89,7 +89,7 @@ int chi_diffusion::Solver::ExecutePWLD_MIP_GRPS(bool suppress_assembly,
 
 
         //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% If POLYGON
-      else if (typeid(*cell) == typeid(chi_mesh::CellPolygon))
+      else if (cell->Type() == chi_mesh::POLYGON_CELL)
       {
         if (!suppress_assembly)
         {
@@ -101,7 +101,7 @@ int chi_diffusion::Solver::ExecutePWLD_MIP_GRPS(bool suppress_assembly,
       }//if typeid %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
         //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% If POLYHEDRON
-      else if (typeid(*cell) == typeid(chi_mesh::CellPolyhedron))
+      else if (cell->Type() == chi_mesh::POLYHEDRON_CELL)
       {
         if (!suppress_assembly)
           PWLD_Ab_Polyhedron(glob_cell_index, cell, cell_ip_view, gi+gr);

--- a/Modules/DiffusionSolver/Solver/exec_pwld_mip_grps.cc
+++ b/Modules/DiffusionSolver/Solver/exec_pwld_mip_grps.cc
@@ -111,7 +111,7 @@ int chi_diffusion::Solver::ExecutePWLD_MIP_GRPS(bool suppress_assembly,
       else
       {
         chi_log.Log(LOG_ALLERROR)
-          << "Invalid cell-type encountered in chi_diffusion::Solver::ExecuteS";
+          << "Invalid cell-type encountered in chi_diffusion::Solver::ExecutePWLD_MIP_GRPS";
       }
     }//for local cell
   }//for gr

--- a/Modules/DiffusionSolver/Solver/exec_pwld_mip_grps.cc
+++ b/Modules/DiffusionSolver/Solver/exec_pwld_mip_grps.cc
@@ -77,7 +77,7 @@ int chi_diffusion::Solver::ExecutePWLD_MIP_GRPS(bool suppress_assembly,
       DiffusionIPCellView* cell_ip_view = ip_cell_views[lc];
 
       //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% If SLAB
-      if (cell->Type() == chi_mesh::SLAB_CELL)
+      if (cell->Type() == chi_mesh::CellTypes::SLAB_CELL)
       {
         if (!suppress_assembly)
         {
@@ -89,7 +89,7 @@ int chi_diffusion::Solver::ExecutePWLD_MIP_GRPS(bool suppress_assembly,
 
 
         //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% If POLYGON
-      else if (cell->Type() == chi_mesh::POLYGON_CELL)
+      else if (cell->Type() == chi_mesh::CellTypes::POLYGON_CELL)
       {
         if (!suppress_assembly)
         {
@@ -101,7 +101,7 @@ int chi_diffusion::Solver::ExecutePWLD_MIP_GRPS(bool suppress_assembly,
       }//if typeid %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
         //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% If POLYHEDRON
-      else if (cell->Type() == chi_mesh::POLYHEDRON_CELL)
+      else if (cell->Type() == chi_mesh::CellTypes::POLYHEDRON_CELL)
       {
         if (!suppress_assembly)
           PWLD_Ab_Polyhedron(glob_cell_index, cell, cell_ip_view, gi+gr);

--- a/Modules/DiffusionSolver/Solver/init_pwlc.cc
+++ b/Modules/DiffusionSolver/Solver/init_pwlc.cc
@@ -131,7 +131,7 @@ int chi_diffusion::Solver::InitializePWLC(bool verbose)
     auto cell = grid->cells[glob_index];
 
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% SLAB
-    if (typeid(*cell) == typeid(chi_mesh::CellSlab))
+    if (cell->Type() == chi_mesh::SLAB_CELL)
     {
       chi_mesh::CellSlab* slab_cell =
         (chi_mesh::CellSlab*)(cell);
@@ -189,7 +189,7 @@ int chi_diffusion::Solver::InitializePWLC(bool verbose)
 
 
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYGON
-    if (typeid(*cell) == typeid(chi_mesh::CellPolygon))
+    if (cell->Type() == chi_mesh::POLYGON_CELL)
     {
       chi_mesh::CellPolygon* poly_cell =
         (chi_mesh::CellPolygon*)(cell);
@@ -247,7 +247,7 @@ int chi_diffusion::Solver::InitializePWLC(bool verbose)
       }//for vertices i
     }//if Polygon
       //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% If polyhedral item_id
-    else if (typeid(*cell) == typeid(chi_mesh::CellPolyhedron))
+    else if (cell->Type() == chi_mesh::POLYHEDRON_CELL)
     {
       chi_mesh::CellPolyhedron* polyh_cell =
         (chi_mesh::CellPolyhedron*)(cell);

--- a/Modules/DiffusionSolver/Solver/init_pwlc.cc
+++ b/Modules/DiffusionSolver/Solver/init_pwlc.cc
@@ -131,7 +131,7 @@ int chi_diffusion::Solver::InitializePWLC(bool verbose)
     auto cell = grid->cells[glob_index];
 
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% SLAB
-    if (cell->Type() == chi_mesh::CellTypes::SLAB_CELL)
+    if (cell->Type() == chi_mesh::CellType::SLAB)
     {
       chi_mesh::CellSlab* slab_cell =
         (chi_mesh::CellSlab*)(cell);
@@ -189,7 +189,7 @@ int chi_diffusion::Solver::InitializePWLC(bool verbose)
 
 
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYGON
-    if (cell->Type() == chi_mesh::CellTypes::POLYGON_CELL)
+    if (cell->Type() == chi_mesh::CellType::POLYGON)
     {
       chi_mesh::CellPolygon* poly_cell =
         (chi_mesh::CellPolygon*)(cell);
@@ -247,7 +247,7 @@ int chi_diffusion::Solver::InitializePWLC(bool verbose)
       }//for vertices i
     }//if Polygon
       //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% If polyhedral item_id
-    else if (cell->Type() == chi_mesh::CellTypes::POLYHEDRON_CELL)
+    else if (cell->Type() == chi_mesh::CellType::POLYHEDRON)
     {
       chi_mesh::CellPolyhedron* polyh_cell =
         (chi_mesh::CellPolyhedron*)(cell);

--- a/Modules/DiffusionSolver/Solver/init_pwlc.cc
+++ b/Modules/DiffusionSolver/Solver/init_pwlc.cc
@@ -131,7 +131,7 @@ int chi_diffusion::Solver::InitializePWLC(bool verbose)
     auto cell = grid->cells[glob_index];
 
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% SLAB
-    if (cell->Type() == chi_mesh::SLAB_CELL)
+    if (cell->Type() == chi_mesh::CellTypes::SLAB_CELL)
     {
       chi_mesh::CellSlab* slab_cell =
         (chi_mesh::CellSlab*)(cell);
@@ -189,7 +189,7 @@ int chi_diffusion::Solver::InitializePWLC(bool verbose)
 
 
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYGON
-    if (cell->Type() == chi_mesh::POLYGON_CELL)
+    if (cell->Type() == chi_mesh::CellTypes::POLYGON_CELL)
     {
       chi_mesh::CellPolygon* poly_cell =
         (chi_mesh::CellPolygon*)(cell);
@@ -247,7 +247,7 @@ int chi_diffusion::Solver::InitializePWLC(bool verbose)
       }//for vertices i
     }//if Polygon
       //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% If polyhedral item_id
-    else if (cell->Type() == chi_mesh::POLYHEDRON_CELL)
+    else if (cell->Type() == chi_mesh::CellTypes::POLYHEDRON_CELL)
     {
       chi_mesh::CellPolyhedron* polyh_cell =
         (chi_mesh::CellPolyhedron*)(cell);

--- a/Modules/DiffusionSolver/Solver/init_pwld.cc
+++ b/Modules/DiffusionSolver/Solver/init_pwld.cc
@@ -162,14 +162,14 @@ int chi_diffusion::Solver::InitializePWLD(bool verbose)
   int first_cell_g_index = grid->local_cell_glob_indices[0];
   auto first_cell = grid->cells[first_cell_g_index];
 
-  if (first_cell->Type() == chi_mesh::SLAB_CELL)
+  if (first_cell->Type() == chi_mesh::CellTypes::SLAB_CELL)
   {
     PetscOptionsInsertString(NULL,"-pc_hypre_boomeramg_agg_nl 1");
     PetscOptionsInsertString(NULL,"-pc_hypre_boomeramg_P_max 4");
     PetscOptionsInsertString(NULL,"-pc_hypre_boomeramg_grid_sweeps_coarse 1");
   }
 
-  if (first_cell->Type() == chi_mesh::POLYHEDRON_CELL)
+  if (first_cell->Type() == chi_mesh::CellTypes::POLYHEDRON_CELL)
   {
     PetscOptionsInsertString(NULL,"-pc_hypre_boomeramg_strong_threshold 0.8");
 

--- a/Modules/DiffusionSolver/Solver/init_pwld.cc
+++ b/Modules/DiffusionSolver/Solver/init_pwld.cc
@@ -162,14 +162,14 @@ int chi_diffusion::Solver::InitializePWLD(bool verbose)
   int first_cell_g_index = grid->local_cell_glob_indices[0];
   auto first_cell = grid->cells[first_cell_g_index];
 
-  if (typeid(*first_cell) == typeid(chi_mesh::CellSlab))
+  if (first_cell->Type() == chi_mesh::SLAB_CELL)
   {
     PetscOptionsInsertString(NULL,"-pc_hypre_boomeramg_agg_nl 1");
     PetscOptionsInsertString(NULL,"-pc_hypre_boomeramg_P_max 4");
     PetscOptionsInsertString(NULL,"-pc_hypre_boomeramg_grid_sweeps_coarse 1");
   }
 
-  if (typeid(*first_cell) == typeid(chi_mesh::CellPolyhedron))
+  if (first_cell->Type() == chi_mesh::POLYHEDRON_CELL)
   {
     PetscOptionsInsertString(NULL,"-pc_hypre_boomeramg_strong_threshold 0.8");
 

--- a/Modules/DiffusionSolver/Solver/init_pwld.cc
+++ b/Modules/DiffusionSolver/Solver/init_pwld.cc
@@ -162,14 +162,14 @@ int chi_diffusion::Solver::InitializePWLD(bool verbose)
   int first_cell_g_index = grid->local_cell_glob_indices[0];
   auto first_cell = grid->cells[first_cell_g_index];
 
-  if (first_cell->Type() == chi_mesh::CellTypes::SLAB_CELL)
+  if (first_cell->Type() == chi_mesh::CellType::SLAB)
   {
     PetscOptionsInsertString(NULL,"-pc_hypre_boomeramg_agg_nl 1");
     PetscOptionsInsertString(NULL,"-pc_hypre_boomeramg_P_max 4");
     PetscOptionsInsertString(NULL,"-pc_hypre_boomeramg_grid_sweeps_coarse 1");
   }
 
-  if (first_cell->Type() == chi_mesh::CellTypes::POLYHEDRON_CELL)
+  if (first_cell->Type() == chi_mesh::CellType::POLYHEDRON)
   {
     PetscOptionsInsertString(NULL,"-pc_hypre_boomeramg_strong_threshold 0.8");
 

--- a/Modules/DiffusionSolver/Solver/initcommon.cc
+++ b/Modules/DiffusionSolver/Solver/initcommon.cc
@@ -94,7 +94,7 @@ void chi_diffusion::Solver::PWLDBuildSparsityPattern()
     auto cell = grid->cells[cell_glob_index];
 
     // %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% SLAB
-    if (typeid(*cell) == typeid(chi_mesh::CellSlab))
+    if (cell->Type() == chi_mesh::SLAB_CELL)
     {
       auto slab_cell = (chi_mesh::CellSlab*)cell;
 
@@ -136,7 +136,7 @@ void chi_diffusion::Solver::PWLDBuildSparsityPattern()
     }
 
     // %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYGON
-    if (typeid(*cell) == typeid(chi_mesh::CellPolygon))
+    if (cell->Type() == chi_mesh::POLYGON_CELL)
     {
       auto poly_cell = (chi_mesh::CellPolygon*)cell;
 
@@ -188,7 +188,7 @@ void chi_diffusion::Solver::PWLDBuildSparsityPattern()
     }//polygon
 
     // %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYHEDRON
-    if (typeid(*cell) == typeid(chi_mesh::CellPolyhedron))
+    if (cell->Type() == chi_mesh::POLYHEDRON_CELL)
     {
       auto polyh_cell = (chi_mesh::CellPolyhedron*)cell;
 
@@ -290,7 +290,7 @@ void chi_diffusion::Solver::PWLDBuildSparsityPattern()
     border_cell_info.push_back(ip_view->cell_dof_start); //cell_dof_start
 
     // %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% SLAB
-    if (typeid(*cell) == typeid(chi_mesh::CellSlab))
+    if (cell->Type() == chi_mesh::SLAB_CELL)
     {
       auto slab_cell = (chi_mesh::CellSlab*)cell;
       border_cell_info.push_back(0);                     //cell_type
@@ -309,7 +309,7 @@ void chi_diffusion::Solver::PWLDBuildSparsityPattern()
     }
 
     // %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYGON
-    if (typeid(*cell) == typeid(chi_mesh::CellPolygon))
+    if (cell->Type() == chi_mesh::POLYGON_CELL)
     {
       auto poly_cell = (chi_mesh::CellPolygon*)cell;
       border_cell_info.push_back(1);                     //cell_type
@@ -329,7 +329,7 @@ void chi_diffusion::Solver::PWLDBuildSparsityPattern()
     }
 
     // %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYHEDRON
-    if (typeid(*cell) == typeid(chi_mesh::CellPolyhedron))
+    if (cell->Type() == chi_mesh::POLYHEDRON_CELL)
     {
       auto polyh_cell = (chi_mesh::CellPolyhedron*)cell;
       border_cell_info.push_back(2);                     //cell_type
@@ -466,7 +466,7 @@ void chi_diffusion::Solver::PWLDBuildSparsityPattern()
     auto cell = grid->cells[cell_glob_index];
 
     // %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% SLAB
-    if (typeid(*cell) == typeid(chi_mesh::CellSlab))
+    if (cell->Type() == chi_mesh::SLAB_CELL)
     {
       auto slab_cell = (chi_mesh::CellSlab*)cell;
 
@@ -476,7 +476,7 @@ void chi_diffusion::Solver::PWLDBuildSparsityPattern()
     }
 
     // %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYGON
-    if (typeid(*cell) == typeid(chi_mesh::CellPolygon))
+    if (cell->Type() == chi_mesh::POLYGON_CELL)
     {
       auto poly_cell = (chi_mesh::CellPolygon*)cell;
 
@@ -503,7 +503,7 @@ void chi_diffusion::Solver::PWLDBuildSparsityPattern()
     }//polygon
 
     // %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYHEDRON
-    if (typeid(*cell) == typeid(chi_mesh::CellPolyhedron))
+    if (cell->Type() == chi_mesh::POLYHEDRON_CELL)
     {
       auto polyh_cell = (chi_mesh::CellPolyhedron*)cell;
 

--- a/Modules/DiffusionSolver/Solver/initcommon.cc
+++ b/Modules/DiffusionSolver/Solver/initcommon.cc
@@ -94,7 +94,7 @@ void chi_diffusion::Solver::PWLDBuildSparsityPattern()
     auto cell = grid->cells[cell_glob_index];
 
     // %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% SLAB
-    if (cell->Type() == chi_mesh::SLAB_CELL)
+    if (cell->Type() == chi_mesh::CellTypes::SLAB_CELL)
     {
       auto slab_cell = (chi_mesh::CellSlab*)cell;
 
@@ -136,7 +136,7 @@ void chi_diffusion::Solver::PWLDBuildSparsityPattern()
     }
 
     // %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYGON
-    if (cell->Type() == chi_mesh::POLYGON_CELL)
+    if (cell->Type() == chi_mesh::CellTypes::POLYGON_CELL)
     {
       auto poly_cell = (chi_mesh::CellPolygon*)cell;
 
@@ -188,7 +188,7 @@ void chi_diffusion::Solver::PWLDBuildSparsityPattern()
     }//polygon
 
     // %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYHEDRON
-    if (cell->Type() == chi_mesh::POLYHEDRON_CELL)
+    if (cell->Type() == chi_mesh::CellTypes::POLYHEDRON_CELL)
     {
       auto polyh_cell = (chi_mesh::CellPolyhedron*)cell;
 
@@ -290,7 +290,7 @@ void chi_diffusion::Solver::PWLDBuildSparsityPattern()
     border_cell_info.push_back(ip_view->cell_dof_start); //cell_dof_start
 
     // %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% SLAB
-    if (cell->Type() == chi_mesh::SLAB_CELL)
+    if (cell->Type() == chi_mesh::CellTypes::SLAB_CELL)
     {
       auto slab_cell = (chi_mesh::CellSlab*)cell;
       border_cell_info.push_back(0);                     //cell_type
@@ -309,7 +309,7 @@ void chi_diffusion::Solver::PWLDBuildSparsityPattern()
     }
 
     // %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYGON
-    if (cell->Type() == chi_mesh::POLYGON_CELL)
+    if (cell->Type() == chi_mesh::CellTypes::POLYGON_CELL)
     {
       auto poly_cell = (chi_mesh::CellPolygon*)cell;
       border_cell_info.push_back(1);                     //cell_type
@@ -329,7 +329,7 @@ void chi_diffusion::Solver::PWLDBuildSparsityPattern()
     }
 
     // %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYHEDRON
-    if (cell->Type() == chi_mesh::POLYHEDRON_CELL)
+    if (cell->Type() == chi_mesh::CellTypes::POLYHEDRON_CELL)
     {
       auto polyh_cell = (chi_mesh::CellPolyhedron*)cell;
       border_cell_info.push_back(2);                     //cell_type
@@ -466,7 +466,7 @@ void chi_diffusion::Solver::PWLDBuildSparsityPattern()
     auto cell = grid->cells[cell_glob_index];
 
     // %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% SLAB
-    if (cell->Type() == chi_mesh::SLAB_CELL)
+    if (cell->Type() == chi_mesh::CellTypes::SLAB_CELL)
     {
       auto slab_cell = (chi_mesh::CellSlab*)cell;
 
@@ -476,7 +476,7 @@ void chi_diffusion::Solver::PWLDBuildSparsityPattern()
     }
 
     // %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYGON
-    if (cell->Type() == chi_mesh::POLYGON_CELL)
+    if (cell->Type() == chi_mesh::CellTypes::POLYGON_CELL)
     {
       auto poly_cell = (chi_mesh::CellPolygon*)cell;
 
@@ -503,7 +503,7 @@ void chi_diffusion::Solver::PWLDBuildSparsityPattern()
     }//polygon
 
     // %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYHEDRON
-    if (cell->Type() == chi_mesh::POLYHEDRON_CELL)
+    if (cell->Type() == chi_mesh::CellTypes::POLYHEDRON_CELL)
     {
       auto polyh_cell = (chi_mesh::CellPolyhedron*)cell;
 

--- a/Modules/DiffusionSolver/Solver/initcommon.cc
+++ b/Modules/DiffusionSolver/Solver/initcommon.cc
@@ -94,7 +94,7 @@ void chi_diffusion::Solver::PWLDBuildSparsityPattern()
     auto cell = grid->cells[cell_glob_index];
 
     // %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% SLAB
-    if (cell->Type() == chi_mesh::CellTypes::SLAB_CELL)
+    if (cell->Type() == chi_mesh::CellType::SLAB)
     {
       auto slab_cell = (chi_mesh::CellSlab*)cell;
 
@@ -136,7 +136,7 @@ void chi_diffusion::Solver::PWLDBuildSparsityPattern()
     }
 
     // %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYGON
-    if (cell->Type() == chi_mesh::CellTypes::POLYGON_CELL)
+    if (cell->Type() == chi_mesh::CellType::POLYGON)
     {
       auto poly_cell = (chi_mesh::CellPolygon*)cell;
 
@@ -188,7 +188,7 @@ void chi_diffusion::Solver::PWLDBuildSparsityPattern()
     }//polygon
 
     // %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYHEDRON
-    if (cell->Type() == chi_mesh::CellTypes::POLYHEDRON_CELL)
+    if (cell->Type() == chi_mesh::CellType::POLYHEDRON)
     {
       auto polyh_cell = (chi_mesh::CellPolyhedron*)cell;
 
@@ -290,7 +290,7 @@ void chi_diffusion::Solver::PWLDBuildSparsityPattern()
     border_cell_info.push_back(ip_view->cell_dof_start); //cell_dof_start
 
     // %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% SLAB
-    if (cell->Type() == chi_mesh::CellTypes::SLAB_CELL)
+    if (cell->Type() == chi_mesh::CellType::SLAB)
     {
       auto slab_cell = (chi_mesh::CellSlab*)cell;
       border_cell_info.push_back(0);                     //cell_type
@@ -309,7 +309,7 @@ void chi_diffusion::Solver::PWLDBuildSparsityPattern()
     }
 
     // %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYGON
-    if (cell->Type() == chi_mesh::CellTypes::POLYGON_CELL)
+    if (cell->Type() == chi_mesh::CellType::POLYGON)
     {
       auto poly_cell = (chi_mesh::CellPolygon*)cell;
       border_cell_info.push_back(1);                     //cell_type
@@ -329,7 +329,7 @@ void chi_diffusion::Solver::PWLDBuildSparsityPattern()
     }
 
     // %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYHEDRON
-    if (cell->Type() == chi_mesh::CellTypes::POLYHEDRON_CELL)
+    if (cell->Type() == chi_mesh::CellType::POLYHEDRON)
     {
       auto polyh_cell = (chi_mesh::CellPolyhedron*)cell;
       border_cell_info.push_back(2);                     //cell_type
@@ -466,7 +466,7 @@ void chi_diffusion::Solver::PWLDBuildSparsityPattern()
     auto cell = grid->cells[cell_glob_index];
 
     // %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% SLAB
-    if (cell->Type() == chi_mesh::CellTypes::SLAB_CELL)
+    if (cell->Type() == chi_mesh::CellType::SLAB)
     {
       auto slab_cell = (chi_mesh::CellSlab*)cell;
 
@@ -476,7 +476,7 @@ void chi_diffusion::Solver::PWLDBuildSparsityPattern()
     }
 
     // %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYGON
-    if (cell->Type() == chi_mesh::CellTypes::POLYGON_CELL)
+    if (cell->Type() == chi_mesh::CellType::POLYGON)
     {
       auto poly_cell = (chi_mesh::CellPolygon*)cell;
 
@@ -503,7 +503,7 @@ void chi_diffusion::Solver::PWLDBuildSparsityPattern()
     }//polygon
 
     // %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYHEDRON
-    if (cell->Type() == chi_mesh::CellTypes::POLYHEDRON_CELL)
+    if (cell->Type() == chi_mesh::CellType::POLYHEDRON)
     {
       auto polyh_cell = (chi_mesh::CellPolyhedron*)cell;
 

--- a/Modules/DiffusionSolver/Solver/initpwld_grpagg.cc
+++ b/Modules/DiffusionSolver/Solver/initpwld_grpagg.cc
@@ -174,14 +174,14 @@ int chi_diffusion::Solver::InitializePWLDGrpAgg(bool verbose)
   int first_cell_g_index = grid->local_cell_glob_indices[0];
   auto first_cell = grid->cells[first_cell_g_index];
 
-  if (typeid(*first_cell) == typeid(chi_mesh::CellSlab))
+  if (first_cell->Type() == chi_mesh::SLAB_CELL)
   {
     PetscOptionsInsertString(NULL,"-pc_hypre_boomeramg_agg_nl 1");
     PetscOptionsInsertString(NULL,"-pc_hypre_boomeramg_P_max 4");
     PetscOptionsInsertString(NULL,"-pc_hypre_boomeramg_grid_sweeps_coarse 1");
   }
 
-  if (typeid(*first_cell) == typeid(chi_mesh::CellPolyhedron))
+  if (first_cell->Type() == chi_mesh::POLYHEDRON_CELL)
   {
     PetscOptionsInsertString(NULL,"-pc_hypre_boomeramg_strong_threshold 0.8");
 

--- a/Modules/DiffusionSolver/Solver/initpwld_grpagg.cc
+++ b/Modules/DiffusionSolver/Solver/initpwld_grpagg.cc
@@ -174,14 +174,14 @@ int chi_diffusion::Solver::InitializePWLDGrpAgg(bool verbose)
   int first_cell_g_index = grid->local_cell_glob_indices[0];
   auto first_cell = grid->cells[first_cell_g_index];
 
-  if (first_cell->Type() == chi_mesh::CellTypes::SLAB_CELL)
+  if (first_cell->Type() == chi_mesh::CellType::SLAB)
   {
     PetscOptionsInsertString(NULL,"-pc_hypre_boomeramg_agg_nl 1");
     PetscOptionsInsertString(NULL,"-pc_hypre_boomeramg_P_max 4");
     PetscOptionsInsertString(NULL,"-pc_hypre_boomeramg_grid_sweeps_coarse 1");
   }
 
-  if (first_cell->Type() == chi_mesh::CellTypes::POLYHEDRON_CELL)
+  if (first_cell->Type() == chi_mesh::CellType::POLYHEDRON)
   {
     PetscOptionsInsertString(NULL,"-pc_hypre_boomeramg_strong_threshold 0.8");
 

--- a/Modules/DiffusionSolver/Solver/initpwld_grpagg.cc
+++ b/Modules/DiffusionSolver/Solver/initpwld_grpagg.cc
@@ -174,14 +174,14 @@ int chi_diffusion::Solver::InitializePWLDGrpAgg(bool verbose)
   int first_cell_g_index = grid->local_cell_glob_indices[0];
   auto first_cell = grid->cells[first_cell_g_index];
 
-  if (first_cell->Type() == chi_mesh::SLAB_CELL)
+  if (first_cell->Type() == chi_mesh::CellTypes::SLAB_CELL)
   {
     PetscOptionsInsertString(NULL,"-pc_hypre_boomeramg_agg_nl 1");
     PetscOptionsInsertString(NULL,"-pc_hypre_boomeramg_P_max 4");
     PetscOptionsInsertString(NULL,"-pc_hypre_boomeramg_grid_sweeps_coarse 1");
   }
 
-  if (first_cell->Type() == chi_mesh::POLYHEDRON_CELL)
+  if (first_cell->Type() == chi_mesh::CellTypes::POLYHEDRON_CELL)
   {
     PetscOptionsInsertString(NULL,"-pc_hypre_boomeramg_strong_threshold 0.8");
 

--- a/Modules/DiffusionSolver/Solver/initpwld_grps.cc
+++ b/Modules/DiffusionSolver/Solver/initpwld_grps.cc
@@ -126,7 +126,7 @@ int chi_diffusion::Solver::InitializePWLDGroups(bool verbose)
     auto cell = grid->cells[cell_glob_index];
 
     // %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% SLAB
-    if (cell->Type() == chi_mesh::SLAB_CELL)
+    if (cell->Type() == chi_mesh::CellTypes::SLAB_CELL)
     {
       auto slab_cell = (chi_mesh::CellSlab*)cell;
 
@@ -168,7 +168,7 @@ int chi_diffusion::Solver::InitializePWLDGroups(bool verbose)
     }
 
     // %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYGON
-    if (cell->Type() == chi_mesh::POLYGON_CELL)
+    if (cell->Type() == chi_mesh::CellTypes::POLYGON_CELL)
     {
       auto poly_cell = (chi_mesh::CellPolygon*)cell;
 
@@ -221,7 +221,7 @@ int chi_diffusion::Solver::InitializePWLDGroups(bool verbose)
     }//polygon
 
     // %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYHEDRON
-    if (cell->Type() == chi_mesh::POLYHEDRON_CELL)
+    if (cell->Type() == chi_mesh::CellTypes::POLYHEDRON_CELL)
     {
       auto polyh_cell = (chi_mesh::CellPolyhedron*)cell;
 
@@ -321,7 +321,7 @@ int chi_diffusion::Solver::InitializePWLDGroups(bool verbose)
     border_cell_info.push_back(ip_view->cell_dof_start); //cell_dof_start
 
     // %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% SLAB
-    if (cell->Type() == chi_mesh::SLAB_CELL)
+    if (cell->Type() == chi_mesh::CellTypes::SLAB_CELL)
     {
       auto slab_cell = (chi_mesh::CellSlab*)cell;
       border_cell_info.push_back(0);                     //cell_type
@@ -340,7 +340,7 @@ int chi_diffusion::Solver::InitializePWLDGroups(bool verbose)
     }
 
     // %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYGON
-    if (cell->Type() == chi_mesh::POLYGON_CELL)
+    if (cell->Type() == chi_mesh::CellTypes::POLYGON_CELL)
     {
       auto poly_cell = (chi_mesh::CellPolygon*)cell;
       border_cell_info.push_back(1);                     //cell_type
@@ -360,7 +360,7 @@ int chi_diffusion::Solver::InitializePWLDGroups(bool verbose)
     }
 
     // %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYHEDRON
-    if (cell->Type() == chi_mesh::POLYHEDRON_CELL)
+    if (cell->Type() == chi_mesh::CellTypes::POLYHEDRON_CELL)
     {
       auto polyh_cell = (chi_mesh::CellPolyhedron*)cell;
       border_cell_info.push_back(2);                     //cell_type

--- a/Modules/DiffusionSolver/Solver/initpwld_grps.cc
+++ b/Modules/DiffusionSolver/Solver/initpwld_grps.cc
@@ -126,7 +126,7 @@ int chi_diffusion::Solver::InitializePWLDGroups(bool verbose)
     auto cell = grid->cells[cell_glob_index];
 
     // %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% SLAB
-    if (typeid(*cell) == typeid(chi_mesh::CellSlab))
+    if (cell->Type() == chi_mesh::SLAB_CELL)
     {
       auto slab_cell = (chi_mesh::CellSlab*)cell;
 
@@ -168,7 +168,7 @@ int chi_diffusion::Solver::InitializePWLDGroups(bool verbose)
     }
 
     // %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYGON
-    if (typeid(*cell) == typeid(chi_mesh::CellPolygon))
+    if (cell->Type() == chi_mesh::POLYGON_CELL)
     {
       auto poly_cell = (chi_mesh::CellPolygon*)cell;
 
@@ -221,7 +221,7 @@ int chi_diffusion::Solver::InitializePWLDGroups(bool verbose)
     }//polygon
 
     // %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYHEDRON
-    if (typeid(*cell) == typeid(chi_mesh::CellPolyhedron))
+    if (cell->Type() == chi_mesh::POLYHEDRON_CELL)
     {
       auto polyh_cell = (chi_mesh::CellPolyhedron*)cell;
 
@@ -321,7 +321,7 @@ int chi_diffusion::Solver::InitializePWLDGroups(bool verbose)
     border_cell_info.push_back(ip_view->cell_dof_start); //cell_dof_start
 
     // %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% SLAB
-    if (typeid(*cell) == typeid(chi_mesh::CellSlab))
+    if (cell->Type() == chi_mesh::SLAB_CELL)
     {
       auto slab_cell = (chi_mesh::CellSlab*)cell;
       border_cell_info.push_back(0);                     //cell_type
@@ -340,7 +340,7 @@ int chi_diffusion::Solver::InitializePWLDGroups(bool verbose)
     }
 
     // %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYGON
-    if (typeid(*cell) == typeid(chi_mesh::CellPolygon))
+    if (cell->Type() == chi_mesh::POLYGON_CELL)
     {
       auto poly_cell = (chi_mesh::CellPolygon*)cell;
       border_cell_info.push_back(1);                     //cell_type
@@ -360,7 +360,7 @@ int chi_diffusion::Solver::InitializePWLDGroups(bool verbose)
     }
 
     // %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYHEDRON
-    if (typeid(*cell) == typeid(chi_mesh::CellPolyhedron))
+    if (cell->Type() == chi_mesh::POLYHEDRON_CELL)
     {
       auto polyh_cell = (chi_mesh::CellPolyhedron*)cell;
       border_cell_info.push_back(2);                     //cell_type

--- a/Modules/DiffusionSolver/Solver/initpwld_grps.cc
+++ b/Modules/DiffusionSolver/Solver/initpwld_grps.cc
@@ -126,7 +126,7 @@ int chi_diffusion::Solver::InitializePWLDGroups(bool verbose)
     auto cell = grid->cells[cell_glob_index];
 
     // %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% SLAB
-    if (cell->Type() == chi_mesh::CellTypes::SLAB_CELL)
+    if (cell->Type() == chi_mesh::CellType::SLAB)
     {
       auto slab_cell = (chi_mesh::CellSlab*)cell;
 
@@ -168,7 +168,7 @@ int chi_diffusion::Solver::InitializePWLDGroups(bool verbose)
     }
 
     // %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYGON
-    if (cell->Type() == chi_mesh::CellTypes::POLYGON_CELL)
+    if (cell->Type() == chi_mesh::CellType::POLYGON)
     {
       auto poly_cell = (chi_mesh::CellPolygon*)cell;
 
@@ -221,7 +221,7 @@ int chi_diffusion::Solver::InitializePWLDGroups(bool verbose)
     }//polygon
 
     // %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYHEDRON
-    if (cell->Type() == chi_mesh::CellTypes::POLYHEDRON_CELL)
+    if (cell->Type() == chi_mesh::CellType::POLYHEDRON)
     {
       auto polyh_cell = (chi_mesh::CellPolyhedron*)cell;
 
@@ -321,7 +321,7 @@ int chi_diffusion::Solver::InitializePWLDGroups(bool verbose)
     border_cell_info.push_back(ip_view->cell_dof_start); //cell_dof_start
 
     // %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% SLAB
-    if (cell->Type() == chi_mesh::CellTypes::SLAB_CELL)
+    if (cell->Type() == chi_mesh::CellType::SLAB)
     {
       auto slab_cell = (chi_mesh::CellSlab*)cell;
       border_cell_info.push_back(0);                     //cell_type
@@ -340,7 +340,7 @@ int chi_diffusion::Solver::InitializePWLDGroups(bool verbose)
     }
 
     // %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYGON
-    if (cell->Type() == chi_mesh::CellTypes::POLYGON_CELL)
+    if (cell->Type() == chi_mesh::CellType::POLYGON)
     {
       auto poly_cell = (chi_mesh::CellPolygon*)cell;
       border_cell_info.push_back(1);                     //cell_type
@@ -360,7 +360,7 @@ int chi_diffusion::Solver::InitializePWLDGroups(bool verbose)
     }
 
     // %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYHEDRON
-    if (cell->Type() == chi_mesh::CellTypes::POLYHEDRON_CELL)
+    if (cell->Type() == chi_mesh::CellType::POLYHEDRON)
     {
       auto polyh_cell = (chi_mesh::CellPolyhedron*)cell;
       border_cell_info.push_back(2);                     //cell_type

--- a/Modules/LinearBoltzmanSolver/IterativeOperations/lbs_compute_pwchange.cc
+++ b/Modules/LinearBoltzmanSolver/IterativeOperations/lbs_compute_pwchange.cc
@@ -21,7 +21,7 @@ double LinearBoltzmanSolver::ComputePiecewiseChange(LBSGroupset* groupset)
     auto cell        = grid->cells[cell_g_index];
 
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% SLAB
-    if (typeid(*cell) == typeid(chi_mesh::CellSlab))
+    if (cell->Type() == chi_mesh::SLAB_CELL)
     {
       chi_mesh::CellSlab* slab_cell =
         (chi_mesh::CellSlab*)cell;
@@ -57,7 +57,7 @@ double LinearBoltzmanSolver::ComputePiecewiseChange(LBSGroupset* groupset)
     }//if slab
 
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYHEDRON
-    if (typeid(*cell) == typeid(chi_mesh::CellPolygon))
+    if (cell->Type() == chi_mesh::POLYGON_CELL)
     {
       chi_mesh::CellPolygon* poly_cell =
         (chi_mesh::CellPolygon*)cell;
@@ -93,7 +93,7 @@ double LinearBoltzmanSolver::ComputePiecewiseChange(LBSGroupset* groupset)
     }//if polyhedron
 
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYHEDRON
-    if (typeid(*cell) == typeid(chi_mesh::CellPolyhedron))
+    if (cell->Type() == chi_mesh::POLYHEDRON_CELL)
     {
       chi_mesh::CellPolyhedron* polyh_cell =
         (chi_mesh::CellPolyhedron*)cell;

--- a/Modules/LinearBoltzmanSolver/IterativeOperations/lbs_compute_pwchange.cc
+++ b/Modules/LinearBoltzmanSolver/IterativeOperations/lbs_compute_pwchange.cc
@@ -21,7 +21,7 @@ double LinearBoltzmanSolver::ComputePiecewiseChange(LBSGroupset* groupset)
     auto cell        = grid->cells[cell_g_index];
 
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% SLAB
-    if (cell->Type() == chi_mesh::SLAB_CELL)
+    if (cell->Type() == chi_mesh::CellTypes::SLAB_CELL)
     {
       chi_mesh::CellSlab* slab_cell =
         (chi_mesh::CellSlab*)cell;
@@ -57,7 +57,7 @@ double LinearBoltzmanSolver::ComputePiecewiseChange(LBSGroupset* groupset)
     }//if slab
 
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYHEDRON
-    if (cell->Type() == chi_mesh::POLYGON_CELL)
+    if (cell->Type() == chi_mesh::CellTypes::POLYGON_CELL)
     {
       chi_mesh::CellPolygon* poly_cell =
         (chi_mesh::CellPolygon*)cell;
@@ -93,7 +93,7 @@ double LinearBoltzmanSolver::ComputePiecewiseChange(LBSGroupset* groupset)
     }//if polyhedron
 
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYHEDRON
-    if (cell->Type() == chi_mesh::POLYHEDRON_CELL)
+    if (cell->Type() == chi_mesh::CellTypes::POLYHEDRON_CELL)
     {
       chi_mesh::CellPolyhedron* polyh_cell =
         (chi_mesh::CellPolyhedron*)cell;

--- a/Modules/LinearBoltzmanSolver/IterativeOperations/lbs_compute_pwchange.cc
+++ b/Modules/LinearBoltzmanSolver/IterativeOperations/lbs_compute_pwchange.cc
@@ -21,7 +21,7 @@ double LinearBoltzmanSolver::ComputePiecewiseChange(LBSGroupset* groupset)
     auto cell        = grid->cells[cell_g_index];
 
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% SLAB
-    if (cell->Type() == chi_mesh::CellTypes::SLAB_CELL)
+    if (cell->Type() == chi_mesh::CellType::SLAB)
     {
       chi_mesh::CellSlab* slab_cell =
         (chi_mesh::CellSlab*)cell;
@@ -57,7 +57,7 @@ double LinearBoltzmanSolver::ComputePiecewiseChange(LBSGroupset* groupset)
     }//if slab
 
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYHEDRON
-    if (cell->Type() == chi_mesh::CellTypes::POLYGON_CELL)
+    if (cell->Type() == chi_mesh::CellType::POLYGON)
     {
       chi_mesh::CellPolygon* poly_cell =
         (chi_mesh::CellPolygon*)cell;
@@ -93,7 +93,7 @@ double LinearBoltzmanSolver::ComputePiecewiseChange(LBSGroupset* groupset)
     }//if polyhedron
 
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYHEDRON
-    if (cell->Type() == chi_mesh::CellTypes::POLYHEDRON_CELL)
+    if (cell->Type() == chi_mesh::CellType::POLYHEDRON)
     {
       chi_mesh::CellPolyhedron* polyh_cell =
         (chi_mesh::CellPolyhedron*)cell;

--- a/Modules/LinearBoltzmanSolver/lbs_initcomms.cc
+++ b/Modules/LinearBoltzmanSolver/lbs_initcomms.cc
@@ -25,7 +25,7 @@ void LinearBoltzmanSolver::InitializeCommunicators()
     auto cell           = grid->cells[cell_glob_index];
 
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% SLAB
-    if (cell->Type() == chi_mesh::SLAB_CELL)
+    if (cell->Type() == chi_mesh::CellTypes::SLAB_CELL)
     {
       chi_mesh::CellSlab* slab_cell =
         (chi_mesh::CellSlab*)cell;
@@ -47,7 +47,7 @@ void LinearBoltzmanSolver::InitializeCommunicators()
       }//for f
     } //if slab
       //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYGON
-    else if (cell->Type() == chi_mesh::POLYGON_CELL)
+    else if (cell->Type() == chi_mesh::CellTypes::POLYGON_CELL)
     {
       chi_mesh::CellPolygon* poly_cell =
         (chi_mesh::CellPolygon*)cell;
@@ -69,7 +69,7 @@ void LinearBoltzmanSolver::InitializeCommunicators()
     } //if polyhedron
 
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYHEDRON
-    else if (cell->Type() == chi_mesh::POLYHEDRON_CELL)
+    else if (cell->Type() == chi_mesh::CellTypes::POLYHEDRON_CELL)
     {
       chi_mesh::CellPolyhedron* polyh_cell =
         (chi_mesh::CellPolyhedron*)cell;

--- a/Modules/LinearBoltzmanSolver/lbs_initcomms.cc
+++ b/Modules/LinearBoltzmanSolver/lbs_initcomms.cc
@@ -25,7 +25,7 @@ void LinearBoltzmanSolver::InitializeCommunicators()
     auto cell           = grid->cells[cell_glob_index];
 
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% SLAB
-    if (typeid(*cell) == typeid(chi_mesh::CellSlab))
+    if (cell->Type() == chi_mesh::SLAB_CELL)
     {
       chi_mesh::CellSlab* slab_cell =
         (chi_mesh::CellSlab*)cell;
@@ -47,7 +47,7 @@ void LinearBoltzmanSolver::InitializeCommunicators()
       }//for f
     } //if slab
       //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYGON
-    else if (typeid(*cell) == typeid(chi_mesh::CellPolygon))
+    else if (cell->Type() == chi_mesh::POLYGON_CELL)
     {
       chi_mesh::CellPolygon* poly_cell =
         (chi_mesh::CellPolygon*)cell;
@@ -69,7 +69,7 @@ void LinearBoltzmanSolver::InitializeCommunicators()
     } //if polyhedron
 
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYHEDRON
-    else if (typeid(*cell) == typeid(chi_mesh::CellPolyhedron))
+    else if (cell->Type() == chi_mesh::POLYHEDRON_CELL)
     {
       chi_mesh::CellPolyhedron* polyh_cell =
         (chi_mesh::CellPolyhedron*)cell;

--- a/Modules/LinearBoltzmanSolver/lbs_initcomms.cc
+++ b/Modules/LinearBoltzmanSolver/lbs_initcomms.cc
@@ -25,7 +25,7 @@ void LinearBoltzmanSolver::InitializeCommunicators()
     auto cell           = grid->cells[cell_glob_index];
 
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% SLAB
-    if (cell->Type() == chi_mesh::CellTypes::SLAB_CELL)
+    if (cell->Type() == chi_mesh::CellType::SLAB)
     {
       chi_mesh::CellSlab* slab_cell =
         (chi_mesh::CellSlab*)cell;
@@ -47,7 +47,7 @@ void LinearBoltzmanSolver::InitializeCommunicators()
       }//for f
     } //if slab
       //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYGON
-    else if (cell->Type() == chi_mesh::CellTypes::POLYGON_CELL)
+    else if (cell->Type() == chi_mesh::CellType::POLYGON)
     {
       chi_mesh::CellPolygon* poly_cell =
         (chi_mesh::CellPolygon*)cell;
@@ -69,7 +69,7 @@ void LinearBoltzmanSolver::InitializeCommunicators()
     } //if polyhedron
 
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYHEDRON
-    else if (cell->Type() == chi_mesh::CellTypes::POLYHEDRON_CELL)
+    else if (cell->Type() == chi_mesh::CellType::POLYHEDRON)
     {
       chi_mesh::CellPolyhedron* polyh_cell =
         (chi_mesh::CellPolyhedron*)cell;

--- a/Modules/LinearBoltzmanSolver/lbs_initparrays.cc
+++ b/Modules/LinearBoltzmanSolver/lbs_initparrays.cc
@@ -121,7 +121,7 @@ int LinearBoltzmanSolver::InitializeParrays()
     auto cell = grid->cells[cell_g_index];
 
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% SLAB
-    if (cell->Type() == chi_mesh::SLAB_CELL)
+    if (cell->Type() == chi_mesh::CellTypes::SLAB_CELL)
     {
       chi_mesh::CellSlab* slab_cell =
         (chi_mesh::CellSlab*)cell;
@@ -179,7 +179,7 @@ int LinearBoltzmanSolver::InitializeParrays()
     }//slab
 
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYGON
-    if (cell->Type() == chi_mesh::POLYGON_CELL)
+    if (cell->Type() == chi_mesh::CellTypes::POLYGON_CELL)
     {
       chi_mesh::CellPolygon* poly_cell =
         (chi_mesh::CellPolygon*)cell;
@@ -237,7 +237,7 @@ int LinearBoltzmanSolver::InitializeParrays()
     }//polygon
 
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYHEDRON
-    if (cell->Type() == chi_mesh::POLYHEDRON_CELL)
+    if (cell->Type() == chi_mesh::CellTypes::POLYHEDRON_CELL)
     {
       chi_mesh::CellPolyhedron* polyh_cell =
         (chi_mesh::CellPolyhedron*)cell;

--- a/Modules/LinearBoltzmanSolver/lbs_initparrays.cc
+++ b/Modules/LinearBoltzmanSolver/lbs_initparrays.cc
@@ -121,7 +121,7 @@ int LinearBoltzmanSolver::InitializeParrays()
     auto cell = grid->cells[cell_g_index];
 
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% SLAB
-    if (cell->Type() == chi_mesh::CellTypes::SLAB_CELL)
+    if (cell->Type() == chi_mesh::CellType::SLAB)
     {
       chi_mesh::CellSlab* slab_cell =
         (chi_mesh::CellSlab*)cell;
@@ -179,7 +179,7 @@ int LinearBoltzmanSolver::InitializeParrays()
     }//slab
 
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYGON
-    if (cell->Type() == chi_mesh::CellTypes::POLYGON_CELL)
+    if (cell->Type() == chi_mesh::CellType::POLYGON)
     {
       chi_mesh::CellPolygon* poly_cell =
         (chi_mesh::CellPolygon*)cell;
@@ -237,7 +237,7 @@ int LinearBoltzmanSolver::InitializeParrays()
     }//polygon
 
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYHEDRON
-    if (cell->Type() == chi_mesh::CellTypes::POLYHEDRON_CELL)
+    if (cell->Type() == chi_mesh::CellType::POLYHEDRON)
     {
       chi_mesh::CellPolyhedron* polyh_cell =
         (chi_mesh::CellPolyhedron*)cell;

--- a/Modules/LinearBoltzmanSolver/lbs_initparrays.cc
+++ b/Modules/LinearBoltzmanSolver/lbs_initparrays.cc
@@ -121,7 +121,7 @@ int LinearBoltzmanSolver::InitializeParrays()
     auto cell = grid->cells[cell_g_index];
 
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% SLAB
-    if (typeid(*cell) == typeid(chi_mesh::CellSlab))
+    if (cell->Type() == chi_mesh::SLAB_CELL)
     {
       chi_mesh::CellSlab* slab_cell =
         (chi_mesh::CellSlab*)cell;
@@ -179,7 +179,7 @@ int LinearBoltzmanSolver::InitializeParrays()
     }//slab
 
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYGON
-    if (typeid(*cell) == typeid(chi_mesh::CellPolygon))
+    if (cell->Type() == chi_mesh::POLYGON_CELL)
     {
       chi_mesh::CellPolygon* poly_cell =
         (chi_mesh::CellPolygon*)cell;
@@ -237,7 +237,7 @@ int LinearBoltzmanSolver::InitializeParrays()
     }//polygon
 
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYHEDRON
-    if (typeid(*cell) == typeid(chi_mesh::CellPolyhedron))
+    if (cell->Type() == chi_mesh::POLYHEDRON_CELL)
     {
       chi_mesh::CellPolyhedron* polyh_cell =
         (chi_mesh::CellPolyhedron*)cell;

--- a/Modules/LinearBoltzmanSolver/lbs_tgdsa.cc
+++ b/Modules/LinearBoltzmanSolver/lbs_tgdsa.cc
@@ -117,7 +117,7 @@ void LinearBoltzmanSolver::AssembleTGDSADeltaPhiVector(LBSGroupset *groupset,
     auto cell        = grid->cells[cell_g_index];
 
     //&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&& SLAB
-    if (cell->Type() == chi_mesh::SLAB_CELL)
+    if (cell->Type() == chi_mesh::CellTypes::SLAB_CELL)
     {
       chi_mesh::CellSlab* slab_cell =
         (chi_mesh::CellSlab*)cell;
@@ -157,7 +157,7 @@ void LinearBoltzmanSolver::AssembleTGDSADeltaPhiVector(LBSGroupset *groupset,
       }//for dof
     }//slab
     //&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&& POLYGON
-    else if (cell->Type() == chi_mesh::POLYGON_CELL)
+    else if (cell->Type() == chi_mesh::CellTypes::POLYGON_CELL)
     {
       chi_mesh::CellPolygon* poly_cell =
         (chi_mesh::CellPolygon*)cell;
@@ -197,7 +197,7 @@ void LinearBoltzmanSolver::AssembleTGDSADeltaPhiVector(LBSGroupset *groupset,
       }//for dof
     }//polygon
     //&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&& POLYHEDRON
-    else if (cell->Type() == chi_mesh::POLYHEDRON_CELL)
+    else if (cell->Type() == chi_mesh::CellTypes::POLYHEDRON_CELL)
     {
       chi_mesh::CellPolyhedron* polyh_cell =
         (chi_mesh::CellPolyhedron*)cell;
@@ -259,7 +259,7 @@ void LinearBoltzmanSolver::DisAssembleTGDSADeltaPhiVector(LBSGroupset *groupset,
     auto cell        = grid->cells[cell_g_index];
 
     //&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&& SLAB
-    if (cell->Type() == chi_mesh::SLAB_CELL)
+    if (cell->Type() == chi_mesh::CellTypes::SLAB_CELL)
     {
       chi_mesh::CellSlab* slab_cell =
         (chi_mesh::CellSlab*)cell;
@@ -284,7 +284,7 @@ void LinearBoltzmanSolver::DisAssembleTGDSADeltaPhiVector(LBSGroupset *groupset,
       }//for dof
     }//slab
       //&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&& POLYGON
-    else if (cell->Type() == chi_mesh::POLYGON_CELL)
+    else if (cell->Type() == chi_mesh::CellTypes::POLYGON_CELL)
     {
       chi_mesh::CellPolygon* poly_cell =
         (chi_mesh::CellPolygon*)cell;
@@ -309,7 +309,7 @@ void LinearBoltzmanSolver::DisAssembleTGDSADeltaPhiVector(LBSGroupset *groupset,
       }//for dof
     }//polygon
     //&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&& POLYHEDRON
-    else if (cell->Type() == chi_mesh::POLYHEDRON_CELL)
+    else if (cell->Type() == chi_mesh::CellTypes::POLYHEDRON_CELL)
     {
       chi_mesh::CellPolyhedron* polyh_cell =
         (chi_mesh::CellPolyhedron*)cell;

--- a/Modules/LinearBoltzmanSolver/lbs_tgdsa.cc
+++ b/Modules/LinearBoltzmanSolver/lbs_tgdsa.cc
@@ -117,7 +117,7 @@ void LinearBoltzmanSolver::AssembleTGDSADeltaPhiVector(LBSGroupset *groupset,
     auto cell        = grid->cells[cell_g_index];
 
     //&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&& SLAB
-    if (cell->Type() == chi_mesh::CellTypes::SLAB_CELL)
+    if (cell->Type() == chi_mesh::CellType::SLAB)
     {
       chi_mesh::CellSlab* slab_cell =
         (chi_mesh::CellSlab*)cell;
@@ -157,7 +157,7 @@ void LinearBoltzmanSolver::AssembleTGDSADeltaPhiVector(LBSGroupset *groupset,
       }//for dof
     }//slab
     //&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&& POLYGON
-    else if (cell->Type() == chi_mesh::CellTypes::POLYGON_CELL)
+    else if (cell->Type() == chi_mesh::CellType::POLYGON)
     {
       chi_mesh::CellPolygon* poly_cell =
         (chi_mesh::CellPolygon*)cell;
@@ -197,7 +197,7 @@ void LinearBoltzmanSolver::AssembleTGDSADeltaPhiVector(LBSGroupset *groupset,
       }//for dof
     }//polygon
     //&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&& POLYHEDRON
-    else if (cell->Type() == chi_mesh::CellTypes::POLYHEDRON_CELL)
+    else if (cell->Type() == chi_mesh::CellType::POLYHEDRON)
     {
       chi_mesh::CellPolyhedron* polyh_cell =
         (chi_mesh::CellPolyhedron*)cell;
@@ -259,7 +259,7 @@ void LinearBoltzmanSolver::DisAssembleTGDSADeltaPhiVector(LBSGroupset *groupset,
     auto cell        = grid->cells[cell_g_index];
 
     //&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&& SLAB
-    if (cell->Type() == chi_mesh::CellTypes::SLAB_CELL)
+    if (cell->Type() == chi_mesh::CellType::SLAB)
     {
       chi_mesh::CellSlab* slab_cell =
         (chi_mesh::CellSlab*)cell;
@@ -284,7 +284,7 @@ void LinearBoltzmanSolver::DisAssembleTGDSADeltaPhiVector(LBSGroupset *groupset,
       }//for dof
     }//slab
       //&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&& POLYGON
-    else if (cell->Type() == chi_mesh::CellTypes::POLYGON_CELL)
+    else if (cell->Type() == chi_mesh::CellType::POLYGON)
     {
       chi_mesh::CellPolygon* poly_cell =
         (chi_mesh::CellPolygon*)cell;
@@ -309,7 +309,7 @@ void LinearBoltzmanSolver::DisAssembleTGDSADeltaPhiVector(LBSGroupset *groupset,
       }//for dof
     }//polygon
     //&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&& POLYHEDRON
-    else if (cell->Type() == chi_mesh::CellTypes::POLYHEDRON_CELL)
+    else if (cell->Type() == chi_mesh::CellType::POLYHEDRON)
     {
       chi_mesh::CellPolyhedron* polyh_cell =
         (chi_mesh::CellPolyhedron*)cell;

--- a/Modules/LinearBoltzmanSolver/lbs_tgdsa.cc
+++ b/Modules/LinearBoltzmanSolver/lbs_tgdsa.cc
@@ -117,7 +117,7 @@ void LinearBoltzmanSolver::AssembleTGDSADeltaPhiVector(LBSGroupset *groupset,
     auto cell        = grid->cells[cell_g_index];
 
     //&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&& SLAB
-    if (typeid(*cell) == typeid(chi_mesh::CellSlab))
+    if (cell->Type() == chi_mesh::SLAB_CELL)
     {
       chi_mesh::CellSlab* slab_cell =
         (chi_mesh::CellSlab*)cell;
@@ -157,7 +157,7 @@ void LinearBoltzmanSolver::AssembleTGDSADeltaPhiVector(LBSGroupset *groupset,
       }//for dof
     }//slab
     //&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&& POLYGON
-    else if (typeid(*cell) == typeid(chi_mesh::CellPolygon))
+    else if (cell->Type() == chi_mesh::POLYGON_CELL)
     {
       chi_mesh::CellPolygon* poly_cell =
         (chi_mesh::CellPolygon*)cell;
@@ -197,7 +197,7 @@ void LinearBoltzmanSolver::AssembleTGDSADeltaPhiVector(LBSGroupset *groupset,
       }//for dof
     }//polygon
     //&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&& POLYHEDRON
-    else if (typeid(*cell) == typeid(chi_mesh::CellPolyhedron))
+    else if (cell->Type() == chi_mesh::POLYHEDRON_CELL)
     {
       chi_mesh::CellPolyhedron* polyh_cell =
         (chi_mesh::CellPolyhedron*)cell;
@@ -259,7 +259,7 @@ void LinearBoltzmanSolver::DisAssembleTGDSADeltaPhiVector(LBSGroupset *groupset,
     auto cell        = grid->cells[cell_g_index];
 
     //&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&& SLAB
-    if (typeid(*cell) == typeid(chi_mesh::CellSlab))
+    if (cell->Type() == chi_mesh::SLAB_CELL)
     {
       chi_mesh::CellSlab* slab_cell =
         (chi_mesh::CellSlab*)cell;
@@ -284,7 +284,7 @@ void LinearBoltzmanSolver::DisAssembleTGDSADeltaPhiVector(LBSGroupset *groupset,
       }//for dof
     }//slab
       //&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&& POLYGON
-    else if (typeid(*cell) == typeid(chi_mesh::CellPolygon))
+    else if (cell->Type() == chi_mesh::POLYGON_CELL)
     {
       chi_mesh::CellPolygon* poly_cell =
         (chi_mesh::CellPolygon*)cell;
@@ -309,7 +309,7 @@ void LinearBoltzmanSolver::DisAssembleTGDSADeltaPhiVector(LBSGroupset *groupset,
       }//for dof
     }//polygon
     //&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&& POLYHEDRON
-    else if (typeid(*cell) == typeid(chi_mesh::CellPolyhedron))
+    else if (cell->Type() == chi_mesh::POLYHEDRON_CELL)
     {
       chi_mesh::CellPolyhedron* polyh_cell =
         (chi_mesh::CellPolyhedron*)cell;

--- a/Modules/LinearBoltzmanSolver/lbs_vectorassembly.cc
+++ b/Modules/LinearBoltzmanSolver/lbs_vectorassembly.cc
@@ -24,7 +24,7 @@ AssembleVector(LBSGroupset *groupset, Vec x, double *y)
     auto cell        = grid->cells[cell_g_index];
 
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% SLAB
-    if (cell->Type() == chi_mesh::SLAB_CELL)
+    if (cell->Type() == chi_mesh::CellTypes::SLAB_CELL)
     {
       LBSCellViewFull* transport_view =
         (LBSCellViewFull*)cell_transport_views[c];
@@ -45,7 +45,7 @@ AssembleVector(LBSGroupset *groupset, Vec x, double *y)
     }//if slab
 
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYGON
-    if (cell->Type() == chi_mesh::POLYGON_CELL)
+    if (cell->Type() == chi_mesh::CellTypes::POLYGON_CELL)
     {
       chi_mesh::CellPolygon* poly_cell =
         (chi_mesh::CellPolygon*)cell;
@@ -68,7 +68,7 @@ AssembleVector(LBSGroupset *groupset, Vec x, double *y)
     }//if polygon
 
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYHEDRON
-    if (cell->Type() == chi_mesh::POLYHEDRON_CELL)
+    if (cell->Type() == chi_mesh::CellTypes::POLYHEDRON_CELL)
     {
       chi_mesh::CellPolyhedron* polyh_cell =
         (chi_mesh::CellPolyhedron*)cell;
@@ -114,7 +114,7 @@ DisAssembleVector(LBSGroupset *groupset, Vec x_src, double *y)
     auto cell        = grid->cells[cell_g_index];
 
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% SLAB
-    if (cell->Type() == chi_mesh::SLAB_CELL)
+    if (cell->Type() == chi_mesh::CellTypes::SLAB_CELL)
     {
       LBSCellViewFull* transport_view =
         (LBSCellViewFull*)cell_transport_views[c];
@@ -135,7 +135,7 @@ DisAssembleVector(LBSGroupset *groupset, Vec x_src, double *y)
     }//if slab
 
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYGON
-    if (cell->Type() == chi_mesh::POLYGON_CELL)
+    if (cell->Type() == chi_mesh::CellTypes::POLYGON_CELL)
     {
       chi_mesh::CellPolygon* poly_cell =
         (chi_mesh::CellPolygon*)cell;
@@ -158,7 +158,7 @@ DisAssembleVector(LBSGroupset *groupset, Vec x_src, double *y)
     }//if polygon
 
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYHEDRON
-    if (cell->Type() == chi_mesh::POLYHEDRON_CELL)
+    if (cell->Type() == chi_mesh::CellTypes::POLYHEDRON_CELL)
     {
       chi_mesh::CellPolyhedron* polyh_cell =
         (chi_mesh::CellPolyhedron*)cell;
@@ -204,7 +204,7 @@ DisAssembleVectorLocalToLocal(LBSGroupset *groupset, double* x_src, double *y)
     auto cell        = grid->cells[cell_g_index];
 
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% SLAB
-    if (cell->Type() == chi_mesh::SLAB_CELL)
+    if (cell->Type() == chi_mesh::CellTypes::SLAB_CELL)
     {
       LBSCellViewFull* transport_view =
         (LBSCellViewFull*)cell_transport_views[c];
@@ -226,7 +226,7 @@ DisAssembleVectorLocalToLocal(LBSGroupset *groupset, double* x_src, double *y)
     }//if slab
 
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYGON
-    if (cell->Type() == chi_mesh::POLYGON_CELL)
+    if (cell->Type() == chi_mesh::CellTypes::POLYGON_CELL)
     {
       chi_mesh::CellPolygon* poly_cell =
         (chi_mesh::CellPolygon*)cell;
@@ -250,7 +250,7 @@ DisAssembleVectorLocalToLocal(LBSGroupset *groupset, double* x_src, double *y)
     }//if polygon
 
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYHEDRON
-    if (cell->Type() == chi_mesh::POLYHEDRON_CELL)
+    if (cell->Type() == chi_mesh::CellTypes::POLYHEDRON_CELL)
     {
       chi_mesh::CellPolyhedron* polyh_cell =
         (chi_mesh::CellPolyhedron*)cell;

--- a/Modules/LinearBoltzmanSolver/lbs_vectorassembly.cc
+++ b/Modules/LinearBoltzmanSolver/lbs_vectorassembly.cc
@@ -24,7 +24,7 @@ AssembleVector(LBSGroupset *groupset, Vec x, double *y)
     auto cell        = grid->cells[cell_g_index];
 
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% SLAB
-    if (typeid(*cell) == typeid(chi_mesh::CellSlab))
+    if (cell->Type() == chi_mesh::SLAB_CELL)
     {
       LBSCellViewFull* transport_view =
         (LBSCellViewFull*)cell_transport_views[c];
@@ -45,7 +45,7 @@ AssembleVector(LBSGroupset *groupset, Vec x, double *y)
     }//if slab
 
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYGON
-    if (typeid(*cell) == typeid(chi_mesh::CellPolygon))
+    if (cell->Type() == chi_mesh::POLYGON_CELL)
     {
       chi_mesh::CellPolygon* poly_cell =
         (chi_mesh::CellPolygon*)cell;
@@ -68,7 +68,7 @@ AssembleVector(LBSGroupset *groupset, Vec x, double *y)
     }//if polygon
 
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYHEDRON
-    if (typeid(*cell) == typeid(chi_mesh::CellPolyhedron))
+    if (cell->Type() == chi_mesh::POLYHEDRON_CELL)
     {
       chi_mesh::CellPolyhedron* polyh_cell =
         (chi_mesh::CellPolyhedron*)cell;
@@ -114,7 +114,7 @@ DisAssembleVector(LBSGroupset *groupset, Vec x_src, double *y)
     auto cell        = grid->cells[cell_g_index];
 
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% SLAB
-    if (typeid(*cell) == typeid(chi_mesh::CellSlab))
+    if (cell->Type() == chi_mesh::SLAB_CELL)
     {
       LBSCellViewFull* transport_view =
         (LBSCellViewFull*)cell_transport_views[c];
@@ -135,7 +135,7 @@ DisAssembleVector(LBSGroupset *groupset, Vec x_src, double *y)
     }//if slab
 
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYGON
-    if (typeid(*cell) == typeid(chi_mesh::CellPolygon))
+    if (cell->Type() == chi_mesh::POLYGON_CELL)
     {
       chi_mesh::CellPolygon* poly_cell =
         (chi_mesh::CellPolygon*)cell;
@@ -158,7 +158,7 @@ DisAssembleVector(LBSGroupset *groupset, Vec x_src, double *y)
     }//if polygon
 
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYHEDRON
-    if (typeid(*cell) == typeid(chi_mesh::CellPolyhedron))
+    if (cell->Type() == chi_mesh::POLYHEDRON_CELL)
     {
       chi_mesh::CellPolyhedron* polyh_cell =
         (chi_mesh::CellPolyhedron*)cell;
@@ -204,7 +204,7 @@ DisAssembleVectorLocalToLocal(LBSGroupset *groupset, double* x_src, double *y)
     auto cell        = grid->cells[cell_g_index];
 
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% SLAB
-    if (typeid(*cell) == typeid(chi_mesh::CellSlab))
+    if (cell->Type() == chi_mesh::SLAB_CELL)
     {
       LBSCellViewFull* transport_view =
         (LBSCellViewFull*)cell_transport_views[c];
@@ -226,7 +226,7 @@ DisAssembleVectorLocalToLocal(LBSGroupset *groupset, double* x_src, double *y)
     }//if slab
 
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYGON
-    if (typeid(*cell) == typeid(chi_mesh::CellPolygon))
+    if (cell->Type() == chi_mesh::POLYGON_CELL)
     {
       chi_mesh::CellPolygon* poly_cell =
         (chi_mesh::CellPolygon*)cell;
@@ -250,7 +250,7 @@ DisAssembleVectorLocalToLocal(LBSGroupset *groupset, double* x_src, double *y)
     }//if polygon
 
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYHEDRON
-    if (typeid(*cell) == typeid(chi_mesh::CellPolyhedron))
+    if (cell->Type() == chi_mesh::POLYHEDRON_CELL)
     {
       chi_mesh::CellPolyhedron* polyh_cell =
         (chi_mesh::CellPolyhedron*)cell;

--- a/Modules/LinearBoltzmanSolver/lbs_vectorassembly.cc
+++ b/Modules/LinearBoltzmanSolver/lbs_vectorassembly.cc
@@ -24,7 +24,7 @@ AssembleVector(LBSGroupset *groupset, Vec x, double *y)
     auto cell        = grid->cells[cell_g_index];
 
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% SLAB
-    if (cell->Type() == chi_mesh::CellTypes::SLAB_CELL)
+    if (cell->Type() == chi_mesh::CellType::SLAB)
     {
       LBSCellViewFull* transport_view =
         (LBSCellViewFull*)cell_transport_views[c];
@@ -45,7 +45,7 @@ AssembleVector(LBSGroupset *groupset, Vec x, double *y)
     }//if slab
 
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYGON
-    if (cell->Type() == chi_mesh::CellTypes::POLYGON_CELL)
+    if (cell->Type() == chi_mesh::CellType::POLYGON)
     {
       chi_mesh::CellPolygon* poly_cell =
         (chi_mesh::CellPolygon*)cell;
@@ -68,7 +68,7 @@ AssembleVector(LBSGroupset *groupset, Vec x, double *y)
     }//if polygon
 
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYHEDRON
-    if (cell->Type() == chi_mesh::CellTypes::POLYHEDRON_CELL)
+    if (cell->Type() == chi_mesh::CellType::POLYHEDRON)
     {
       chi_mesh::CellPolyhedron* polyh_cell =
         (chi_mesh::CellPolyhedron*)cell;
@@ -114,7 +114,7 @@ DisAssembleVector(LBSGroupset *groupset, Vec x_src, double *y)
     auto cell        = grid->cells[cell_g_index];
 
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% SLAB
-    if (cell->Type() == chi_mesh::CellTypes::SLAB_CELL)
+    if (cell->Type() == chi_mesh::CellType::SLAB)
     {
       LBSCellViewFull* transport_view =
         (LBSCellViewFull*)cell_transport_views[c];
@@ -135,7 +135,7 @@ DisAssembleVector(LBSGroupset *groupset, Vec x_src, double *y)
     }//if slab
 
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYGON
-    if (cell->Type() == chi_mesh::CellTypes::POLYGON_CELL)
+    if (cell->Type() == chi_mesh::CellType::POLYGON)
     {
       chi_mesh::CellPolygon* poly_cell =
         (chi_mesh::CellPolygon*)cell;
@@ -158,7 +158,7 @@ DisAssembleVector(LBSGroupset *groupset, Vec x_src, double *y)
     }//if polygon
 
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYHEDRON
-    if (cell->Type() == chi_mesh::CellTypes::POLYHEDRON_CELL)
+    if (cell->Type() == chi_mesh::CellType::POLYHEDRON)
     {
       chi_mesh::CellPolyhedron* polyh_cell =
         (chi_mesh::CellPolyhedron*)cell;
@@ -204,7 +204,7 @@ DisAssembleVectorLocalToLocal(LBSGroupset *groupset, double* x_src, double *y)
     auto cell        = grid->cells[cell_g_index];
 
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% SLAB
-    if (cell->Type() == chi_mesh::CellTypes::SLAB_CELL)
+    if (cell->Type() == chi_mesh::CellType::SLAB)
     {
       LBSCellViewFull* transport_view =
         (LBSCellViewFull*)cell_transport_views[c];
@@ -226,7 +226,7 @@ DisAssembleVectorLocalToLocal(LBSGroupset *groupset, double* x_src, double *y)
     }//if slab
 
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYGON
-    if (cell->Type() == chi_mesh::CellTypes::POLYGON_CELL)
+    if (cell->Type() == chi_mesh::CellType::POLYGON)
     {
       chi_mesh::CellPolygon* poly_cell =
         (chi_mesh::CellPolygon*)cell;
@@ -250,7 +250,7 @@ DisAssembleVectorLocalToLocal(LBSGroupset *groupset, double* x_src, double *y)
     }//if polygon
 
     //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% POLYHEDRON
-    if (cell->Type() == chi_mesh::CellTypes::POLYHEDRON_CELL)
+    if (cell->Type() == chi_mesh::CellType::POLYHEDRON)
     {
       chi_mesh::CellPolyhedron* polyh_cell =
         (chi_mesh::CellPolyhedron*)cell;

--- a/Modules/LinearBoltzmanSolver/lbs_wgdsa.cc
+++ b/Modules/LinearBoltzmanSolver/lbs_wgdsa.cc
@@ -117,7 +117,7 @@ void LinearBoltzmanSolver::AssembleWGDSADeltaPhiVector(LBSGroupset *groupset,
     auto cell        = grid->cells[cell_g_index];
 
     //&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&& SLAB
-    if (cell->Type() == chi_mesh::CellTypes::SLAB_CELL)
+    if (cell->Type() == chi_mesh::CellType::SLAB)
     {
       LBSCellViewFull* transport_view =
         (LBSCellViewFull*)cell_transport_views[c];
@@ -143,7 +143,7 @@ void LinearBoltzmanSolver::AssembleWGDSADeltaPhiVector(LBSGroupset *groupset,
       }//for dof
     }//slab
       //&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&& POLYGON
-    else if (cell->Type() == chi_mesh::CellTypes::POLYGON_CELL)
+    else if (cell->Type() == chi_mesh::CellType::POLYGON)
     {
       chi_mesh::CellPolygon* poly_cell =
         (chi_mesh::CellPolygon*)cell;
@@ -171,7 +171,7 @@ void LinearBoltzmanSolver::AssembleWGDSADeltaPhiVector(LBSGroupset *groupset,
       }//for dof
     }//polygon
     //&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&& POLYHEDRON
-    else if (cell->Type() == chi_mesh::CellTypes::POLYHEDRON_CELL)
+    else if (cell->Type() == chi_mesh::CellType::POLYHEDRON)
     {
       chi_mesh::CellPolyhedron* polyh_cell =
         (chi_mesh::CellPolyhedron*)cell;
@@ -228,7 +228,7 @@ void LinearBoltzmanSolver::DisAssembleWGDSADeltaPhiVector(LBSGroupset *groupset,
     auto cell        = grid->cells[cell_g_index];
 
     //&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&& SLAB
-    if (cell->Type() == chi_mesh::CellTypes::SLAB_CELL)
+    if (cell->Type() == chi_mesh::CellType::SLAB)
     {
       LBSCellViewFull* transport_view =
         (LBSCellViewFull*)cell_transport_views[c];
@@ -247,7 +247,7 @@ void LinearBoltzmanSolver::DisAssembleWGDSADeltaPhiVector(LBSGroupset *groupset,
       }//for dof
     }//slab
       //&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&& POLYGON
-    else if (cell->Type() == chi_mesh::CellTypes::POLYGON_CELL)
+    else if (cell->Type() == chi_mesh::CellType::POLYGON)
     {
       chi_mesh::CellPolygon* poly_cell =
         (chi_mesh::CellPolygon*)cell;
@@ -268,7 +268,7 @@ void LinearBoltzmanSolver::DisAssembleWGDSADeltaPhiVector(LBSGroupset *groupset,
       }//for dof
     }//polygon
     //&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&& POLYHEDRON
-    else if (cell->Type() == chi_mesh::CellTypes::POLYHEDRON_CELL)
+    else if (cell->Type() == chi_mesh::CellType::POLYHEDRON)
     {
       chi_mesh::CellPolyhedron* polyh_cell =
         (chi_mesh::CellPolyhedron*)cell;

--- a/Modules/LinearBoltzmanSolver/lbs_wgdsa.cc
+++ b/Modules/LinearBoltzmanSolver/lbs_wgdsa.cc
@@ -117,7 +117,7 @@ void LinearBoltzmanSolver::AssembleWGDSADeltaPhiVector(LBSGroupset *groupset,
     auto cell        = grid->cells[cell_g_index];
 
     //&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&& SLAB
-    if (typeid(*cell) == typeid(chi_mesh::CellSlab))
+    if (cell->Type() == chi_mesh::SLAB_CELL)
     {
       LBSCellViewFull* transport_view =
         (LBSCellViewFull*)cell_transport_views[c];
@@ -143,7 +143,7 @@ void LinearBoltzmanSolver::AssembleWGDSADeltaPhiVector(LBSGroupset *groupset,
       }//for dof
     }//slab
       //&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&& POLYGON
-    else if (typeid(*cell) == typeid(chi_mesh::CellPolygon))
+    else if (cell->Type() == chi_mesh::POLYGON_CELL)
     {
       chi_mesh::CellPolygon* poly_cell =
         (chi_mesh::CellPolygon*)cell;
@@ -171,7 +171,7 @@ void LinearBoltzmanSolver::AssembleWGDSADeltaPhiVector(LBSGroupset *groupset,
       }//for dof
     }//polygon
     //&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&& POLYHEDRON
-    else if (typeid(*cell) == typeid(chi_mesh::CellPolyhedron))
+    else if (cell->Type() == chi_mesh::POLYHEDRON_CELL)
     {
       chi_mesh::CellPolyhedron* polyh_cell =
         (chi_mesh::CellPolyhedron*)cell;
@@ -228,7 +228,7 @@ void LinearBoltzmanSolver::DisAssembleWGDSADeltaPhiVector(LBSGroupset *groupset,
     auto cell        = grid->cells[cell_g_index];
 
     //&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&& SLAB
-    if (typeid(*cell) == typeid(chi_mesh::CellSlab))
+    if (cell->Type() == chi_mesh::SLAB_CELL)
     {
       LBSCellViewFull* transport_view =
         (LBSCellViewFull*)cell_transport_views[c];
@@ -247,7 +247,7 @@ void LinearBoltzmanSolver::DisAssembleWGDSADeltaPhiVector(LBSGroupset *groupset,
       }//for dof
     }//slab
       //&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&& POLYGON
-    else if (typeid(*cell) == typeid(chi_mesh::CellPolygon))
+    else if (cell->Type() == chi_mesh::POLYGON_CELL)
     {
       chi_mesh::CellPolygon* poly_cell =
         (chi_mesh::CellPolygon*)cell;
@@ -268,7 +268,7 @@ void LinearBoltzmanSolver::DisAssembleWGDSADeltaPhiVector(LBSGroupset *groupset,
       }//for dof
     }//polygon
     //&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&& POLYHEDRON
-    else if (typeid(*cell) == typeid(chi_mesh::CellPolyhedron))
+    else if (cell->Type() == chi_mesh::POLYHEDRON_CELL)
     {
       chi_mesh::CellPolyhedron* polyh_cell =
         (chi_mesh::CellPolyhedron*)cell;

--- a/Modules/LinearBoltzmanSolver/lbs_wgdsa.cc
+++ b/Modules/LinearBoltzmanSolver/lbs_wgdsa.cc
@@ -117,7 +117,7 @@ void LinearBoltzmanSolver::AssembleWGDSADeltaPhiVector(LBSGroupset *groupset,
     auto cell        = grid->cells[cell_g_index];
 
     //&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&& SLAB
-    if (cell->Type() == chi_mesh::SLAB_CELL)
+    if (cell->Type() == chi_mesh::CellTypes::SLAB_CELL)
     {
       LBSCellViewFull* transport_view =
         (LBSCellViewFull*)cell_transport_views[c];
@@ -143,7 +143,7 @@ void LinearBoltzmanSolver::AssembleWGDSADeltaPhiVector(LBSGroupset *groupset,
       }//for dof
     }//slab
       //&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&& POLYGON
-    else if (cell->Type() == chi_mesh::POLYGON_CELL)
+    else if (cell->Type() == chi_mesh::CellTypes::POLYGON_CELL)
     {
       chi_mesh::CellPolygon* poly_cell =
         (chi_mesh::CellPolygon*)cell;
@@ -171,7 +171,7 @@ void LinearBoltzmanSolver::AssembleWGDSADeltaPhiVector(LBSGroupset *groupset,
       }//for dof
     }//polygon
     //&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&& POLYHEDRON
-    else if (cell->Type() == chi_mesh::POLYHEDRON_CELL)
+    else if (cell->Type() == chi_mesh::CellTypes::POLYHEDRON_CELL)
     {
       chi_mesh::CellPolyhedron* polyh_cell =
         (chi_mesh::CellPolyhedron*)cell;
@@ -228,7 +228,7 @@ void LinearBoltzmanSolver::DisAssembleWGDSADeltaPhiVector(LBSGroupset *groupset,
     auto cell        = grid->cells[cell_g_index];
 
     //&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&& SLAB
-    if (cell->Type() == chi_mesh::SLAB_CELL)
+    if (cell->Type() == chi_mesh::CellTypes::SLAB_CELL)
     {
       LBSCellViewFull* transport_view =
         (LBSCellViewFull*)cell_transport_views[c];
@@ -247,7 +247,7 @@ void LinearBoltzmanSolver::DisAssembleWGDSADeltaPhiVector(LBSGroupset *groupset,
       }//for dof
     }//slab
       //&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&& POLYGON
-    else if (cell->Type() == chi_mesh::POLYGON_CELL)
+    else if (cell->Type() == chi_mesh::CellTypes::POLYGON_CELL)
     {
       chi_mesh::CellPolygon* poly_cell =
         (chi_mesh::CellPolygon*)cell;
@@ -268,7 +268,7 @@ void LinearBoltzmanSolver::DisAssembleWGDSADeltaPhiVector(LBSGroupset *groupset,
       }//for dof
     }//polygon
     //&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&& POLYHEDRON
-    else if (cell->Type() == chi_mesh::POLYHEDRON_CELL)
+    else if (cell->Type() == chi_mesh::CellTypes::POLYHEDRON_CELL)
     {
       chi_mesh::CellPolyhedron* polyh_cell =
         (chi_mesh::CellPolyhedron*)cell;

--- a/Modules/LinearBoltzmanSolver/lua/lbs_setproperty.cc
+++ b/Modules/LinearBoltzmanSolver/lua/lbs_setproperty.cc
@@ -584,7 +584,7 @@ int chiLBSSetProperty(lua_State *L)
     int limit = lua_tonumber(L,3);
     if (limit<=64000)
     {
-      solver->options.sweep_eager_limit;
+      solver->options.sweep_eager_limit = limit;
     }
   }
   else

--- a/Modules/MonteCarlon/Solver/solver_montecarlon_05_tallies.cc
+++ b/Modules/MonteCarlon/Solver/solver_montecarlon_05_tallies.cc
@@ -51,13 +51,13 @@ void chi_montecarlon::Solver::ComputeTallySqr()
     auto cell = grid->cells[cell_glob_index];
 
     double V = 1.0;
-    if (cell->Type() == chi_mesh::SLAB_CELL)
+    if (cell->Type() == chi_mesh::CellTypes::SLAB_CELL)
     {
       auto cell_fv_view =
         (SlabFVView*)fv_discretization->MapFeView(cell->cell_global_id);
       V = cell_fv_view->volume;
     }
-    else if (cell->Type() == chi_mesh::POLYGON_CELL)
+    else if (cell->Type() == chi_mesh::CellTypes::POLYGON_CELL)
     {
       auto cell_fv_view =
         (PolygonFVView*)fv_discretization->MapFeView(cell->cell_global_id);

--- a/Modules/MonteCarlon/Solver/solver_montecarlon_05_tallies.cc
+++ b/Modules/MonteCarlon/Solver/solver_montecarlon_05_tallies.cc
@@ -51,13 +51,13 @@ void chi_montecarlon::Solver::ComputeTallySqr()
     auto cell = grid->cells[cell_glob_index];
 
     double V = 1.0;
-    if (typeid(*cell) == typeid(chi_mesh::CellSlab))
+    if (cell->Type() == chi_mesh::SLAB_CELL)
     {
       auto cell_fv_view =
         (SlabFVView*)fv_discretization->MapFeView(cell->cell_global_id);
       V = cell_fv_view->volume;
     }
-    else if (typeid(*cell) == typeid(chi_mesh::CellPolygon))
+    else if (cell->Type() == chi_mesh::POLYGON_CELL)
     {
       auto cell_fv_view =
         (PolygonFVView*)fv_discretization->MapFeView(cell->cell_global_id);

--- a/Modules/MonteCarlon/Solver/solver_montecarlon_05_tallies.cc
+++ b/Modules/MonteCarlon/Solver/solver_montecarlon_05_tallies.cc
@@ -51,13 +51,13 @@ void chi_montecarlon::Solver::ComputeTallySqr()
     auto cell = grid->cells[cell_glob_index];
 
     double V = 1.0;
-    if (cell->Type() == chi_mesh::CellTypes::SLAB_CELL)
+    if (cell->Type() == chi_mesh::CellType::SLAB)
     {
       auto cell_fv_view =
         (SlabFVView*)fv_discretization->MapFeView(cell->cell_global_id);
       V = cell_fv_view->volume;
     }
-    else if (cell->Type() == chi_mesh::CellTypes::POLYGON_CELL)
+    else if (cell->Type() == chi_mesh::CellType::POLYGON)
     {
       auto cell_fv_view =
         (PolygonFVView*)fv_discretization->MapFeView(cell->cell_global_id);

--- a/Modules/MonteCarlon/Source/BoundarySource/mc_bndry_source.cc
+++ b/Modules/MonteCarlon/Source/BoundarySource/mc_bndry_source.cc
@@ -51,7 +51,7 @@ void chi_montecarlon::BoundarySource::
     auto cell = grid->cells[cell_glob_index];
 
     //$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$ SLAB
-    if (cell->Type() == chi_mesh::SLAB_CELL)
+    if (cell->Type() == chi_mesh::CellTypes::SLAB_CELL)
     {
       auto slab_cell = (chi_mesh::CellSlab*)cell;
 
@@ -88,7 +88,7 @@ void chi_montecarlon::BoundarySource::
       }//for faces
     }//if slab
     // $$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$ POLYGON
-    else if (cell->Type() == chi_mesh::POLYGON_CELL)
+    else if (cell->Type() == chi_mesh::CellTypes::POLYGON_CELL)
     {
       auto poly_cell = (chi_mesh::CellPolygon*)cell;
       auto cell_fv_view = (PolygonFVView*)fv_sdm->MapFeView(cell_glob_index);
@@ -211,7 +211,7 @@ chi_montecarlon::Particle chi_montecarlon::BoundarySource::
   //$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$ SLAB
   // Categorally slab surface sampling does not require
   // a cdf and therefore we have a specific routine for it.
-  if (first_cell->Type() == chi_mesh::SLAB_CELL)
+  if (first_cell->Type() == chi_mesh::CellTypes::SLAB_CELL)
   {
     //====================================== Sample ref face
     int num_ref_faces = ref_cell_faces.size();
@@ -243,7 +243,7 @@ chi_montecarlon::Particle chi_montecarlon::BoundarySource::
 
     return new_particle;
   }//Slab cells
-  else if (first_cell->Type() == chi_mesh::POLYGON_CELL)
+  else if (first_cell->Type() == chi_mesh::CellTypes::POLYGON_CELL)
   {
     int f = surface_sampler->Sample(rng->Rand());
 

--- a/Modules/MonteCarlon/Source/BoundarySource/mc_bndry_source.cc
+++ b/Modules/MonteCarlon/Source/BoundarySource/mc_bndry_source.cc
@@ -51,7 +51,7 @@ void chi_montecarlon::BoundarySource::
     auto cell = grid->cells[cell_glob_index];
 
     //$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$ SLAB
-    if (cell->Type() == chi_mesh::CellTypes::SLAB_CELL)
+    if (cell->Type() == chi_mesh::CellType::SLAB)
     {
       auto slab_cell = (chi_mesh::CellSlab*)cell;
 
@@ -88,7 +88,7 @@ void chi_montecarlon::BoundarySource::
       }//for faces
     }//if slab
     // $$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$ POLYGON
-    else if (cell->Type() == chi_mesh::CellTypes::POLYGON_CELL)
+    else if (cell->Type() == chi_mesh::CellType::POLYGON)
     {
       auto poly_cell = (chi_mesh::CellPolygon*)cell;
       auto cell_fv_view = (PolygonFVView*)fv_sdm->MapFeView(cell_glob_index);
@@ -211,7 +211,7 @@ chi_montecarlon::Particle chi_montecarlon::BoundarySource::
   //$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$ SLAB
   // Categorally slab surface sampling does not require
   // a cdf and therefore we have a specific routine for it.
-  if (first_cell->Type() == chi_mesh::CellTypes::SLAB_CELL)
+  if (first_cell->Type() == chi_mesh::CellType::SLAB)
   {
     //====================================== Sample ref face
     int num_ref_faces = ref_cell_faces.size();
@@ -243,7 +243,7 @@ chi_montecarlon::Particle chi_montecarlon::BoundarySource::
 
     return new_particle;
   }//Slab cells
-  else if (first_cell->Type() == chi_mesh::CellTypes::POLYGON_CELL)
+  else if (first_cell->Type() == chi_mesh::CellType::POLYGON)
   {
     int f = surface_sampler->Sample(rng->Rand());
 

--- a/Modules/MonteCarlon/Source/BoundarySource/mc_bndry_source.cc
+++ b/Modules/MonteCarlon/Source/BoundarySource/mc_bndry_source.cc
@@ -51,7 +51,7 @@ void chi_montecarlon::BoundarySource::
     auto cell = grid->cells[cell_glob_index];
 
     //$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$ SLAB
-    if (typeid(*cell) == typeid(chi_mesh::CellSlab))
+    if (cell->Type() == chi_mesh::SLAB_CELL)
     {
       auto slab_cell = (chi_mesh::CellSlab*)cell;
 
@@ -88,7 +88,7 @@ void chi_montecarlon::BoundarySource::
       }//for faces
     }//if slab
     // $$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$ POLYGON
-    else if (typeid(*cell) == typeid(chi_mesh::CellPolygon))
+    else if (cell->Type() == chi_mesh::POLYGON_CELL)
     {
       auto poly_cell = (chi_mesh::CellPolygon*)cell;
       auto cell_fv_view = (PolygonFVView*)fv_sdm->MapFeView(cell_glob_index);
@@ -206,10 +206,12 @@ chi_montecarlon::Particle chi_montecarlon::BoundarySource::
 
   chi_montecarlon::Particle new_particle;
 
+  chi_mesh::Cell* first_cell = grid->cells[0];
+
   //$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$ SLAB
   // Categorally slab surface sampling does not require
   // a cdf and therefore we have a specific routine for it.
-  if (typeid(*mesher) == typeid(chi_mesh::VolumeMesherLinemesh1D))
+  if (first_cell->Type() == chi_mesh::SLAB_CELL)
   {
     //====================================== Sample ref face
     int num_ref_faces = ref_cell_faces.size();
@@ -241,7 +243,7 @@ chi_montecarlon::Particle chi_montecarlon::BoundarySource::
 
     return new_particle;
   }//Slab cells
-  else if (typeid(*grid->cells[0]) == typeid(chi_mesh::CellPolygon))
+  else if (first_cell->Type() == chi_mesh::POLYGON_CELL)
   {
     int f = surface_sampler->Sample(rng->Rand());
 

--- a/Modules/MonteCarlon/Source/ResidualSource/mc_rmc_source.cc
+++ b/Modules/MonteCarlon/Source/ResidualSource/mc_rmc_source.cc
@@ -119,7 +119,7 @@ void chi_montecarlon::ResidualSource::
     }
 
     //$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$ SLAB
-    if (typeid(*cell) == typeid(chi_mesh::CellSlab))
+    if (cell->Type() == chi_mesh::SLAB_CELL)
     {
       chi_log.Log(LOG_0VERBOSE_1) << "Cell " << cell_glob_index;
       auto slab_cell = (chi_mesh::CellSlab*)cell;
@@ -291,7 +291,7 @@ chi_montecarlon::Particle chi_montecarlon::ResidualSource::
 
 
   //$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$ SLAB
-  if (typeid(*cell) == typeid(chi_mesh::CellSlab))
+  if (cell->Type() == chi_mesh::SLAB_CELL)
   {
     auto slab_cell = (chi_mesh::CellSlab*)cell;
 

--- a/Modules/MonteCarlon/Source/ResidualSource/mc_rmc_source.cc
+++ b/Modules/MonteCarlon/Source/ResidualSource/mc_rmc_source.cc
@@ -119,7 +119,7 @@ void chi_montecarlon::ResidualSource::
     }
 
     //$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$ SLAB
-    if (cell->Type() == chi_mesh::SLAB_CELL)
+    if (cell->Type() == chi_mesh::CellTypes::SLAB_CELL)
     {
       chi_log.Log(LOG_0VERBOSE_1) << "Cell " << cell_glob_index;
       auto slab_cell = (chi_mesh::CellSlab*)cell;
@@ -291,7 +291,7 @@ chi_montecarlon::Particle chi_montecarlon::ResidualSource::
 
 
   //$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$ SLAB
-  if (cell->Type() == chi_mesh::SLAB_CELL)
+  if (cell->Type() == chi_mesh::CellTypes::SLAB_CELL)
   {
     auto slab_cell = (chi_mesh::CellSlab*)cell;
 

--- a/Modules/MonteCarlon/Source/ResidualSource/mc_rmc_source.cc
+++ b/Modules/MonteCarlon/Source/ResidualSource/mc_rmc_source.cc
@@ -119,7 +119,7 @@ void chi_montecarlon::ResidualSource::
     }
 
     //$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$ SLAB
-    if (cell->Type() == chi_mesh::CellTypes::SLAB_CELL)
+    if (cell->Type() == chi_mesh::CellType::SLAB)
     {
       chi_log.Log(LOG_0VERBOSE_1) << "Cell " << cell_glob_index;
       auto slab_cell = (chi_mesh::CellSlab*)cell;
@@ -291,7 +291,7 @@ chi_montecarlon::Particle chi_montecarlon::ResidualSource::
 
 
   //$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$ SLAB
-  if (cell->Type() == chi_mesh::CellTypes::SLAB_CELL)
+  if (cell->Type() == chi_mesh::CellType::SLAB)
   {
     auto slab_cell = (chi_mesh::CellSlab*)cell;
 


### PR DESCRIPTION
- `chi_mesh::CellTypes` enumeration added for cell types
- `CellTypes cell_type` added to the base cell class as a `protected` method
- public `Type()` method added to base cell class to be used to identify cell type. i.e. `if (typeid(*cell) == typeid(chi_mesh::CellPolygon))` is now replaced with `if (cell->Type() == chi_mesh::POLYGON_CELL)`

I also fixed the assignment of eager limit in the boltzman solvers input language. This was a stupid mistake when manually modded a test case.