### PR TITLE
Minor bug fix on 1D shape function [see description]

### DIFF
--- a/CHI_TECH/ChiMath/SpatialDiscretization/PiecewiseLinear/CellViews/pwl_slab.h
+++ b/CHI_TECH/ChiMath/SpatialDiscretization/PiecewiseLinear/CellViews/pwl_slab.h
@@ -140,17 +140,17 @@ public:
 
     chi_mesh::Vector v01 = p1 - p0;
 
-    double xi   = v01.Dot(xyz_ref)/v01.Norm();
+    double xi   = v01.Dot(xyz_ref)/v01.Norm()/h;
 
     if ((xi>=-1.0e-12) and (xi<=1.0+1.0e-12))
     {
       if (i==0)
       {
-        return 1.0 - xi/h;
+        return 1.0 - xi;
       }
       else
       {
-        return xi/h;
+        return xi;
       }
     }
 


### PR DESCRIPTION
Field Function interpolators use the actual xyz evaluation of the shape function to compute things like lineouts. Under certain circumstances I've noticed that the lineouts looked weird for 1D simulations and tracked it down to this bug. It luckily only affects 1D Slab geometries.