### PR TITLE
ParMETIS partitioning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ CHI_RESOURCES/Dependencies/readline/
 CHI_RESOURCES/Dependencies/triangle/
 CHI_RESOURCES/Dependencies/glew-2.1.0/
 
+# Latex compile files
 *.aux
 *.lof
 *.log
@@ -32,6 +33,7 @@ CHI_RESOURCES/Dependencies/\.DS_Store
 
 CHI_RESOURCES/\.DS_Store
 
+# python files
 \.DS_Store
 ._.DS_Store
 *.pyc

--- a/CHI_TECH/ChiMath/PETScUtils/petsc_utils_00.cc
+++ b/CHI_TECH/ChiMath/PETScUtils/petsc_utils_00.cc
@@ -92,6 +92,7 @@ Vec chi_math::PETScUtils::CreateVector(int local_size, int global_size)
   VecCreate(PETSC_COMM_WORLD,&x);
   VecSetType(x,VECMPI);
   VecSetSizes(x, local_size, global_size);
+  VecSetOption(x,VEC_IGNORE_NEGATIVE_INDICES,PETSC_TRUE);
 
   return x;
 }

--- a/CHI_TECH/ChiMath/SpatialDiscretization/FiniteVolume/fv.cc
+++ b/CHI_TECH/ChiMath/SpatialDiscretization/FiniteVolume/fv.cc
@@ -86,25 +86,33 @@ int SpatialDiscretization_FV::
          unsigned int unknown_id,
          unsigned int component)
 {
+  if (component < 0) return -1;
+
   size_t num_unknowns = unknown_manager->GetTotalUnknownSize();
+
+  if (component >= num_unknowns) return -1;
+
   size_t block_id = unknown_manager->MapUnknown(unknown_id,component);
 
-//  return block_size_per_unknown*block_id + cell->global_id;
   return num_unknowns*cell->global_id + block_id;
 }
 
 //###################################################################
 /**Maps a finite volume degree of freedom.*/
 int SpatialDiscretization_FV::
-MapDOF(int cell_global_id,
+  MapDOF(int cell_global_id,
        chi_math::UnknownManager* unknown_manager,
        unsigned int unknown_id,
        unsigned int component)
 {
+  if (component < 0) return -1;
+
   size_t num_unknowns = unknown_manager->GetTotalUnknownSize();
+
+  if (component >= num_unknowns) return -1;
+
   size_t block_id = unknown_manager->MapUnknown(unknown_id,component);
 
-//  return block_size_per_unknown*block_id + cell->global_id;
   return num_unknowns*cell_global_id + block_id;
 }
 

--- a/CHI_TECH/ChiMesh/Cell/cell.cc
+++ b/CHI_TECH/ChiMesh/Cell/cell.cc
@@ -87,31 +87,17 @@ int chi_mesh::CellFace::
   int associated_face = -1;
   if (cur_face.neighbor_ass_face < 0)
   {
+    std::set<int> cfvids(cur_face.vertex_ids.begin(),
+                         cur_face.vertex_ids.end());
     //======================================== Loop over adj cell faces
     int af=-1;
     for (auto& adj_face : adj_cell->faces)
     {
       ++af;
-      //Assume face matches
-      bool face_matches = true; //Now disprove it
-      //================================= Loop over adj cell face verts
-      for (auto afvi : adj_face.vertex_ids)
-      {
-        //========================== Try and find them in the reference face
-        bool found = false;
-        for (auto cfvi : cur_face.vertex_ids)
-        {
-          if (cfvi == afvi)
-          {
-            found = true;
-            break;
-          }
-        }//for cfv
+      std::set<int> afvids(adj_face.vertex_ids.begin(),
+                           adj_face.vertex_ids.end());
 
-        if (!found) {face_matches = false; break;}
-      }//for afv
-
-      if (face_matches) {associated_face = af; break;}
+      if (afvids == cfvids) {associated_face = af; break;}
     }
   }
   else
@@ -122,8 +108,10 @@ int chi_mesh::CellFace::
   {
     chi_log.Log(LOG_ALLERROR)
       << "Could not find associated face in call to "
-      << "CellFace::GetNeighborAssociatedFace. Reference face with centroid at \n"
-      << cur_face.centroid.PrintS();
+      << "CellFace::GetNeighborAssociatedFace.\n"
+      << "Reference face with centroid at: "
+      << cur_face.centroid.PrintS() << "\n"
+      << "Adjacent cell: " << adj_cell->global_id;
     for (int af=0; af < adj_cell->faces.size(); af++)
     {
       chi_log.Log(LOG_ALLERROR)

--- a/CHI_TECH/ChiMesh/SweepUtilities/FLUDS/FLUDS_betapass_nonlocal_inc_mapping.cc
+++ b/CHI_TECH/ChiMesh/SweepUtilities/FLUDS/FLUDS_betapass_nonlocal_inc_mapping.cc
@@ -58,27 +58,20 @@ void chi_mesh::sweep_management::PRIMARY_FLUDS::
           }
 
           //============================== Find associated face
+          std::set<int> cfvids(face.vertex_ids.begin(),
+                               face.vertex_ids.end());
           CompactCellView* adj_cell_view =
               &prelocI_cell_views[prelocI][ass_cell];
-          int ass_face = -1;
-          for (int af=0; af<adj_cell_view->second.size(); af++)
+          int ass_face = -1, af = -1;
+          for (auto& adj_face : adj_cell_view->second)
           {
+            ++af;
             bool face_matches = true;
-            for (int afv=0; afv<adj_cell_view->second[af].second.size(); afv++)
-            {
-              bool match_found = false;
-              for (int fv=0; fv < face.vertex_ids.size(); fv++)
-              {
-                if (adj_cell_view->second[af].second[afv] ==
-                    face.vertex_ids[fv])
-                {
-                  match_found = true;
-                  break;
-                }
-              }
 
-              if (!match_found){face_matches = false; break;}
-            }
+            std::set<int> afvids(adj_face.second.begin(),
+                                 adj_face.second.end());
+
+            if (cfvids != afvids) face_matches = false;
 
             if (face_matches){ass_face = af; break;}
           }

--- a/CHI_TECH/ChiMesh/UnpartitionedMesh/chi_unpartitioned_mesh.h
+++ b/CHI_TECH/ChiMesh/UnpartitionedMesh/chi_unpartitioned_mesh.h
@@ -52,6 +52,10 @@ public:
   LightWeightCell* CreateCellFromVTKHexahedron(vtkCell* vtk_cell);
   LightWeightCell* CreateCellFromVTKTetrahedron(vtkCell* vtk_cell);
 
+  LightWeightCell* CreateCellFromVTKPolygon(vtkCell* vtk_cell);
+  LightWeightCell* CreateCellFromVTKQuad(vtkCell* vtk_cell);
+  LightWeightCell* CreateCellFromVTKTriangle(vtkCell* vtk_cell);
+
   void ReadFromVTU(const Options& options);
   void ReadFromEnsightGold(const Options& options);
 };

--- a/CHI_TECH/ChiMesh/UnpartitionedMesh/chi_unpartitioned_mesh.h
+++ b/CHI_TECH/ChiMesh/UnpartitionedMesh/chi_unpartitioned_mesh.h
@@ -37,6 +37,7 @@ public:
   struct Options
   {
     std::string file_name;
+    double scale=1.0;
     ParallelMethod parallel_method = ParallelMethod::ALL_FROM_HOME;
   }mesh_options;
 

--- a/CHI_TECH/ChiMesh/UnpartitionedMesh/lua/create.cc
+++ b/CHI_TECH/ChiMesh/UnpartitionedMesh/lua/create.cc
@@ -45,6 +45,7 @@ int chiUnpartitionedMeshFromVTU(lua_State* L)
  * Ensight Gold mesh files.
  *
  * \param file_name char Filename of the .case file.
+ * \param scale float Scale to apply to the mesh
  *
  * \ingroup LuaUnpartitionedMesh
  *
@@ -53,14 +54,17 @@ int chiUnpartitionedMeshFromEnsightGold(lua_State* L)
 {
   const char func_name[] = "chiUnpartitionedMeshFromEnsightGold";
   int num_args = lua_gettop(L);
-  if (num_args != 1)
+  if (num_args <1)
     LuaPostArgAmountError(func_name,1,num_args);
 
   const char* temp = lua_tostring(L,1);
+  double scale = 1.0;
+  if (num_args >= 2) scale = lua_tonumber(L,2);
   auto new_object = new chi_mesh::UnpartitionedMesh;
 
   chi_mesh::UnpartitionedMesh::Options options;
   options.file_name = std::string(temp);
+  options.scale = scale;
 
   new_object->ReadFromEnsightGold(options);
 

--- a/CHI_TECH/ChiMesh/UnpartitionedMesh/unpartmesh_00_general.cc
+++ b/CHI_TECH/ChiMesh/UnpartitionedMesh/unpartmesh_00_general.cc
@@ -6,6 +6,10 @@
 #include <vtkHexahedron.h>
 #include <vtkTetra.h>
 
+#include <vtkPolygon.h>
+#include <vtkQuad.h>
+#include <vtkTriangle.h>
+
 //###################################################################
 /**Creates a raw polyhedron cell from a vtk-polyhedron.*/
 chi_mesh::UnpartitionedMesh::LightWeightCell* chi_mesh::UnpartitionedMesh::
@@ -108,6 +112,123 @@ chi_mesh::UnpartitionedMesh::LightWeightCell* chi_mesh::UnpartitionedMesh::
   {
     LightWeightFace face;
     auto vtk_face = vtk_tet->GetFace(f);
+    auto num_face_points = vtk_face->GetNumberOfPoints();
+
+    face.vertex_ids.reserve(num_face_points);
+    auto face_point_ids = vtk_face->GetPointIds();
+    for (int p = 0; p < num_face_points; ++p) {
+      int point_id = face_point_ids->GetId(p);
+      face.vertex_ids.push_back(point_id);
+    }
+
+    polyh_cell->faces.push_back(face);
+  }
+
+  return polyh_cell;
+}
+
+//###################################################################
+/**Creates a raw polyhedron cell from a vtk-polygon.*/
+chi_mesh::UnpartitionedMesh::LightWeightCell* chi_mesh::UnpartitionedMesh::
+  CreateCellFromVTKPolygon(vtkCell *vtk_cell)
+{
+  auto polyh_cell  = new LightWeightCell;
+
+  auto vtk_polygon    = vtkPolygon::SafeDownCast(vtk_cell);
+  auto num_cpoints = vtk_polygon->GetNumberOfPoints();
+  auto num_cfaces  = vtk_polygon->GetNumberOfFaces();
+
+  polyh_cell->vertex_ids.reserve(num_cpoints);
+  auto point_ids   = vtk_polygon->GetPointIds();
+  for (int p=0; p<num_cpoints; ++p)
+  {
+    int point_id = point_ids->GetId(p);
+    polyh_cell->vertex_ids.push_back(point_id);
+  }//for p
+
+  polyh_cell->faces.reserve(num_cfaces);
+  for (int f=0; f<num_cfaces; ++f)
+  {
+    LightWeightFace face;
+    auto vtk_face = vtk_polygon->GetFace(f);
+    auto num_face_points = vtk_face->GetNumberOfPoints();
+
+    face.vertex_ids.reserve(num_face_points);
+    auto face_point_ids = vtk_face->GetPointIds();
+    for (int p = 0; p < num_face_points; ++p) {
+      int point_id = face_point_ids->GetId(p);
+      face.vertex_ids.push_back(point_id);
+    }
+
+    polyh_cell->faces.push_back(face);
+  }
+
+  return polyh_cell;
+}
+
+//###################################################################
+/**Creates a raw polyhedron cell from a vtk-quad.*/
+chi_mesh::UnpartitionedMesh::LightWeightCell* chi_mesh::UnpartitionedMesh::
+  CreateCellFromVTKQuad(vtkCell *vtk_cell)
+{
+  auto polyh_cell  = new LightWeightCell;
+
+  auto vtk_quad    = vtkQuad::SafeDownCast(vtk_cell);
+  auto num_cpoints = vtk_quad->GetNumberOfPoints();
+  auto num_cfaces  = vtk_quad->GetNumberOfFaces();
+
+  polyh_cell->vertex_ids.reserve(num_cpoints);
+  auto point_ids   = vtk_quad->GetPointIds();
+  for (int p=0; p<num_cpoints; ++p)
+  {
+    int point_id = point_ids->GetId(p);
+    polyh_cell->vertex_ids.push_back(point_id);
+  }//for p
+
+  polyh_cell->faces.reserve(num_cfaces);
+  for (int f=0; f<num_cfaces; ++f)
+  {
+    LightWeightFace face;
+    auto vtk_face = vtk_quad->GetFace(f);
+    auto num_face_points = vtk_face->GetNumberOfPoints();
+
+    face.vertex_ids.reserve(num_face_points);
+    auto face_point_ids = vtk_face->GetPointIds();
+    for (int p = 0; p < num_face_points; ++p) {
+      int point_id = face_point_ids->GetId(p);
+      face.vertex_ids.push_back(point_id);
+    }
+
+    polyh_cell->faces.push_back(face);
+  }
+
+  return polyh_cell;
+}
+
+//###################################################################
+/**Creates a raw polyhedron cell from a vtk-triangle.*/
+chi_mesh::UnpartitionedMesh::LightWeightCell* chi_mesh::UnpartitionedMesh::
+  CreateCellFromVTKTriangle(vtkCell *vtk_cell)
+{
+  auto polyh_cell  = new LightWeightCell;
+
+  auto vtk_triangle = vtkTriangle::SafeDownCast(vtk_cell);
+  auto num_cpoints = vtk_triangle->GetNumberOfPoints();
+  auto num_cfaces  = vtk_triangle->GetNumberOfFaces();
+
+  polyh_cell->vertex_ids.reserve(num_cpoints);
+  auto point_ids   = vtk_triangle->GetPointIds();
+  for (int p=0; p<num_cpoints; ++p)
+  {
+    int point_id = point_ids->GetId(p);
+    polyh_cell->vertex_ids.push_back(point_id);
+  }//for p
+
+  polyh_cell->faces.reserve(num_cfaces);
+  for (int f=0; f<num_cfaces; ++f)
+  {
+    LightWeightFace face;
+    auto vtk_face = vtk_triangle->GetFace(f);
     auto num_face_points = vtk_face->GetNumberOfPoints();
 
     face.vertex_ids.reserve(num_face_points);

--- a/CHI_TECH/ChiMesh/UnpartitionedMesh/unpartmesh_00_general.cc
+++ b/CHI_TECH/ChiMesh/UnpartitionedMesh/unpartmesh_00_general.cc
@@ -91,7 +91,7 @@ chi_mesh::UnpartitionedMesh::LightWeightCell* chi_mesh::UnpartitionedMesh::
 {
   auto polyh_cell  = new LightWeightCell;
 
-  auto vtk_tet     = vtkHexahedron::SafeDownCast(vtk_cell);
+  auto vtk_tet     = vtkTetra::SafeDownCast(vtk_cell);
   auto num_cpoints = vtk_tet->GetNumberOfPoints();
   auto num_cfaces  = vtk_tet->GetNumberOfFaces();
 

--- a/CHI_TECH/ChiMesh/UnpartitionedMesh/unpartmesh_02_readfromensight.cc
+++ b/CHI_TECH/ChiMesh/UnpartitionedMesh/unpartmesh_02_readfromensight.cc
@@ -22,7 +22,7 @@ extern ChiMPI& chi_mpi;
 
 
 //###################################################################
-/**Reads a VTK unstructured mesh.*/
+/**Reads an Ensight-Gold unstructured mesh.*/
 void chi_mesh::UnpartitionedMesh::
   ReadFromEnsightGold(const chi_mesh::UnpartitionedMesh::Options &options)
 {
@@ -62,11 +62,31 @@ void chi_mesh::UnpartitionedMesh::
   std::vector<vtkSmartPointer<vtkUnstructuredGrid>> grid_blocks;
   grid_blocks.reserve(num_blocks);
   for (int b=0; b<num_blocks; ++b)
-    grid_blocks.push_back(
-      vtkSmartPointer<vtkUnstructuredGrid>(
+    grid_blocks.emplace_back(
         vtkUnstructuredGrid::SafeDownCast(multiblock->GetBlock(b))
-        )
       );
+
+  //========================================= Determine mesh type
+  // This step goes through each grid block
+  // and tries to find 3D cells. If it does the
+  // overall mesh is classified as 3D.
+  bool mesh_is_3D = false;
+  for (auto ugrid : grid_blocks)
+  {
+    if (ugrid->GetNumberOfCells() == 0) continue;
+
+    auto cell = ugrid->GetCell(0); //Get first cell
+    auto ctype = cell->GetCellType();
+
+    if ((ctype == VTK_POLYHEDRON) or
+        (ctype == VTK_HEXAHEDRON) or
+        (ctype == VTK_TETRA) )
+    {
+      mesh_is_3D = true;
+      break;
+    }
+  }//for grid block
+
 
   //========================================= Process each block
   vtkSmartPointer<vtkAppendFilter> append =
@@ -80,29 +100,43 @@ void chi_mesh::UnpartitionedMesh::
     int num_cells  = ugrid->GetNumberOfCells();
     int num_points = ugrid->GetNumberOfPoints();
 
-
     std::stringstream outstr;
     outstr
       << "Block " << ug << " has "
       << num_cells << " cells and "
       << num_points << " points";
 
-    if (num_cells > 0)
-    {
-      auto cell = ugrid->GetCell(0);
-      auto ctype = cell->GetCellType();
+    if (num_cells == 0) continue;
 
+    auto cell = ugrid->GetCell(0);
+    auto ctype = cell->GetCellType();
+
+    if (mesh_is_3D)
+    {
       if (not ((ctype == VTK_POLYHEDRON) or
                (ctype == VTK_HEXAHEDRON) or
                (ctype == VTK_TETRA)) )
-           { outstr << " (Boundary Mesh)"; }
+      { outstr << " (Boundary Mesh)"; }
       else
       {
         append->AddInputData(ugrid);
         total_cells += num_cells;
         block_mat_id.push_back(total_cells);
       }
-    }
+    }//3D mesh
+    else
+    {
+      if (not ((ctype == VTK_POLYGON) or
+               (ctype == VTK_QUAD) or
+               (ctype == VTK_TRIANGLE)) )
+      { outstr << " (Boundary Mesh)"; }
+      else
+      {
+        append->AddInputData(ugrid);
+        total_cells += num_cells;
+        block_mat_id.push_back(total_cells);
+      }
+    }//2D mesh
 
    chi_log.Log(LOG_0VERBOSE_1) << outstr.str();
   }
@@ -140,6 +174,12 @@ void chi_mesh::UnpartitionedMesh::
       raw_cells.push_back(CreateCellFromVTKHexahedron(vtk_cell));
     else if (vtk_celltype == VTK_TETRA)
       raw_cells.push_back(CreateCellFromVTKTetrahedron(vtk_cell));
+    else if (vtk_celltype == VTK_POLYGON)
+      raw_cells.push_back(CreateCellFromVTKPolygon(vtk_cell));
+    else if (vtk_celltype == VTK_QUAD)
+      raw_cells.push_back(CreateCellFromVTKQuad(vtk_cell));
+    else if (vtk_celltype == VTK_TRIANGLE)
+      raw_cells.push_back(CreateCellFromVTKTriangle(vtk_cell));
 
     int mat_id=-1;
     int prev_block_lim = -1;
@@ -158,16 +198,20 @@ void chi_mesh::UnpartitionedMesh::
   for (int p=0; p<total_point_count; ++p)
   {
     auto point = ugrid->GetPoint(p);
-    vertices.push_back(new chi_mesh::Vertex(point[0]*options.scale,
-                                            point[1]*options.scale,
-                                            point[2]*options.scale));
 
-    if (point[0]*options.scale < bound_box.xmin) bound_box.xmin = point[0]*options.scale;
-    if (point[0]*options.scale > bound_box.xmax) bound_box.xmax = point[0]*options.scale;
-    if (point[1]*options.scale < bound_box.ymin) bound_box.ymin = point[1]*options.scale;
-    if (point[1]*options.scale > bound_box.ymax) bound_box.ymax = point[1]*options.scale;
-    if (point[2]*options.scale < bound_box.zmin) bound_box.zmin = point[2]*options.scale;
-    if (point[2]*options.scale > bound_box.zmax) bound_box.zmax = point[2]*options.scale;
+    point[0] = point[0]*options.scale;
+    point[1] = point[1]*options.scale;
+    point[2] = point[2]*options.scale;
+
+
+    vertices.push_back(new chi_mesh::Vertex(point[0],point[1],point[2]));
+
+    if (point[0] < bound_box.xmin) bound_box.xmin = point[0];
+    if (point[0] > bound_box.xmax) bound_box.xmax = point[0];
+    if (point[1] < bound_box.ymin) bound_box.ymin = point[1];
+    if (point[1] > bound_box.ymax) bound_box.ymax = point[1];
+    if (point[2] < bound_box.zmin) bound_box.zmin = point[2];
+    if (point[2] > bound_box.zmax) bound_box.zmax = point[2];
   }
 
 //  std::stringstream ostr;

--- a/CHI_TECH/ChiMesh/UnpartitionedMesh/unpartmesh_02_readfromensight.cc
+++ b/CHI_TECH/ChiMesh/UnpartitionedMesh/unpartmesh_02_readfromensight.cc
@@ -142,10 +142,13 @@ void chi_mesh::UnpartitionedMesh::
       raw_cells.push_back(CreateCellFromVTKTetrahedron(vtk_cell));
 
     int mat_id=-1;
+    int prev_block_lim = -1;
     for (auto block_lim : block_mat_id)
     {
       ++mat_id;
-      if (c>=block_lim) break;
+      if (c<block_lim and c>=prev_block_lim) break;
+
+      prev_block_lim=block_lim;
     }
 
     raw_cells.back()->material_id = mat_id;
@@ -155,14 +158,35 @@ void chi_mesh::UnpartitionedMesh::
   for (int p=0; p<total_point_count; ++p)
   {
     auto point = ugrid->GetPoint(p);
-    vertices.push_back(new chi_mesh::Vertex(point[0],point[1],point[2]));
+    vertices.push_back(new chi_mesh::Vertex(point[0]*options.scale,
+                                            point[1]*options.scale,
+                                            point[2]*options.scale));
 
-    if (point[0] < bound_box.xmin) bound_box.xmin = point[0];
-    if (point[0] > bound_box.xmax) bound_box.xmax = point[0];
-    if (point[1] < bound_box.ymin) bound_box.ymin = point[1];
-    if (point[1] > bound_box.ymax) bound_box.ymax = point[1];
-    if (point[2] < bound_box.zmin) bound_box.zmin = point[2];
-    if (point[2] > bound_box.zmax) bound_box.zmax = point[2];
+    if (point[0]*options.scale < bound_box.xmin) bound_box.xmin = point[0]*options.scale;
+    if (point[0]*options.scale > bound_box.xmax) bound_box.xmax = point[0]*options.scale;
+    if (point[1]*options.scale < bound_box.ymin) bound_box.ymin = point[1]*options.scale;
+    if (point[1]*options.scale > bound_box.ymax) bound_box.ymax = point[1]*options.scale;
+    if (point[2]*options.scale < bound_box.zmin) bound_box.zmin = point[2]*options.scale;
+    if (point[2]*options.scale > bound_box.zmax) bound_box.zmax = point[2]*options.scale;
   }
+
+//  std::stringstream ostr;
+//
+//  ostr << "Cell 0 vids: ";
+//  auto first_cell = raw_cells[0];
+//  for (auto vid : first_cell->vertex_ids)
+//    ostr << vid << " " << vertices[vid]->PrintS();
+//  ostr << "\n";
+//  int f=-1;
+//  for (auto& face : first_cell->faces)
+//  {
+//    ++f;
+//    ostr << "Face " << f << ": ";
+//    for (auto vid : face.vertex_ids)
+//      ostr << vid << " ";
+//    ostr << "\n";
+//  }
+//
+//  chi_log.Log(LOG_0) << ostr.str();
 
 }

--- a/CHI_TECH/ChiMesh/VolumeMesher/Predefined3D/volmesher_predefined3d.h
+++ b/CHI_TECH/ChiMesh/VolumeMesher/Predefined3D/volmesher_predefined3d.h
@@ -7,10 +7,19 @@
 class chi_mesh::VolumeMesherPredefined3D : public chi_mesh::VolumeMesher
 {
 public:
-  int GetPartitionIDFromCentroid(const chi_mesh::Vertex& centroid);
-  bool IsRawCellNeighborToPartition(
-    const chi_mesh::UnpartitionedMesh::LightWeightCell& lwcell);
   void Execute();
+
+  int GetPartitionIDFromCentroid(const chi_mesh::Vertex& centroid);
+  bool IsRawCellNeighborToPartitionKBA(
+    const chi_mesh::UnpartitionedMesh::LightWeightCell& lwcell);
+  void KBA(chi_mesh::UnpartitionedMesh* umesh,
+           chi_mesh::MeshContinuum* grid);
+
+  bool IsRawCellNeighborToPartitionParmetis(
+    const chi_mesh::UnpartitionedMesh::LightWeightCell& lwcell,
+    const std::vector<int>& cell_pids);
+  void PARMETIS(chi_mesh::UnpartitionedMesh* umesh,
+                chi_mesh::MeshContinuum* grid);
 };
 
 

--- a/CHI_TECH/ChiMesh/VolumeMesher/Predefined3D/volmesher_predefined3d_execute.cc
+++ b/CHI_TECH/ChiMesh/VolumeMesher/Predefined3D/volmesher_predefined3d_execute.cc
@@ -3,7 +3,6 @@
 #include "ChiMesh/MeshHandler/chi_meshhandler.h"
 #include "ChiMesh/SurfaceMesher/surfacemesher.h"
 #include "ChiMesh/VolumeMesher/chi_volumemesher.h"
-#include "ChiMesh/UnpartitionedMesh/chi_unpartitioned_mesh.h"
 
 #include "ChiMesh/MeshContinuum/chi_meshcontinuum.h"
 #include "ChiMesh/Region//chi_region.h"
@@ -26,7 +25,7 @@ void chi_mesh::VolumeMesherPredefined3D::Execute()
 {
   chi_log.Log(LOG_0)
     << chi_program_timer.GetTimeString()
-    << " VolumeMesherPredefined3D executed. Memory in use = "
+    << " VolumeMesherPredefined3D executing. Memory in use = "
     << chi_console.GetMemoryUsageInMB() << " MB"
     << std::endl;
 
@@ -160,7 +159,7 @@ void chi_mesh::VolumeMesherPredefined3D::Execute()
   MPI_Barrier(MPI_COMM_WORLD);
 
 
-  //======================================== Apply paritioning scheme
+  //======================================== Apply partitioning scheme
   auto grid = new chi_mesh::MeshContinuum;
 
   if (options.partition_type == PartitionType::KBA_STYLE_XY or

--- a/CHI_TECH/ChiMesh/VolumeMesher/Predefined3D/volmesher_predefined3d_execute.cc
+++ b/CHI_TECH/ChiMesh/VolumeMesher/Predefined3D/volmesher_predefined3d_execute.cc
@@ -6,7 +6,6 @@
 #include "ChiMesh/UnpartitionedMesh/chi_unpartitioned_mesh.h"
 
 #include "ChiMesh/MeshContinuum/chi_meshcontinuum.h"
-#include "ChiMesh/Cell/cell_polyhedron.h"
 #include "ChiMesh/Region//chi_region.h"
 
 #include "chi_log.h"
@@ -20,60 +19,6 @@ extern ChiTimer chi_program_timer;
 
 #include <ChiConsole/chi_console.h>
 extern ChiConsole&   chi_console;
-
-//###################################################################
-/**Gets the partition ID from a centroid.*/
-int chi_mesh::VolumeMesherPredefined3D::
-  GetPartitionIDFromCentroid(const chi_mesh::Vertex& centroid)
-{
-  auto handler = chi_mesh::GetCurrentHandler();
-
-  int Px = handler->surface_mesher->partitioning_x;
-  int Py = handler->surface_mesher->partitioning_y;
-
-
-  chi_mesh::Cell temp_cell(chi_mesh::CellType::GHOST);
-  temp_cell.centroid = centroid;
-
-  auto xyz = GetCellXYZPartitionID(&temp_cell);
-
-  int nxi = std::get<0>(xyz);
-  int nyi = std::get<1>(xyz);
-  int nzi = std::get<2>(xyz);
-
-  return nzi*Px*Py + nyi*Px + nxi;
-}
-
-//###################################################################
-/**Determines if a chi_mesh::UnpartitionedMesh::LightWeightCell is a
- * neighbor to the current partition.
- * This method loops over the faces of the lightweight cell and
- * determines the partition-id of each the neighbors. If the neighbor
- * has a partition id equal to that of the current process then
- * it means this reference cell is a neighbor.*/
-bool chi_mesh::VolumeMesherPredefined3D::
-  IsRawCellNeighborToPartition(
-    const chi_mesh::UnpartitionedMesh::LightWeightCell& lwcell)
-{
-  auto handler = chi_mesh::GetCurrentHandler();
-
-  auto umesh = handler->unpartitionedmesh_stack.back();
-
-  bool is_neighbor = false;
-  for (const auto& face : lwcell.faces)
-  {
-    if (face.neighbor < 0) continue;
-    auto adj_cell = umesh->raw_cells[face.neighbor];
-    int partition_id = GetPartitionIDFromCentroid(adj_cell->centroid);
-    if (partition_id == chi_mpi.location_id)
-    {
-      is_neighbor = true;
-      break;
-    }
-  }
-
-  return is_neighbor;
-}
 
 //###################################################################
 /**Executes the predefined3D mesher.*/
@@ -215,91 +160,14 @@ void chi_mesh::VolumeMesherPredefined3D::Execute()
   MPI_Barrier(MPI_COMM_WORLD);
 
 
-  //======================================== Load up the vertices
+  //======================================== Apply paritioning scheme
   auto grid = new chi_mesh::MeshContinuum;
-  for (auto vert : umesh->vertices)
-    grid->vertices.push_back(new chi_mesh::Vertex(*vert));
 
-  chi_log.Log(LOG_0) << "Vertices loaded.";
-  MPI_Barrier(MPI_COMM_WORLD);
-
-  int loc_id = chi_mpi.location_id;
-
-  //======================================== Load up the cells
-  int global_id=-1;
-  for (auto raw_cell : umesh->raw_cells)
-  {
-    ++global_id;
-    auto temp_cell = new chi_mesh::Cell(chi_mesh::CellType::GHOST);
-    temp_cell->centroid = raw_cell->centroid;
-    temp_cell->global_id = global_id;
-    temp_cell->partition_id = GetPartitionIDFromCentroid(temp_cell->centroid);
-    temp_cell->material_id = raw_cell->material_id;
-
-//    printf("[%d] Bla\n",loc_id);
-
-    if (temp_cell->partition_id != chi_mpi.location_id)
-    {
-//      printf("[%d] Bla1\n",loc_id);
-      if (IsRawCellNeighborToPartition(*raw_cell))
-        grid->cells.push_back(temp_cell);
-      else
-        delete temp_cell;
-
-//      printf("[%d] Bla2\n",loc_id);
-    }
-    else
-    {
-//      printf("[%d] Bla3\n",loc_id);
-      auto polyh_cell = new chi_mesh::CellPolyhedron;
-      polyh_cell->centroid = temp_cell->centroid;
-      polyh_cell->global_id = temp_cell->global_id;
-      polyh_cell->partition_id = temp_cell->partition_id;
-      polyh_cell->material_id = temp_cell->material_id;
-
-      polyh_cell->vertex_ids = raw_cell->vertex_ids;
-
-      for (auto& raw_face : raw_cell->faces)
-      {
-        chi_mesh::CellFace newFace;
-
-        newFace.neighbor = raw_face.neighbor;
-
-        newFace.vertex_ids = raw_face.vertex_ids;
-        auto vfc = chi_mesh::Vertex(0.0, 0.0, 0.0);
-        for (auto fvid : newFace.vertex_ids)
-          vfc = vfc + *grid->vertices[fvid];
-        newFace.centroid = vfc / newFace.vertex_ids.size();
-
-        //Compute normal
-//        auto va = *grid->vertices[newFace.vertex_ids[0]] - vfc;
-//        auto vb = *grid->vertices[newFace.vertex_ids[1]] - vfc;
-//
-//        auto vn = va.Cross(vb);
-//        newFace.normal = vn/vn.Norm();
-
-        newFace.normal = chi_mesh::Normal(0.0,0.0,0.0);
-        int last_vert_ind = newFace.vertex_ids.size()-1;
-        for (int fv=0; fv<newFace.vertex_ids.size(); ++fv)
-        {
-          int fvid_m = newFace.vertex_ids[fv];
-          int fvid_p = (fv == last_vert_ind)? newFace.vertex_ids[0] :
-                                              newFace.vertex_ids[fv+1];
-          auto leg_m = *grid->vertices[fvid_m] - newFace.centroid;
-          auto leg_p = *grid->vertices[fvid_p] - newFace.centroid;
-
-          auto vn = leg_m.Cross(leg_p);
-
-          newFace.normal = newFace.normal + vn.Normalized();
-        }
-        newFace.normal = (newFace.normal/newFace.vertex_ids.size()).Normalized();
-
-        polyh_cell->faces.push_back(newFace);
-      }
-
-      grid->cells.push_back(polyh_cell);
-    }//else
-  }
+  if (options.partition_type == PartitionType::KBA_STYLE_XY or
+      options.partition_type == PartitionType::KBA_STYLE_XYZ)
+    KBA(umesh, grid);
+  else
+    PARMETIS(umesh,grid);
 
   chi_log.Log(LOG_0) << "Cells loaded.";
   MPI_Barrier(MPI_COMM_WORLD);

--- a/CHI_TECH/ChiMesh/VolumeMesher/Predefined3D/volmesher_predefined3d_execute.cc
+++ b/CHI_TECH/ChiMesh/VolumeMesher/Predefined3D/volmesher_predefined3d_execute.cc
@@ -106,6 +106,9 @@ void chi_mesh::VolumeMesherPredefined3D::Execute()
       for (auto cfvid : face.vertex_ids)
         cells_to_search.push_back(vertex_subs[cfvid]);
 
+      std::set<int> cfvids(face.vertex_ids.begin(),
+                           face.vertex_ids.end());
+
       bool stop_searching = false;
       for (auto& adj_cell_id_set : cells_to_search)
       {
@@ -117,37 +120,15 @@ void chi_mesh::VolumeMesherPredefined3D::Execute()
           bool adj_cell_matches = false;
           for (auto& aface : adj_cell->faces)
           {
-            bool face_matches=true;
-            for (auto cfvid : face.vertex_ids)
-            {
-              bool vertex_found = false;
-              for (auto afvid : aface.vertex_ids)
-                if (cfvid == afvid) {vertex_found = true; break;}
+            std::set<int> afvids(aface.vertex_ids.begin(),
+                                 aface.vertex_ids.end());
 
-              if (not vertex_found)
-              {
-                face_matches = false;
-                break;
-              }
-            }
-
-            if (face_matches)
+            if (afvids == cfvids)
             {
               adj_cell_matches = true;
               break;
             }
           }
-
-          //Assume it matches now disprove
-//          bool adj_cell_matches = true;
-//          for (auto cfvid : face.vertex_ids)
-//          {
-//            bool vertex_found=false;
-//            for (auto acvid : adj_cell->vertex_ids)
-//              if (cfvid == acvid) {vertex_found = true; break;}
-//
-//            if (not vertex_found) { adj_cell_matches = false; break;}
-//          }
 
           if (adj_cell_matches)
           {

--- a/CHI_TECH/ChiMesh/VolumeMesher/Predefined3D/volmesher_predefined3d_execute.cc
+++ b/CHI_TECH/ChiMesh/VolumeMesher/Predefined3D/volmesher_predefined3d_execute.cc
@@ -114,16 +114,40 @@ void chi_mesh::VolumeMesherPredefined3D::Execute()
           if (adj_cell_id == c) continue;
           auto adj_cell = umesh->raw_cells[adj_cell_id];
 
-          //Assume it matches now disprove
-          bool adj_cell_matches = true;
-          for (auto cfvid : face.vertex_ids)
+          bool adj_cell_matches = false;
+          for (auto& aface : adj_cell->faces)
           {
-            bool vertex_found=false;
-            for (auto acvid : adj_cell->vertex_ids)
-              if (cfvid == acvid) {vertex_found = true; break;}
+            bool face_matches=true;
+            for (auto cfvid : face.vertex_ids)
+            {
+              bool vertex_found = false;
+              for (auto afvid : aface.vertex_ids)
+                if (cfvid == afvid) {vertex_found = true; break;}
 
-            if (not vertex_found) { adj_cell_matches = false; break;}
+              if (not vertex_found)
+              {
+                face_matches = false;
+                break;
+              }
+            }
+
+            if (face_matches)
+            {
+              adj_cell_matches = true;
+              break;
+            }
           }
+
+          //Assume it matches now disprove
+//          bool adj_cell_matches = true;
+//          for (auto cfvid : face.vertex_ids)
+//          {
+//            bool vertex_found=false;
+//            for (auto acvid : adj_cell->vertex_ids)
+//              if (cfvid == acvid) {vertex_found = true; break;}
+//
+//            if (not vertex_found) { adj_cell_matches = false; break;}
+//          }
 
           if (adj_cell_matches)
           {

--- a/CHI_TECH/ChiMesh/VolumeMesher/Predefined3D/volmesher_predefined3d_kba.cc
+++ b/CHI_TECH/ChiMesh/VolumeMesher/Predefined3D/volmesher_predefined3d_kba.cc
@@ -1,0 +1,160 @@
+#include "volmesher_predefined3d.h"
+
+#include "ChiMesh/MeshHandler/chi_meshhandler.h"
+#include "ChiMesh/SurfaceMesher/surfacemesher.h"
+#include "ChiMesh/VolumeMesher/chi_volumemesher.h"
+#include "ChiMesh/MeshContinuum/chi_meshcontinuum.h"
+#include "ChiMesh/Cell/cell_polyhedron.h"
+
+
+#include "chi_log.h"
+#include "chi_mpi.h"
+
+extern ChiLog& chi_log;
+extern ChiMPI& chi_mpi;
+
+//###################################################################
+/**Gets the partition ID from a centroid for KBA-style partitioning.*/
+int chi_mesh::VolumeMesherPredefined3D::
+  GetPartitionIDFromCentroid(const chi_mesh::Vertex& centroid)
+{
+  auto handler = chi_mesh::GetCurrentHandler();
+
+  int Px = handler->surface_mesher->partitioning_x;
+  int Py = handler->surface_mesher->partitioning_y;
+
+
+  chi_mesh::Cell temp_cell(chi_mesh::CellType::GHOST);
+  temp_cell.centroid = centroid;
+
+  auto xyz = GetCellXYZPartitionID(&temp_cell);
+
+  int nxi = std::get<0>(xyz);
+  int nyi = std::get<1>(xyz);
+  int nzi = std::get<2>(xyz);
+
+  return nzi*Px*Py + nyi*Px + nxi;
+}
+
+//###################################################################
+/**Determines if a chi_mesh::UnpartitionedMesh::LightWeightCell is a
+ * neighbor to the current partition for KBA-style partitioning.
+ * This method loops over the faces of the lightweight cell and
+ * determines the partition-id of each the neighbors. If the neighbor
+ * has a partition id equal to that of the current process then
+ * it means this reference cell is a neighbor.*/
+bool chi_mesh::VolumeMesherPredefined3D::
+  IsRawCellNeighborToPartitionKBA(
+  const chi_mesh::UnpartitionedMesh::LightWeightCell& lwcell)
+{
+  auto handler = chi_mesh::GetCurrentHandler();
+
+  auto umesh = handler->unpartitionedmesh_stack.back();
+
+  bool is_neighbor = false;
+  for (const auto& face : lwcell.faces)
+  {
+    if (face.neighbor < 0) continue;
+    auto adj_cell = umesh->raw_cells[face.neighbor];
+    int partition_id = GetPartitionIDFromCentroid(adj_cell->centroid);
+    if (partition_id == chi_mpi.location_id)
+    {
+      is_neighbor = true;
+      break;
+    }
+  }
+
+  return is_neighbor;
+}
+
+//###################################################################
+/** Applies KBA-style partitioning to the mesh.*/
+void chi_mesh::VolumeMesherPredefined3D::
+  KBA(chi_mesh::UnpartitionedMesh* umesh,
+      chi_mesh::MeshContinuum* grid)
+{
+  //======================================== Load up the vertices
+  for (auto vert : umesh->vertices)
+    grid->vertices.push_back(new chi_mesh::Vertex(*vert));
+
+  chi_log.Log(LOG_0) << "Vertices loaded.";
+  MPI_Barrier(MPI_COMM_WORLD);
+
+  int loc_id = chi_mpi.location_id;
+
+  //======================================== Load up the cells
+  int global_id=-1;
+  for (auto raw_cell : umesh->raw_cells)
+  {
+    ++global_id;
+    auto temp_cell = new chi_mesh::Cell(chi_mesh::CellType::GHOST);
+    temp_cell->centroid = raw_cell->centroid;
+    temp_cell->global_id = global_id;
+    temp_cell->partition_id = GetPartitionIDFromCentroid(temp_cell->centroid);
+    temp_cell->material_id = raw_cell->material_id;
+
+//    printf("[%d] Bla\n",loc_id);
+
+    if (temp_cell->partition_id != chi_mpi.location_id)
+    {
+//      printf("[%d] Bla1\n",loc_id);
+      if (IsRawCellNeighborToPartitionKBA(*raw_cell))
+        grid->cells.push_back(temp_cell);
+      else
+        delete temp_cell;
+
+//      printf("[%d] Bla2\n",loc_id);
+    }
+    else
+    {
+//      printf("[%d] Bla3\n",loc_id);
+      auto polyh_cell = new chi_mesh::CellPolyhedron;
+      polyh_cell->centroid = temp_cell->centroid;
+      polyh_cell->global_id = temp_cell->global_id;
+      polyh_cell->partition_id = temp_cell->partition_id;
+      polyh_cell->material_id = temp_cell->material_id;
+
+      polyh_cell->vertex_ids = raw_cell->vertex_ids;
+
+      for (auto& raw_face : raw_cell->faces)
+      {
+        chi_mesh::CellFace newFace;
+
+        newFace.neighbor = raw_face.neighbor;
+
+        newFace.vertex_ids = raw_face.vertex_ids;
+        auto vfc = chi_mesh::Vertex(0.0, 0.0, 0.0);
+        for (auto fvid : newFace.vertex_ids)
+          vfc = vfc + *grid->vertices[fvid];
+        newFace.centroid = vfc / newFace.vertex_ids.size();
+
+        //Compute normal
+//        auto va = *grid->vertices[newFace.vertex_ids[0]] - vfc;
+//        auto vb = *grid->vertices[newFace.vertex_ids[1]] - vfc;
+//
+//        auto vn = va.Cross(vb);
+//        newFace.normal = vn/vn.Norm();
+
+        newFace.normal = chi_mesh::Normal(0.0,0.0,0.0);
+        int last_vert_ind = newFace.vertex_ids.size()-1;
+        for (int fv=0; fv<newFace.vertex_ids.size(); ++fv)
+        {
+          int fvid_m = newFace.vertex_ids[fv];
+          int fvid_p = (fv == last_vert_ind)? newFace.vertex_ids[0] :
+                       newFace.vertex_ids[fv+1];
+          auto leg_m = *grid->vertices[fvid_m] - newFace.centroid;
+          auto leg_p = *grid->vertices[fvid_p] - newFace.centroid;
+
+          auto vn = leg_m.Cross(leg_p);
+
+          newFace.normal = newFace.normal + vn.Normalized();
+        }
+        newFace.normal = (newFace.normal/newFace.vertex_ids.size()).Normalized();
+
+        polyh_cell->faces.push_back(newFace);
+      }
+
+      grid->cells.push_back(polyh_cell);
+    }//else
+  }
+}

--- a/CHI_TECH/ChiMesh/VolumeMesher/Predefined3D/volmesher_predefined3d_parmetis.cc
+++ b/CHI_TECH/ChiMesh/VolumeMesher/Predefined3D/volmesher_predefined3d_parmetis.cc
@@ -1,0 +1,205 @@
+#include "volmesher_predefined3d.h"
+
+#include "ChiMesh/MeshHandler/chi_meshhandler.h"
+#include "ChiMesh/MeshContinuum/chi_meshcontinuum.h"
+#include "ChiMesh/Cell/cell_polyhedron.h"
+
+#include "chi_log.h"
+#include "chi_mpi.h"
+
+extern ChiLog& chi_log;
+extern ChiMPI& chi_mpi;
+
+#include "petsc.h"
+
+//###################################################################
+/**Determines if a chi_mesh::UnpartitionedMesh::LightWeightCell is a
+ * neighbor to the current partition for ParMETIS-style partitioning.
+ * This method loops over the faces of the lightweight cell and
+ * determines the partition-id of each the neighbors. If the neighbor
+ * has a partition id equal to that of the current process then
+ * it means this reference cell is a neighbor.*/
+bool chi_mesh::VolumeMesherPredefined3D::
+  IsRawCellNeighborToPartitionParmetis(
+    const chi_mesh::UnpartitionedMesh::LightWeightCell& lwcell,
+    const std::vector<int>& cell_pids)
+{
+  auto handler = chi_mesh::GetCurrentHandler();
+
+  auto umesh = handler->unpartitionedmesh_stack.back();
+
+  bool is_neighbor = false;
+  for (const auto& face : lwcell.faces)
+  {
+    if (face.neighbor < 0) continue;
+    auto adj_cell = umesh->raw_cells[face.neighbor];
+    int partition_id = cell_pids[face.neighbor];
+    if (partition_id == chi_mpi.location_id)
+    {
+      is_neighbor = true;
+      break;
+    }
+  }
+
+  return is_neighbor;
+}
+
+//###################################################################
+/** Applies KBA-style partitioning to the mesh.*/
+void chi_mesh::VolumeMesherPredefined3D::
+  PARMETIS(chi_mesh::UnpartitionedMesh* umesh,
+           chi_mesh::MeshContinuum* grid)
+{
+  chi_log.Log(LOG_0) << "Partitioning mesh.";
+  std::vector<int> cell_pids(umesh->raw_cells.size(),0);
+  if (chi_mpi.location_id == 0)
+  {
+    //======================================== Build indices
+    std::vector<int> i_indices(umesh->raw_cells.size()+1,0);
+    std::vector<int> j_indices;
+    int i=-1;
+    int icount = 0;
+    for (auto cell : umesh->raw_cells)
+    {
+      ++i;
+      i_indices[i] = icount;
+
+      for (auto& face : cell->faces)
+        if (face.neighbor >= 0)
+        {
+          j_indices.push_back(face.neighbor);
+          ++icount;
+        }
+    }
+    i_indices[i+1] = icount+1;
+    chi_log.Log(LOG_0VERBOSE_1) << "Done building indices.";
+
+    //======================================== Copy to raw arrays
+    int* i_indices_raw; // = new int[i_indices.size()];
+    int* j_indices_raw; // = new int[j_indices.size()];
+    PetscMalloc(i_indices.size()*sizeof(int),&i_indices_raw);
+    PetscMalloc(j_indices.size()*sizeof(int),&j_indices_raw);
+
+    for (int j=0; j<i_indices.size(); ++j)
+      i_indices_raw[j] = i_indices[j];
+
+    for (int j=0; j<j_indices.size(); ++j)
+      j_indices_raw[j] = j_indices[j];
+
+    chi_log.Log(LOG_0VERBOSE_1) << "Done copying to raw indices.";
+
+    //========================================= Create adjacency matrix
+    Mat Adj; //Adjacency matrix
+    MatCreateMPIAdj(PETSC_COMM_SELF,
+                    (int)umesh->raw_cells.size(),
+                    (int)umesh->raw_cells.size(),
+                    i_indices_raw,j_indices_raw,NULL,&Adj);
+
+    chi_log.Log(LOG_0VERBOSE_1) << "Done creating adjacency matrix.";
+
+    //========================================= Create partitioning
+    MatPartitioning part;
+    IS is,isg;
+    MatPartitioningCreate(MPI_COMM_SELF,&part);
+    MatPartitioningSetAdjacency(part,Adj);
+    MatPartitioningSetType(part,"parmetis");
+    MatPartitioningSetNParts(part,chi_mpi.process_count);
+    MatPartitioningApply(part,&is);
+    MatPartitioningDestroy(&part);
+    MatDestroy(&Adj);
+    ISPartitioningToNumbering(is,&isg);
+
+    chi_log.Log(LOG_0VERBOSE_1) << "Done building paritioned index set.";
+
+    //========================================= Get cell global indices
+    const int* cell_pids_raw;
+    ISGetIndices(is,&cell_pids_raw);
+    i=0;
+    for (auto cell : umesh->raw_cells)
+    {
+      cell_pids[i] = cell_pids_raw[i];
+      ++i;
+    }
+    ISRestoreIndices(is,&cell_pids_raw);
+
+    chi_log.Log(LOG_0VERBOSE_1) << "Done retrieving cell global indices.";
+  }
+
+  //======================================== Broadcast partitioning to all
+  //                                         locations
+  MPI_Bcast(cell_pids.data(),        //buffer [IN/OUT]
+            umesh->raw_cells.size(), //count
+            MPI_INT,                 //data type
+            0,                       //root
+            MPI_COMM_WORLD);         //communicator
+  chi_log.Log(LOG_0) << "Done partitioning mesh.";
+
+  //======================================== Load up the vertices
+  for (auto vert : umesh->vertices)
+    grid->vertices.push_back(new chi_mesh::Vertex(*vert));
+
+  MPI_Barrier(MPI_COMM_WORLD);
+
+  //======================================== Load up the cells
+  int global_id=-1;
+  for (auto raw_cell : umesh->raw_cells)
+  {
+    ++global_id;
+    auto temp_cell = new chi_mesh::Cell(chi_mesh::CellType::GHOST);
+    temp_cell->centroid = raw_cell->centroid;
+    temp_cell->global_id = global_id;
+    temp_cell->partition_id = cell_pids[global_id];
+    temp_cell->material_id = raw_cell->material_id;
+
+    if (temp_cell->partition_id != chi_mpi.location_id)
+    {
+      if (IsRawCellNeighborToPartitionParmetis(*raw_cell,cell_pids))
+        grid->cells.push_back(temp_cell);
+      else
+        delete temp_cell;
+    }
+    else
+    {
+      auto polyh_cell = new chi_mesh::CellPolyhedron;
+      polyh_cell->centroid = temp_cell->centroid;
+      polyh_cell->global_id = temp_cell->global_id;
+      polyh_cell->partition_id = temp_cell->partition_id;
+      polyh_cell->material_id = temp_cell->material_id;
+
+      polyh_cell->vertex_ids = raw_cell->vertex_ids;
+
+      for (auto& raw_face : raw_cell->faces)
+      {
+        chi_mesh::CellFace newFace;
+
+        newFace.neighbor = raw_face.neighbor;
+
+        newFace.vertex_ids = raw_face.vertex_ids;
+        auto vfc = chi_mesh::Vertex(0.0, 0.0, 0.0);
+        for (auto fvid : newFace.vertex_ids)
+          vfc = vfc + *grid->vertices[fvid];
+        newFace.centroid = vfc / newFace.vertex_ids.size();
+
+        newFace.normal = chi_mesh::Normal(0.0,0.0,0.0);
+        int last_vert_ind = newFace.vertex_ids.size()-1;
+        for (int fv=0; fv<newFace.vertex_ids.size(); ++fv)
+        {
+          int fvid_m = newFace.vertex_ids[fv];
+          int fvid_p = (fv == last_vert_ind)? newFace.vertex_ids[0] :
+                       newFace.vertex_ids[fv+1];
+          auto leg_m = *grid->vertices[fvid_m] - newFace.centroid;
+          auto leg_p = *grid->vertices[fvid_p] - newFace.centroid;
+
+          auto vn = leg_m.Cross(leg_p);
+
+          newFace.normal = newFace.normal + vn.Normalized();
+        }
+        newFace.normal = (newFace.normal/newFace.vertex_ids.size()).Normalized();
+
+        polyh_cell->faces.push_back(newFace);
+      }
+
+      grid->cells.push_back(polyh_cell);
+    }//else
+  }
+}

--- a/CHI_TECH/ChiMesh/VolumeMesher/lua/volumemesher_setproperty.cc
+++ b/CHI_TECH/ChiMesh/VolumeMesher/lua/volumemesher_setproperty.cc
@@ -19,21 +19,32 @@ extern ChiLog& chi_log;
 
 ###PropertyIndex:
  FORCE_POLYGONS = <B>PropertyValue:[bool]</B> Forces the 2D Meshing to use
-                  polygon cells even if the
- underlying surface mesh is triangles. Expects a boolean value.\n
+                  polygon cells even if the underlying surface mesh is
+                  triangles. Expects a boolean value.\n
+ MESH_GLOBAL = <B>PropertyValue:[bool]</B> Generate/Read the full mesh at each
+               location. Expects a boolean value [Default=true].
+ PARTITION_TYPE = <B>PartitionType</B>. See below.
  EXTRUSION_LAYER = <B>PropertyValue:[double,(int),(char)]</B> Adds a layer to the
                    extruder volume mesher if it exists.
                    Expects 1 required parameter, the layer height, followed by 2 optional
                    parameters: number of subdivisions (defaults to 1), and layer id (char)(defaults
-                   to nothing).\n
- MESH_GLOBAL = <B>PropertyValue:[bool]</B> Generate/Read the full mesh at each
-               location. Expects a boolean value [Default=true].\n
- CUT_X = Adds a cut at the given x-value.\n
- CUT_Y = Adds a cut at the given y-value.\n
- CUT_Z = Adds a cut at the given z-value.\n
- PARTITION_X   = <B>PropertyValue:[int]</B> Number of partitions in X.\n
- PARTITION_Y   = <B>PropertyValue:[int]</B> Number of partitions in Y.\n
- PARTITION_Z   = <B>PropertyValue:[int]</B> Number of partitions in Z.\n
+                   to nothing). Only supported if partition-type is
+                   ```KBA_STYLE_XY``` or ```KBA_STYLE_XYZ```. \n
+ CUT_X = Adds a cut at the given x-value. Only supported if partition-type is
+                   ```KBA_STYLE_XY``` or ```KBA_STYLE_XYZ```.\n
+ CUT_Y = Adds a cut at the given y-value. Only supported if partition-type is
+                   ```KBA_STYLE_XY``` or ```KBA_STYLE_XYZ```.\n
+ CUT_Z = Adds a cut at the given z-value. Only supported if partition-type is
+                   ```KBA_STYLE_XY``` or ```KBA_STYLE_XYZ```.\n
+ PARTITION_X   = <B>PropertyValue:[int]</B> Number of partitions in X.
+                    Only supported if partition-type is
+                   ```KBA_STYLE_XY``` or ```KBA_STYLE_XYZ```.\n
+ PARTITION_Y   = <B>PropertyValue:[int]</B> Number of partitions in Y.
+                    Only supported if partition-type is
+                   ```KBA_STYLE_XY``` or ```KBA_STYLE_XYZ```.\n
+ PARTITION_Z   = <B>PropertyValue:[int]</B> Number of partitions in Z.
+                    Only supported if partition-type is
+                   ```KBA_STYLE_XY``` or ```KBA_STYLE_XYZ```.\n
  MATID_FROMLOGICAL = <B>LogicalVolumeHandle:[int],Mat_id:[int],
                      Sense:[bool](Optional, default:true)</B> Sets the material
                      id of cells that meet the sense requirement for the given
@@ -44,6 +55,13 @@ extern ChiLog& chi_log;
                      that meet the sense requirement for the given
                      logical volume.\n
 
+## _
+
+### PartitionType
+Can be any of the following:
+ - KBA_STYLE_XY
+ - KBA_STYLE_XYZ
+ - PARMETIS
 
 \ingroup LuaVolumeMesher
 \author Jan*/

--- a/CHI_TECH/ChiMesh/chi_mesh_utilities.cc
+++ b/CHI_TECH/ChiMesh/chi_mesh_utilities.cc
@@ -177,7 +177,7 @@ void chi_mesh::Create3DOrthoMesh(std::vector<double>& vertices_x,
 }
 
 //###################################################################
-/**Returns a 3D vector multiplied by the given scalar.*/
+/**Returns a 3D vector multiplied by the given scalar from the left.*/
 chi_mesh::Vector3 operator*(double value,const chi_mesh::Vector3& a)
 {
   chi_mesh::Vector3 newVector;

--- a/CHI_TECH/ChiMesh/chi_meshvector.h
+++ b/CHI_TECH/ChiMesh/chi_meshvector.h
@@ -92,6 +92,17 @@ struct chi_mesh::Vector3
     return newVector;
   }
 
+  /**Vector component-wise division.*/
+  Vector3 operator/(const Vector3& that) const
+  {
+    Vector3 newVector;
+    newVector.x = this->x/that.x;
+    newVector.y = this->y/that.y;
+    newVector.z = this->z/that.z;
+
+    return newVector;
+  }
+
   /**Returns a copy of the value at the given index.*/
   double operator[](int i) const
   {

--- a/CHI_TECH/ChiMesh/chi_meshvector.h
+++ b/CHI_TECH/ChiMesh/chi_meshvector.h
@@ -4,7 +4,7 @@
 #include <sstream>
 
 //=============================================== General 3D vector structure
-/**General vertex structure*/
+/**General vector structure. */
 struct chi_mesh::Vector3
 {
   double x;
@@ -27,6 +27,7 @@ struct chi_mesh::Vector3
     x=a; y=b; z=c;
   }
 
+  /**Component-wise addition.*/
   Vector3 operator+(const Vector3& that) const
   {
     Vector3 newVector;
@@ -37,6 +38,7 @@ struct chi_mesh::Vector3
     return newVector;
   }
 
+  /**Component-wise subtraction.*/
   Vector3 operator-(const Vector3& that) const
   {
     Vector3 newVector;
@@ -47,6 +49,7 @@ struct chi_mesh::Vector3
     return newVector;
   }
 
+  /**Component-wise copy.*/
   Vector3& operator=(const Vector3& that)
   {
     this->x = that.x;
@@ -56,6 +59,7 @@ struct chi_mesh::Vector3
     return *this;
   }
 
+  /**Vector component-wise multiplication by scalar.*/
   Vector3 operator*(double value) const
   {
     Vector3 newVector;
@@ -66,6 +70,18 @@ struct chi_mesh::Vector3
     return newVector;
   }
 
+  /**Vector component-wise multiplication.*/
+  Vector3 operator*(const Vector3& that) const
+  {
+    Vector3 newVector;
+    newVector.x = this->x*that.x;
+    newVector.y = this->y*that.y;
+    newVector.z = this->z*that.z;
+
+    return newVector;
+  }
+
+  /**Vector component-wise division by scalar.*/
   Vector3 operator/(double value) const
   {
     Vector3 newVector;
@@ -76,6 +92,27 @@ struct chi_mesh::Vector3
     return newVector;
   }
 
+  /**Returns a copy of the value at the given index.*/
+  double operator[](int i) const
+  {
+         if (i==0) return this->x;
+    else if (i==1) return this->y;
+    else if (i==2) return this->z;
+
+    return 0.0;
+  }
+
+  /**Returns a reference of the value at the given index.*/
+  double& operator()(int i)
+  {
+    if (i==0)      return this->x;
+    else if (i==1) return this->y;
+    else if (i==2) return this->z;
+
+    return this->x;
+  }
+
+  /**Vector cross-product.*/
   Vector3 Cross(const Vector3& that) const
   {
     Vector3 newVector;
@@ -86,6 +123,7 @@ struct chi_mesh::Vector3
     return newVector;
   }
 
+  /**Vector dot-product.*/
   double Dot(const Vector3& that) const
   {
     double value = 0.0;
@@ -96,6 +134,7 @@ struct chi_mesh::Vector3
     return value;
   }
 
+  /**Normalizes the vector in-place.*/
   void Normalize()
   {
     double norm = this->Norm();
@@ -105,6 +144,7 @@ struct chi_mesh::Vector3
     z /= norm;
   }
 
+  /**Returns a normalized version of the vector.*/
   Vector3 Normalized() const
   {
     double norm = this->Norm();
@@ -118,8 +158,22 @@ struct chi_mesh::Vector3
   }
 
   /**Returns a vector v^* where each element is inverted provided
-   * that it is greater than the given tolerance, otherwise it is zeroed.*/
-  Vector3 InverseZeroIfGreater(double tol) const
+   * that it is greater than the given tolerance, otherwise the offending entry
+   * is set to 0.0.*/
+  Vector3 InverseZeroIfSmaller(double tol) const
+  {
+    Vector3 newVector;
+    newVector.x = (std::fabs(this->x)>tol)? 1.0/this->x : 0.0;
+    newVector.y = (std::fabs(this->y)>tol)? 1.0/this->y : 0.0;
+    newVector.z = (std::fabs(this->z)>tol)? 1.0/this->z : 0.0;
+
+    return newVector;
+  }
+
+  /**Returns a vector v^* where each element is inverted provided
+   * that it is greater than the given tolerance, otherwise the offending entry
+   * is set to 1.0.*/
+  Vector3 InverseOneIfSmaller(double tol) const
   {
     Vector3 newVector;
     newVector.x = (std::fabs(this->x)>tol)? 1.0/this->x : 0.0;
@@ -145,6 +199,8 @@ struct chi_mesh::Vector3
     return newVector;
   }
 
+  /**Computes the L2-norm of the vector. Otherwise known as the length of
+   * a 3D vector.*/
   double Norm() const
   {
     double value = 0.0;
@@ -157,6 +213,9 @@ struct chi_mesh::Vector3
     return value;
   }
 
+  /**Computes the square of the L2-norm of the vector. This eliminates the
+   * usage of the square root and is therefore less expensive that a proper
+   * L2-norm. Useful if only comparing distances.*/
   double NormSquare()
   {
     double value = 0.0;
@@ -167,6 +226,7 @@ struct chi_mesh::Vector3
     return value;
   }
 
+  /**Prints the vector to std::cout.*/
   void Print()
   {
     std::cout<<this->x << " ";
@@ -181,6 +241,7 @@ struct chi_mesh::Vector3
     return out;
   }
 
+  /**Prints the vector to a string and then returns the string.*/
   std::string PrintS() const
   {
     std::stringstream out;
@@ -190,14 +251,8 @@ struct chi_mesh::Vector3
   }
 };
 
+//The following functions are defined in chi_mesh_utilities.cc
+
 chi_mesh::Vector3 operator*(double value,const chi_mesh::Vector3& a);
-//{
-//  chi_mesh::Vector3 newVector;
-//  newVector.x = a.x*value;
-//  newVector.y = a.y*value;
-//  newVector.z = a.z*value;
-//
-//  return newVector;
-//}
 
 #endif

--- a/CHI_TECH/LuaTest/lua_test.cc
+++ b/CHI_TECH/LuaTest/lua_test.cc
@@ -1,6 +1,8 @@
 #include <ChiLua/chi_lua.h>
 
-#include "ChiMath/SparseMatrix/chi_math_sparse_matrix.h"
+#include "ChiMesh/chi_mesh.h"
+#include "ChiMesh/MeshHandler/chi_meshhandler.h"
+#include "ChiMesh/MeshContinuum/chi_meshcontinuum.h"
 
 #include <chi_log.h>
 
@@ -13,33 +15,17 @@ extern ChiLog& chi_log;
  */
 int chiLuaTest(lua_State* L)
 {
-  chi_math::SparseMatrix A(5,5);
+  auto mesh_handler = chi_mesh::GetCurrentHandler();
+  auto grid = mesh_handler->GetGrid();
 
-  std::cout << A.PrintS();
-
-  A.Insert(0,4,20.0);
-  A.Insert(0,0,2.0);
-  A.Insert(0,1,-1.0);
-  A.InsertAdd(0,1,-1.0);
-
-  A.Compress();
-
-  std::cout << std::endl;
-
-  std::cout << A.PrintS();
-
-  std::cout << std::endl;
-
-  auto& indicesJ_rowI = A.rowI_indices[0];
-  auto& valuesJ_rowI  = A.rowI_values[0];
-
-  auto j = indicesJ_rowI.begin();
-  auto v = valuesJ_rowI.begin();
-  for (; j!= indicesJ_rowI.end(); ++j,++v)
+  for (auto& cell : grid->local_cells)
   {
-    std::cout << *j << " " << *v << "\n";
+    for (auto& face : cell.faces)
+    {
+      if (face.neighbor >= 0)
+        face.GetNeighborAssociatedFace(grid);
+    }
   }
-  std::cout << std::endl;
 
   return 0;
 }

--- a/CHI_TEST/Transport3D_5Cycles2.lua
+++ b/CHI_TEST/Transport3D_5Cycles2.lua
@@ -44,9 +44,9 @@ for g=1,num_groups do
     src[g] = 0.0
 end
 
-chiPhysicsMaterialSetProperty(materials[1],ISOTROPIC_MG_SOURCE,FROM_ARRAY,src)
-src[1]=1.0
 chiPhysicsMaterialSetProperty(materials[2],ISOTROPIC_MG_SOURCE,FROM_ARRAY,src)
+src[1]=1.0
+chiPhysicsMaterialSetProperty(materials[1],ISOTROPIC_MG_SOURCE,FROM_ARRAY,src)
 
 
 

--- a/CHI_TEST/Transport3D_6Cycles3.lua
+++ b/CHI_TEST/Transport3D_6Cycles3.lua
@@ -1,0 +1,147 @@
+chiMeshHandlerCreate()
+
+chiUnpartitionedMeshFromEnsightGold("CHI_RESOURCES/TestObjects/Sphere.case")
+
+region1 = chiRegionCreate()
+chiRegionAddEmptyBoundary(region1)
+
+chiSurfaceMesherCreate(SURFACEMESHER_PREDEFINED)
+chiVolumeMesherCreate(VOLUMEMESHER_PREDEFINED3D)
+
+chiVolumeMesherSetProperty(PARTITION_TYPE,PARMETIS)
+
+
+
+chiSurfaceMesherExecute()
+chiVolumeMesherExecute()
+
+chiRegionExportMeshToVTK(region1,"Mesh")
+
+
+--############################################### Add materials
+materials = {}
+materials[1] = chiPhysicsAddMaterial("Test Material");
+materials[2] = chiPhysicsAddMaterial("Test Material2");
+
+chiPhysicsMaterialAddProperty(materials[1],TRANSPORT_XSECTIONS)
+chiPhysicsMaterialAddProperty(materials[2],TRANSPORT_XSECTIONS)
+
+chiPhysicsMaterialAddProperty(materials[1],ISOTROPIC_MG_SOURCE)
+chiPhysicsMaterialAddProperty(materials[2],ISOTROPIC_MG_SOURCE)
+
+
+num_groups = 5
+chiPhysicsMaterialSetProperty(materials[1],TRANSPORT_XSECTIONS,
+        PDT_XSFILE,"CHI_TEST/xs_graphite_pure.data")
+chiPhysicsMaterialSetProperty(materials[2],TRANSPORT_XSECTIONS,
+        PDT_XSFILE,"CHI_TEST/xs_graphite_pure.data")
+
+src={}
+for g=1,num_groups do
+    src[g] = 0.0
+end
+
+chiPhysicsMaterialSetProperty(materials[1],ISOTROPIC_MG_SOURCE,FROM_ARRAY,src)
+src[1]=1.0
+chiPhysicsMaterialSetProperty(materials[2],ISOTROPIC_MG_SOURCE,FROM_ARRAY,src)
+
+
+
+--############################################### Setup Physics
+
+phys1 = chiLBSCreateSolver()
+chiSolverAddRegion(phys1,region1)
+
+--========== Groups
+grp = {}
+for g=1,num_groups do
+    grp[g] = chiLBSCreateGroup(phys1)
+end
+
+--========== ProdQuad
+pquad  = chiCreateProductQuadrature(GAUSS_LEGENDRE_CHEBYSHEV,2, 2)
+pquad2 = chiCreateProductQuadrature(GAUSS_LEGENDRE_CHEBYSHEV,8, 8)
+
+--========== Groupset def
+gs0 = chiLBSCreateGroupset(phys1)
+cur_gs = gs0
+chiLBSGroupsetAddGroups(phys1,cur_gs,0,num_groups-1)
+chiLBSGroupsetSetQuadrature(phys1,cur_gs,pquad2)
+chiLBSGroupsetSetAngleAggregationType(phys1,cur_gs,LBSGroupset.ANGLE_AGG_SINGLE)
+chiLBSGroupsetSetAngleAggDiv(phys1,cur_gs,1)
+chiLBSGroupsetSetGroupSubsets(phys1,cur_gs,1)
+chiLBSGroupsetSetIterativeMethod(phys1,cur_gs,NPT_GMRES_CYCLES)
+chiLBSGroupsetSetResidualTolerance(phys1,cur_gs,1.0e-6)
+if (master_export == nil) then
+    --chiLBSGroupsetSetEnableSweepLog(phys1,cur_gs,true)
+end
+--chiLBSGroupsetSetMaxIterations(phys1,cur_gs,10)
+chiLBSGroupsetSetGMRESRestartIntvl(phys1,cur_gs,100)
+
+--========== Boundary conditions
+bsrc={}
+for g=1,num_groups do
+    bsrc[g] = 0.0
+end
+bsrc[1] = 1.0/4.0/math.pi;
+--chiLBSSetProperty(phys1,BOUNDARY_CONDITION,ZMIN,LBSBoundaryTypes.INCIDENT_ISOTROPIC,bsrc);
+
+--========== Solvers
+chiLBSSetProperty(phys1,SCATTERING_ORDER,0)
+chiLBSSetProperty(phys1,DISCRETIZATION_METHOD,PWLD3D)
+
+chiLBSInitialize(phys1)
+chiLBSExecute(phys1)
+
+
+
+fflist,count = chiLBSGetScalarFieldFunctionList(phys1)
+--slices = {}
+--for k=1,count do
+--    slices[k] = chiFFInterpolationCreate(SLICE)
+--    chiFFInterpolationSetProperty(slices[k],SLICE_POINT,0.0,0.0,0.8001)
+--    chiFFInterpolationSetProperty(slices[k],ADD_FIELDFUNCTION,fflist[k])
+--    --chiFFInterpolationSetProperty(slices[k],SLICE_TANGENT,0.393,1.0-0.393,0)
+--    --chiFFInterpolationSetProperty(slices[k],SLICE_NORMAL,-(1.0-0.393),-0.393,0.0)
+--    --chiFFInterpolationSetProperty(slices[k],SLICE_BINORM,0.0,0.0,1.0)
+--    chiFFInterpolationInitialize(slices[k])
+--    chiFFInterpolationExecute(slices[k])
+--    chiFFInterpolationExportPython(slices[k])
+--end
+
+vol0 = chiLogicalVolumeCreate(RPP,-1000,1000,-1000,1000,-1000,1000)
+ffi1 = chiFFInterpolationCreate(VOLUME)
+curffi = ffi1
+chiFFInterpolationSetProperty(curffi,OPERATION,OP_MAX)
+chiFFInterpolationSetProperty(curffi,LOGICAL_VOLUME,vol0)
+chiFFInterpolationSetProperty(curffi,ADD_FIELDFUNCTION,fflist[1])
+
+chiFFInterpolationInitialize(curffi)
+chiFFInterpolationExecute(curffi)
+maxval = chiFFInterpolationGetValue(curffi)
+
+chiLog(LOG_0,string.format("Max-value1=%.5e", maxval))
+
+ffi1 = chiFFInterpolationCreate(VOLUME)
+curffi = ffi1
+chiFFInterpolationSetProperty(curffi,OPERATION,OP_MAX)
+chiFFInterpolationSetProperty(curffi,LOGICAL_VOLUME,vol0)
+chiFFInterpolationSetProperty(curffi,ADD_FIELDFUNCTION,fflist[2])
+
+chiFFInterpolationInitialize(curffi)
+chiFFInterpolationExecute(curffi)
+maxval = chiFFInterpolationGetValue(curffi)
+
+chiLog(LOG_0,string.format("Max-value2=%.5e", maxval))
+
+if (chi_location_id == 0 and master_export == nil) then
+
+    --os.execute("python ZPFFI00.py")
+    ----os.execute("python ZPFFI11.py")
+    --local handle = io.popen("python ZPFFI00.py")
+    print("Execution completed")
+end
+
+if (master_export == nil) then
+    chiExportFieldFunctionToVTKG(fflist[1],"ZPhi3D","Phi")
+end

--- a/CHI_TEST/Transport3D_7Cycles4.lua
+++ b/CHI_TEST/Transport3D_7Cycles4.lua
@@ -1,6 +1,6 @@
 chiMeshHandlerCreate()
 
-chiUnpartitionedMeshFromEnsightGold("/Users/janv4/Desktop/GoogleDrive/Temp/DMDMeshes/Mesh3c.case",1.0)
+chiUnpartitionedMeshFromEnsightGold("/Users/janv4/Desktop/GoogleDrive/Temp/DMDMeshes/Mesh3c.case",2.0)
 
 region1 = chiRegionCreate()
 chiRegionAddEmptyBoundary(region1)

--- a/CHI_TEST/Transport3D_7Cycles4.lua
+++ b/CHI_TEST/Transport3D_7Cycles4.lua
@@ -1,0 +1,191 @@
+chiMeshHandlerCreate()
+
+chiUnpartitionedMeshFromEnsightGold("/Users/janv4/Desktop/GoogleDrive/Temp/DMDMeshes/Mesh3c.case",1.0)
+
+region1 = chiRegionCreate()
+chiRegionAddEmptyBoundary(region1)
+
+chiSurfaceMesherCreate(SURFACEMESHER_PREDEFINED)
+chiVolumeMesherCreate(VOLUMEMESHER_PREDEFINED3D)
+
+chiVolumeMesherSetProperty(PARTITION_TYPE,PARMETIS)
+
+
+
+chiSurfaceMesherExecute()
+chiVolumeMesherExecute()
+
+chiRegionExportMeshToVTK(region1,"Mesh")
+
+
+--############################################### Add materials
+materials = {}
+materials[1] = chiPhysicsAddMaterial("Air");
+materials[2] = chiPhysicsAddMaterial("Ground");
+materials[3] = chiPhysicsAddMaterial("ROI");
+materials[4] = chiPhysicsAddMaterial("Shield");
+materials[5] = chiPhysicsAddMaterial("Source");
+
+chiPhysicsMaterialAddProperty(materials[1],TRANSPORT_XSECTIONS)
+chiPhysicsMaterialAddProperty(materials[2],TRANSPORT_XSECTIONS)
+chiPhysicsMaterialAddProperty(materials[3],TRANSPORT_XSECTIONS)
+chiPhysicsMaterialAddProperty(materials[4],TRANSPORT_XSECTIONS)
+chiPhysicsMaterialAddProperty(materials[5],TRANSPORT_XSECTIONS)
+
+--chiPhysicsMaterialAddProperty(materials[1],ISOTROPIC_MG_SOURCE)
+--chiPhysicsMaterialAddProperty(materials[2],ISOTROPIC_MG_SOURCE)
+--chiPhysicsMaterialAddProperty(materials[3],ISOTROPIC_MG_SOURCE)
+--chiPhysicsMaterialAddProperty(materials[4],ISOTROPIC_MG_SOURCE)
+chiPhysicsMaterialAddProperty(materials[5],ISOTROPIC_MG_SOURCE)
+
+
+num_groups = 2
+--chiPhysicsMaterialSetProperty(materials[1],TRANSPORT_XSECTIONS,
+--        PDT_XSFILE,"CHI_TEST/xs_air50RH.data")
+--chiPhysicsMaterialSetProperty(materials[2],TRANSPORT_XSECTIONS,
+--        PDT_XSFILE,"CHI_TEST/xs_air50RH.data")
+--chiPhysicsMaterialSetProperty(materials[3],TRANSPORT_XSECTIONS,
+--        PDT_XSFILE,"CHI_TEST/xs_air50RH.data")
+--chiPhysicsMaterialSetProperty(materials[4],TRANSPORT_XSECTIONS,
+--        PDT_XSFILE,"CHI_TEST/xs_air50RH.data")
+--chiPhysicsMaterialSetProperty(materials[5],TRANSPORT_XSECTIONS,
+--        PDT_XSFILE,"CHI_TEST/xs_air50RH.data")
+
+for i=1,5 do
+    chiPhysicsMaterialSetProperty(materials[i],TRANSPORT_XSECTIONS,
+            SIMPLEXS1,num_groups,1.0,0.1)
+end
+
+
+src={}
+for g=1,num_groups do
+    src[g] = 0.0
+end
+
+--chiPhysicsMaterialSetProperty(materials[1],ISOTROPIC_MG_SOURCE,FROM_ARRAY,src)
+src[1]=1.0e10
+chiPhysicsMaterialSetProperty(materials[5],ISOTROPIC_MG_SOURCE,FROM_ARRAY,src)
+
+
+
+--############################################### Setup Physics
+
+phys1 = chiLBSCreateSolver()
+chiSolverAddRegion(phys1,region1)
+
+--========== Groups
+grp = {}
+for g=1,num_groups do
+    grp[g] = chiLBSCreateGroup(phys1)
+end
+
+--========== ProdQuad
+pquad  = chiCreateProductQuadrature(GAUSS_LEGENDRE_CHEBYSHEV,2, 2)
+pquad2 = chiCreateProductQuadrature(GAUSS_LEGENDRE_CHEBYSHEV,6, 6)
+
+--========== Groupset def
+gs0 = chiLBSCreateGroupset(phys1)
+cur_gs = gs0
+chiLBSGroupsetAddGroups(phys1,cur_gs,0,num_groups-1)
+chiLBSGroupsetSetQuadrature(phys1,cur_gs,pquad)
+chiLBSGroupsetSetAngleAggregationType(phys1,cur_gs,LBSGroupset.ANGLE_AGG_SINGLE)
+chiLBSGroupsetSetAngleAggDiv(phys1,cur_gs,1)
+chiLBSGroupsetSetGroupSubsets(phys1,cur_gs,1)
+chiLBSGroupsetSetIterativeMethod(phys1,cur_gs,NPT_GMRES_CYCLES)
+chiLBSGroupsetSetResidualTolerance(phys1,cur_gs,1.0e-6)
+if (master_export == nil) then
+    --chiLBSGroupsetSetEnableSweepLog(phys1,cur_gs,true)
+end
+--chiLBSGroupsetSetMaxIterations(phys1,cur_gs,10)
+chiLBSGroupsetSetGMRESRestartIntvl(phys1,cur_gs,100)
+
+--========== Boundary conditions
+bsrc={}
+for g=1,num_groups do
+    bsrc[g] = 0.0
+end
+bsrc[1] = 1.0e12/4.0/math.pi;
+--chiLBSSetProperty(phys1,BOUNDARY_CONDITION,ZMIN,LBSBoundaryTypes.INCIDENT_ISOTROPIC,bsrc);
+
+--========== Solvers
+chiLBSSetProperty(phys1,SCATTERING_ORDER,0)
+chiLBSSetProperty(phys1,DISCRETIZATION_METHOD,PWLD3D)
+
+chiLBSInitialize(phys1)
+chiLBSExecute(phys1)
+
+
+
+fflist,count = chiLBSGetScalarFieldFunctionList(phys1)
+--slices = {}
+--for k=1,count do
+--    slices[k] = chiFFInterpolationCreate(SLICE)
+--    chiFFInterpolationSetProperty(slices[k],SLICE_POINT,0.0,0.0,0.8001)
+--    chiFFInterpolationSetProperty(slices[k],ADD_FIELDFUNCTION,fflist[k])
+--    --chiFFInterpolationSetProperty(slices[k],SLICE_TANGENT,0.393,1.0-0.393,0)
+--    --chiFFInterpolationSetProperty(slices[k],SLICE_NORMAL,-(1.0-0.393),-0.393,0.0)
+--    --chiFFInterpolationSetProperty(slices[k],SLICE_BINORM,0.0,0.0,1.0)
+--    chiFFInterpolationInitialize(slices[k])
+--    chiFFInterpolationExecute(slices[k])
+--    chiFFInterpolationExportPython(slices[k])
+--end
+
+vol0 = chiLogicalVolumeCreate(RPP,-1000,1000,-1000,1000,-1000,1000)
+ffi1 = chiFFInterpolationCreate(VOLUME)
+curffi = ffi1
+chiFFInterpolationSetProperty(curffi,OPERATION,OP_MAX)
+chiFFInterpolationSetProperty(curffi,LOGICAL_VOLUME,vol0)
+chiFFInterpolationSetProperty(curffi,ADD_FIELDFUNCTION,fflist[1])
+
+chiFFInterpolationInitialize(curffi)
+chiFFInterpolationExecute(curffi)
+maxval = chiFFInterpolationGetValue(curffi)
+
+chiLog(LOG_0,string.format("Max-value1=%.5e", maxval))
+
+ffi1 = chiFFInterpolationCreate(VOLUME)
+curffi = ffi1
+chiFFInterpolationSetProperty(curffi,OPERATION,OP_MAX)
+chiFFInterpolationSetProperty(curffi,LOGICAL_VOLUME,vol0)
+chiFFInterpolationSetProperty(curffi,ADD_FIELDFUNCTION,fflist[2])
+
+chiFFInterpolationInitialize(curffi)
+chiFFInterpolationExecute(curffi)
+maxval = chiFFInterpolationGetValue(curffi)
+
+chiLog(LOG_0,string.format("Max-value2=%.5e", maxval))
+
+slice1 = chiFFInterpolationCreate(SLICE)
+
+--chiFFInterpolationSetProperty(slice1,SLICE_POINT,10000.0,10000.0,79900.0)
+--chiFFInterpolationSetProperty(slice1,SLICE_BINORM,0,0.0,-1.0)
+--chiFFInterpolationSetProperty(slice1,SLICE_TANGENT,100.0,135.71,0.0)
+--chiFFInterpolationSetProperty(slice1,SLICE_NORMAL,135.71,-100.0,0.0)
+
+chiFFInterpolationSetProperty(slice1,SLICE_POINT,0.0,0.0,0.0)
+chiFFInterpolationSetProperty(slice1,SLICE_BINORM,0,0.0,-1.0)
+chiFFInterpolationSetProperty(slice1,SLICE_TANGENT,1,0,0)
+chiFFInterpolationSetProperty(slice1,SLICE_NORMAL,0.0,-1,0.0)
+
+chiFFInterpolationSetProperty(slice1,ADD_FIELDFUNCTION,fflist[1])
+
+chiFFInterpolationInitialize(slice1)
+chiFFInterpolationExecute(slice1)
+
+if (master_export == nil) then
+    chiFFInterpolationExportPython(slice1)
+end
+
+if (chi_location_id == 0 and master_export == nil) then
+
+    --os.execute("python ZPFFI20.py")
+    ----os.execute("python ZPFFI11.py")
+    --local handle = io.popen("python ZPFFI00.py")
+    print("Execution completed")
+end
+
+if (master_export == nil) then
+    chiExportFieldFunctionToVTKG(fflist[1],"ZPhi3D","Phi")
+end
+
+


### PR DESCRIPTION
## Main highlights of this PR:

- Added ParMETIS partitioning to ```chi_mesh::VolumeMesherPredefined3D```.
- Fixed bug not reading VTK Tetrahedron.
- Added component-wise multiplication and division to chi_mesh::Vector3.
- Bug fix in the general logic of finding an adjacent cell's associated face given a current face.

## ParMETIS partitioning
The ```chi_mesh::VolumeMesherPredefined3D``` can now set its partition type to ```PARMETIS``` which will allow completely automated partitioning. Example usage in the input language is:

```lua
chiMeshHandlerCreate()

chiUnpartitionedMeshFromEnsightGold("P2.case",1.0)

region1 = chiRegionCreate()
chiRegionAddEmptyBoundary(region1)

chiSurfaceMesherCreate(SURFACEMESHER_PREDEFINED)
chiVolumeMesherCreate(VOLUMEMESHER_PREDEFINED3D)

chiVolumeMesherSetProperty(PARTITION_TYPE,PARMETIS)

chiSurfaceMesherExecute()
chiVolumeMesherExecute()
``` 

## Upgrades to ```chi_mesh::Vector3```
Some utilities have been added and include

```cpp
double a = 2.0;
double b = 3.0;
chi_mesh::Vector3 v;

auto w = a*v*b + a*v/b;
auto x = v*w; //Component wise multiplication
```

## Associated face bug
Given a face on a given cell, which we shall call the "current face", where the neighbor is not a boundary, we often seek which face, of the adjacent cell, maps to the current face. The faulty logic was to search the vertices of each of the adjacent cell's faces. If all of the current face's vertices were found on any adjacent cell's face then it was assumed that that face matched and the algorithm would move to it's next section. In all-tetrahedral and all-hexahedral meshes, this approach was sufficient, however, polyhedral meshes has a likely situation where all of the current face's vertices would be found in an adjacent cell's face but the adjacent cell's face vertices are not found in the current cell's face. 

This reared up in cell-connectivity routines and was fixed by using better STL functionality. The current face's vertices and the adjacent cell's face vertices are both inserted into a ```std::set<int>```. C++ then has the logical operation ```if (set_a == set_b)``` which can only be true if both faces have the same vertices AND the same amount of vertices. Note though that since we are using a set the vertices are ordered therefore catering for the fact the pair of faces have opposite right-hand-rule orientations. This is a much more elegant solution than the previous.

