### PR TITLE
Minor fixes for ChiMath, ChiMesh, and CMake

### DIFF
--- a/CHI_TECH/ChiMath/Quadratures/SLDFESQ/sldfe_sq.h
+++ b/CHI_TECH/ChiMath/Quadratures/SLDFESQ/sldfe_sq.h
@@ -81,7 +81,8 @@ public:
     AngularQuadrature(chi_math::AngularQuadratureType::SLDFESQ)
   {}
 
-
+  virtual ~Quadrature()
+  {}
 
   //01
   void GenerateInitialRefinement(int level);

--- a/CHI_TECH/ChiMath/Quadratures/angular_quadrature_base.h
+++ b/CHI_TECH/ChiMath/Quadratures/angular_quadrature_base.h
@@ -45,11 +45,14 @@ protected:
 public:
   AngularQuadrature() :
   type(chi_math::AngularQuadratureType::Arbitrary)
-  {  }
+  {}
 
   AngularQuadrature(chi_math::AngularQuadratureType in_type) :
     type(in_type)
-  {  }
+  {}
+
+  virtual ~AngularQuadrature()
+  {} 
 
   virtual void
   InitializeWithCustom(std::vector<double>& azimuthal,

--- a/CHI_TECH/ChiMath/Quadratures/product_quadrature.h
+++ b/CHI_TECH/ChiMath/Quadratures/product_quadrature.h
@@ -27,10 +27,13 @@ public:
   std::vector<double>           azimu_ang;
 
 public:
-  //product_quadrature.cc
-       ProductQuadrature() :
-         AngularQuadrature(chi_math::AngularQuadratureType::ProductQuadrature)
-       {}
+  ProductQuadrature() :
+    AngularQuadrature(chi_math::AngularQuadratureType::ProductQuadrature)
+  {}
+
+  virtual ~ProductQuadrature()
+  {} 
+ 
   void InitializeWithGL(int Np, bool verbose=false);
   void InitializeWithGLL(int Na, int Np, bool verbose=false);
   void InitializeWithGLC(int Na, int Np, bool verbose=false);

--- a/CHI_TECH/ChiMath/SpatialDiscretization/PiecewiseLinear/CellViews/pwl_polyhedron.h
+++ b/CHI_TECH/ChiMath/SpatialDiscretization/PiecewiseLinear/CellViews/pwl_polyhedron.h
@@ -180,7 +180,7 @@ public:
   {
     for (auto& face : face_data)
       for (auto& side : face.sides)
-        side.qp_data = std::move(std::vector<FEqp_data3d>(0));
+        side.qp_data = std::vector<FEqp_data3d>(0);
   }
 
 };

--- a/CHI_TECH/ChiMesh/VolumeMesher/chi_volumemesher_01_utils.cc
+++ b/CHI_TECH/ChiMesh/VolumeMesher/chi_volumemesher_01_utils.cc
@@ -46,7 +46,7 @@ CreatePolygonCells(chi_mesh::SurfaceMesh *surface_mesh,
 
   //============================================= Delete nodes
   if (delete_surface_mesh_elements)
-    surface_mesh->vertices = std::move(std::vector<chi_mesh::Vertex>(0));
+    surface_mesh->vertices = std::vector<chi_mesh::Vertex>(0);
 
   //============================================= Process faces
   unsigned int num_cells = 0;

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,8 +57,11 @@ add_definitions(-DNO_FONTGENESIS)
 
 
 #================================================ Compiler flags
-if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wno-unused-variable")
+  set(CMAKE_CXX_FLAGS_DEBUG  "${CMAKE_CXX_FLAGS_DEBUG} -O0")
+elseif(CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wno-unused-variable -Wno-c++17-extensions")
   set(CMAKE_CXX_FLAGS_DEBUG  "${CMAKE_CXX_FLAGS_DEBUG} -O0")
 elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
   set(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -Wall -Wno-unused-variable")


### PR DESCRIPTION
Modifications to distinguish between AppleClang and Clang. Adding compiler option to squash warnings about nested namespaces with AppleClang. Fixes for various quadratures with missing destructors. Removing std::move in a couple of places to enable copy elision.