### PR TITLE
Interface fixes

### DIFF
--- a/Modules/LinearBoltzmannSolver/GroupSet/lbs_groupset.h
+++ b/Modules/LinearBoltzmannSolver/GroupSet/lbs_groupset.h
@@ -78,18 +78,19 @@ public:
   /**
    * Convenient typdef for the moment call back function. See moment_callbacks.
    *  Arguments are:
-   *  int dof_mapping Local DOF-address with moment and group folded in.
-   *  int moment The moment number.
-   *  int angle_num The reference angle number in the angular quadrature
-   *  double psi Angular flux for the given dof and angle_num.
+   *  int cell_id, the value cell->local_id for the current cell
+   *  int dof_mapping, local DOF-address with moment and group folded in.
+   *  int dof_index, dof for the solution psi from ((CellFEView*)grid_fe_view->MapFeViewL(cell->local_id))->dofs
+   *  int moment, the moment number.
+   *  int angle_num, the reference angle number in the angular quadrature
+   *  double psi, angular flux for the given dof and angle_num.
    */
-  typedef std::function<void(int dof, int moment, int angle_num, double psi)> MomentCallbackF;
+  typedef std::function<void(int cell_id, int dof_mapping, int dof_index, int group, int moment, int angle_num, double psi)> MomentCallbackF;
   /**
    * Functions of type MomentCallbackF can be added to the moment_callbacks
    * vector and these can be called from within functions taking a
    * LBSGroupset instance. The intention is that this function can
-   * be used as a general interface to calculate specific types of
-   * moments beyond the simple scalar flux moments already accounted for
+   * be used as a general interface to retrieve angular flux values
    */
   std::vector<MomentCallbackF> moment_callbacks;
 

--- a/Modules/LinearBoltzmannSolver/SweepChunks/lbs_sweepchunk_pwl.h
+++ b/Modules/LinearBoltzmannSolver/SweepChunks/lbs_sweepchunk_pwl.h
@@ -268,13 +268,8 @@ public:
               (*x)[ir + gsg] += wn_d2m*b[gsg][i];
 
             for (auto callback : groupset->moment_callbacks)
-            {
-              if(callback)
-              {
-                for (int gsg = 0; gsg < gs_ss_size; ++gsg)
-                  callback(ir + gsg, m, angle_num, b[gsg][i]);
-              }
-            }
+              for (int gsg=0; gsg<gs_ss_size; gsg++)
+                callback(cell->local_id, ir+gsg, i, gsg, m, angle_num, b[gsg][i]);
           }
         }
 


### PR DESCRIPTION
This PR includes the following items:

1) In Modules/LinearBoltzmannSolver/lua/lbs_setproperty.cc, there are a number of places where a dynamic cast is performed, but the wrong pointer is checked for validity in the subsequent if statement
2) In class LBSGroupset, I changed the function MomentCallbackF. I added two additional arguments which are a cell_id and also another dof_index. Before there was a dof index that gave the transport_view dof, but if you had your own indexing, you need information about the fe_view dof so that's what I added. Also, knowing what cell the solution is for is useful and that is given by cell_id
3) I moved sweep_orderings from LinearBoltzmann::Solver to LBSGroupset and changed it from a vector of raw pointer to unique_ptr. Because of this, I also needed to go through and change places where pointers were passed to references since you don't want to be passing unique_ptrs around. This should better reflect pointer ownership and the fact that the arguments where pointers were being passed were not optional arguments and using a reference better reflects the fact that they are required information.