### PR TITLE
Improvements to VTU unpartitioned mesh reader

### DIFF
--- a/ChiTech/ChiMesh/UnpartitionedMesh/chi_unpartitioned_mesh.h
+++ b/ChiTech/ChiMesh/UnpartitionedMesh/chi_unpartitioned_mesh.h
@@ -65,6 +65,10 @@ public:
   static LightWeightCell* CreateCellFromVTKQuad(vtkCell* vtk_cell);
   static LightWeightCell* CreateCellFromVTKTriangle(vtkCell* vtk_cell);
 
+  static LightWeightCell* CreateCellFromVTKLine(vtkCell* vtk_cell);
+
+  static LightWeightCell* CreateCellFromVTKVertex(vtkCell* vtk_cell);
+
   void BuildMeshConnectivity();
   void ComputeCentroidsAndCheckQuality();
 

--- a/ChiTech/ChiMesh/UnpartitionedMesh/lua/create.cc
+++ b/ChiTech/ChiMesh/UnpartitionedMesh/lua/create.cc
@@ -11,6 +11,8 @@
 /**Creates an unpartitioned mesh from VTK Unstructured mesh files.
 
 \param file_name char Filename of the .vtu file.
+\param field char Name of the cell data field from which to read
+                  material and boundary identifiers (optional).
 
 \ingroup LuaUnpartitionedMesh
 
@@ -39,14 +41,18 @@ int chiUnpartitionedMeshFromVTU(lua_State* L)
 {
   const char func_name[] = "chiUnpartitionedMeshFromVTU";
   int num_args = lua_gettop(L);
-  if (num_args != 1)
+  if (num_args < 1)
     LuaPostArgAmountError(func_name,1,num_args);
 
   const char* temp = lua_tostring(L,1);
+  const char* field = "";
+  if (num_args >= 2) field = lua_tostring(L,2);
   auto new_object = new chi_mesh::UnpartitionedMesh;
 
   chi_mesh::UnpartitionedMesh::Options options;
   options.file_name = std::string(temp);
+  options.material_id_fieldname = field;
+  options.boundary_id_fieldname = field;
 
   new_object->ReadFromVTU(options);
 

--- a/ChiTech/ChiMesh/UnpartitionedMesh/lua/create.cc
+++ b/ChiTech/ChiMesh/UnpartitionedMesh/lua/create.cc
@@ -44,6 +44,9 @@ int chiUnpartitionedMeshFromVTU(lua_State* L)
   if (num_args < 1)
     LuaPostArgAmountError(func_name,1,num_args);
 
+  LuaCheckNilValue(func_name,L,1);
+  if (num_args >= 2) LuaCheckNilValue(func_name,L,2);
+
   const char* temp = lua_tostring(L,1);
   const char* field = "";
   if (num_args >= 2) field = lua_tostring(L,2);
@@ -100,6 +103,9 @@ int chiUnpartitionedMeshFromEnsightGold(lua_State* L)
   if (num_args <1)
     LuaPostArgAmountError(func_name,1,num_args);
 
+  LuaCheckNilValue(func_name,L,1);
+  if (num_args >= 2) LuaCheckNilValue(func_name,L,2);
+
   const char* temp = lua_tostring(L,1);
   double scale = 1.0;
   if (num_args >= 2) scale = lua_tonumber(L,2);
@@ -153,6 +159,8 @@ int chiUnpartitionedMeshFromWavefrontOBJ(lua_State* L)
   if (num_args <1)
     LuaPostArgAmountError(func_name,1,num_args);
 
+  LuaCheckNilValue(func_name,L,1);
+
   const char* temp = lua_tostring(L,1);
 
   auto new_object = new chi_mesh::UnpartitionedMesh;
@@ -204,6 +212,8 @@ int chiUnpartitionedMeshFromMshFormat(lua_State* L)
   int num_args = lua_gettop(L);
   if (num_args <1)
     LuaPostArgAmountError(func_name,1,num_args);
+
+  LuaCheckNilValue(func_name,L,1);
 
   const char* temp = lua_tostring(L,1);
 

--- a/ChiTech/ChiMesh/UnpartitionedMesh/unpartmesh_01_readfromvtu.cc
+++ b/ChiTech/ChiMesh/UnpartitionedMesh/unpartmesh_01_readfromvtu.cc
@@ -303,7 +303,6 @@ chi_mesh::UnpartitionedMesh::LightWeightCell* chi_mesh::UnpartitionedMesh::
 
   auto vtk_vertex  = vtkVertex::SafeDownCast(vtk_cell);
   auto num_cpoints = vtk_vertex->GetNumberOfPoints();
-  auto num_cfaces  = num_cpoints;
 
   point_cell->vertex_ids.reserve(num_cpoints);
   auto point_ids   = vtk_vertex->GetPointIds();
@@ -372,7 +371,7 @@ void chi_mesh::UnpartitionedMesh::
   }
 
   vtkDataArray* cell_id_array_ptr = nullptr;
-  if (options.material_id_fieldname.size() == 0)
+  if (options.material_id_fieldname.empty())
   {
     chi_log.Log(LOG_0)
       << "A user-supplied field name from which to recover cell identifiers "


### PR DESCRIPTION
Improvements to VTU unpartitioned mesh reader:
- ability to read one-, two- and three-dimensional meshes;
- ability to read material identifier and boundary identifier.

In reading a mesh of arbitrary dimension, the present algorithm involves two complete passes through the mesh: (1) to determine the maximum dimension of the cells of the mesh (assuming unordered cells) and (2) to reconstruct all cells encountered in the mesh file. The latter can be rendered more efficient if cells of dimension less than DIM-1 are bypassed, with DIM the maximum dimension of cells determined in the first pass. However, that optimisation may be best only after abandoning the present approach of counting cells by type that are encountered in the VTU file.

The reading of material identifiers and boundary identifiers assumes that the VTU mesh file may contain a vtkCellData field of arbitrary name and arbitrary type in which cell identifiers are stored. If the user provides the name of this field on input, the VTU reader reads the cell identifier from this field after having read the cell itself. Note that the GetTuple method of the class vtkDataArray is employed to extract the data from the field containing the cell identifier. This approach simplifies implementation but will produce incorrect results if the vtkCellData field of the VTU file contains non-integral values.