### PR TITLE
More specific nomenclature in TransportCrossSections.

### DIFF
--- a/ChiDoc/YReGenerateDocumentation.sh
+++ b/ChiDoc/YReGenerateDocumentation.sh
@@ -14,4 +14,3 @@ cd ../../..
 
 #============================== Making main documentation
 doxygen "ChiDoc/DoxyfileLua"
-cd CHI_BUILD

--- a/ChiModules/KEigenvalueSolver/IterativeMethods/power_iteration.cc
+++ b/ChiModules/KEigenvalueSolver/IterativeMethods/power_iteration.cc
@@ -48,12 +48,10 @@ void KEigenvalue::Solver::PowerIteration(LBSGroupset& groupset)
                                          phi_old_local.data()); 
 
   // ----- Start outer k iterations
-  double F_new = 0.0;
-  double F_prev = 1.0;
+  double F_new = 0.0;        //Production source new (0.0 is not used)
+  double F_prev = 1.0;       //Production source prev
   double k_eff_prev = k_eff;
-  double k_eff_change = 0.0;
-  double reactivity = 0.0;
-  int nit = 0;
+  int nit = 0;               //number of iterations
   bool k_converged = false;
 
   while (nit < options.max_iterations)
@@ -63,9 +61,7 @@ void KEigenvalue::Solver::PowerIteration(LBSGroupset& groupset)
 
 
     // ----- Start inner source iterations
-    double pw_change = 0.0;
     double pw_change_prev = 1.0;
-    double rho = 0.0;
     bool si_converged = false;
     for (int si_nit=0; si_nit<groupset.max_iterations; si_nit++)
     {
@@ -78,10 +74,10 @@ void KEigenvalue::Solver::PowerIteration(LBSGroupset& groupset)
       SweepScheduler.Sweep(*sweep_chunk);
 
       // ----- Compute convergence parameters
-      pw_change = ComputePiecewiseChange(groupset);
+      double pw_change = ComputePiecewiseChange(groupset);
       DisAssembleVectorLocalToLocal(groupset,phi_new_local.data(),
                                              phi_old_local.data());
-      rho = sqrt(pw_change/pw_change_prev);
+      double rho = sqrt(pw_change/pw_change_prev);
       pw_change_prev = pw_change;
       nit += 1;
 
@@ -124,10 +120,10 @@ void KEigenvalue::Solver::PowerIteration(LBSGroupset& groupset)
     // ----- Recompute eigenvalue
     F_new = ComputeProduction();
     k_eff = F_new/F_prev * k_eff;
-    reactivity = (k_eff - 1.0) / k_eff;
+    double reactivity = (k_eff - 1.0) / k_eff;
 
     // ----- Compute convergence parameters and bump values
-    k_eff_change = fabs(k_eff - k_eff_prev) / k_eff;
+    double k_eff_change = fabs(k_eff - k_eff_prev) / k_eff;
     k_eff_prev = k_eff; F_prev = F_new;
     DisAssembleVectorLocalToLocal(groupset,phi_new_local.data(),
                                            phi_prev_local.data());
@@ -158,9 +154,9 @@ void KEigenvalue::Solver::PowerIteration(LBSGroupset& groupset)
     chi_log.ProcessEvent(source_event_tag,
                          ChiLog::EventOperation::AVERAGE_DURATION);
   size_t num_angles = groupset.quadrature->abscissae.size();
-  long int num_unknowns = (long int)glob_node_count *
-                          (long int)num_angles *
-                          (long int)groupset.groups.size();
+  size_t num_unknowns = glob_node_count *
+                        num_angles *
+                        groupset.groups.size();
   chi_log.Log(LOG_0)
     << "\n";
   chi_log.Log(LOG_0)
@@ -174,7 +170,7 @@ void KEigenvalue::Solver::PowerIteration(LBSGroupset& groupset)
     << sweep_time;
   chi_log.Log(LOG_0)
     << "        Sweep Time/Unknown (ns):       "
-    << sweep_time*1.0e9*chi_mpi.process_count/num_unknowns;
+    << sweep_time*1.0e9*chi_mpi.process_count/static_cast<double>(num_unknowns);
   chi_log.Log(LOG_0)
     << "        Number of unknowns per sweep:  " << num_unknowns;
   chi_log.Log(LOG_0)

--- a/ChiModules/KEigenvalueSolver/IterativeOperations/set_k_source.cc
+++ b/ChiModules/KEigenvalueSolver/IterativeOperations/set_k_source.cc
@@ -118,7 +118,7 @@ void KEigenvalue::Solver::
           double precursor_g = 0.0;
           if ( (ell == 0) and (options.use_precursors) )
           {
-            if ( (apply_mat_src) and (xs->J > 0) )
+            if ((apply_mat_src) and (xs->num_precursors > 0))
             {
               for (int j=0; j<num_precursors; ++j)
               {

--- a/ChiModules/KEigenvalueSolver/IterativeOperations/set_k_source.cc
+++ b/ChiModules/KEigenvalueSolver/IterativeOperations/set_k_source.cc
@@ -124,7 +124,7 @@ void KEigenvalue::Solver::SetKSource(LBSGroupset& groupset,
           precursor_g = 0.0;
           if ((ell == 0) and (options.use_precursors))
           {
-            if ((apply_mat_src) and (xs->J > 0))
+            if ((apply_mat_src) and (xs->num_precursors > 0))
             {
               for (int j=0; j<num_precursors; ++j)
               {

--- a/ChiModules/KEigenvalueSolver/IterativeOperations/set_k_source.cc
+++ b/ChiModules/KEigenvalueSolver/IterativeOperations/set_k_source.cc
@@ -56,7 +56,7 @@ void KEigenvalue::Solver::
     int cell_matid = cell.material_id;
     int xs_id = matid_to_xs_map[cell_matid];
 
-    if ((xs_id<0) || (xs_id>=material_xs.size()))
+    if ( (xs_id<0) || (xs_id>=material_xs.size()) )
     {
       chi_log.Log(LOG_ALLERROR)
       << "Cross-section lookup error\n";
@@ -85,7 +85,7 @@ void KEigenvalue::Solver::
         {
           // ----- Contribute scattering
           double inscat_g = 0.0;
-          if ((ell < xs->transfer_matrix.size()) && (apply_scatter_src) )
+          if ( (ell < xs->transfer_matrix.size()) && (apply_scatter_src) )
           {
             size_t num_transfers = xs->transfer_matrix[ell].rowI_indices[g].size();
             for (int t=0; t<num_transfers; t++)
@@ -99,7 +99,7 @@ void KEigenvalue::Solver::
 
           // ----- Contribute fission
           double fission_g = 0.0;
-          if ((ell == 0) and (apply_fission_src))
+          if ( (ell == 0) and (apply_fission_src) )
           {
             if (xs->is_fissile)
             {
@@ -116,9 +116,9 @@ void KEigenvalue::Solver::
 
           // ----- Contribute precursors
           double precursor_g = 0.0;
-          if ((ell == 0) and (options.use_precursors))
+          if ( (ell == 0) and (options.use_precursors) )
           {
-            if ((apply_mat_src) and (xs->J > 0))
+            if ( (apply_mat_src) and (xs->J > 0) )
             {
               for (int j=0; j<num_precursors; ++j)
               {

--- a/ChiModules/KEigenvalueSolver/IterativeOperations/set_k_source.cc
+++ b/ChiModules/KEigenvalueSolver/IterativeOperations/set_k_source.cc
@@ -23,11 +23,14 @@ using namespace LinearBoltzmann;
  * \param suppress_phi_old Flag indicating whether to suppress phi_old.
  *
  * */
-void KEigenvalue::Solver::SetKSource(LBSGroupset& groupset,
-                                     bool apply_mat_src,
-                                     bool suppress_phi_old)
+void KEigenvalue::Solver::
+  SetKSource(LBSGroupset& groupset, SourceFlags source_flags)
 {
   chi_log.LogEvent(source_event_tag,ChiLog::EventType::EVENT_BEGIN);
+
+  const bool apply_mat_src     = (source_flags & APPLY_MATERIAL_SOURCE);
+  const bool apply_scatter_src = (source_flags & APPLY_SCATTER_SOURCE);
+  const bool apply_fission_src = (source_flags & APPLY_FISSION_SOURCE);
 
   // ----- Groupset group information
   int gs_i = groupset.groups[0].id;
@@ -61,15 +64,6 @@ void KEigenvalue::Solver::SetKSource(LBSGroupset& groupset,
     }
 
     auto xs = material_xs[xs_id];
-    
-    double inscat_g = 0.0;
-    double sigma_sm = 0.0;
-    double fission_g = 0.0;
-    double precursor_g = 0.0;
-    double* q_mom;
-    double* phi_oldp;
-    double* phi_prevp;
-    int gprime;
 
     // ----- Loop over dofs
     int num_dofs = full_cell_view.dofs;
@@ -80,36 +74,36 @@ void KEigenvalue::Solver::SetKSource(LBSGroupset& groupset,
       {
         unsigned int ell = m_to_ell_em_map[m].ell;
 
-        int64_t ir = full_cell_view.MapDOF(i,m,0);
-        q_mom      = &q_moments_local[ir];
+        int64_t ir        = full_cell_view.MapDOF(i,m,0);
+        double* q_mom     = &q_moments_local[ir];
 
-        phi_oldp  = &phi_old_local[ir];
-        phi_prevp = &phi_prev_local[ir];
+        double* phi_oldp  = &phi_old_local[ir];
+        double* phi_prevp = &phi_prev_local[ir];
 
         // ----- Loop over groupset groups
         for (int g=gs_i; g<=gs_f; g++)
         {
           // ----- Contribute scattering
-          inscat_g = 0.0;
-          if ((ell < xs->transfer_matrix.size()) && (!suppress_phi_old) )
+          double inscat_g = 0.0;
+          if ((ell < xs->transfer_matrix.size()) && (apply_scatter_src) )
           {
-            int num_transfers = xs->transfer_matrix[ell].rowI_indices[g].size();
+            size_t num_transfers = xs->transfer_matrix[ell].rowI_indices[g].size();
             for (int t=0; t<num_transfers; t++)
             {
-              gprime    = xs->transfer_matrix[ell].rowI_indices[g][t];
-              sigma_sm  = xs->transfer_matrix[ell].rowI_values[g][t];
+              size_t gprime = xs->transfer_matrix[ell].rowI_indices[g][t];
+              double sigma_sm  = xs->transfer_matrix[ell].rowI_values[g][t];
               inscat_g += sigma_sm * phi_oldp[gprime];
             }
           }
           q_mom[g] += inscat_g;
 
           // ----- Contribute fission
-          fission_g = 0.0;
-          if ((ell == 0) and (apply_mat_src))
+          double fission_g = 0.0;
+          if ((ell == 0) and (apply_fission_src))
           {
             if (xs->is_fissile)
             {
-              for (gprime=first_grp; gprime<=last_grp; ++gprime)
+              for (size_t gprime=first_grp; gprime<=last_grp; ++gprime)
                 if (options.use_precursors)
                   fission_g += xs->chi_g[g]*xs->nu_p_sigma_fg[gprime]*
                                phi_prevp[gprime]/k_eff;
@@ -121,14 +115,14 @@ void KEigenvalue::Solver::SetKSource(LBSGroupset& groupset,
           q_mom[g] += fission_g;
 
           // ----- Contribute precursors
-          precursor_g = 0.0;
+          double precursor_g = 0.0;
           if ((ell == 0) and (options.use_precursors))
           {
             if ((apply_mat_src) and (xs->J > 0))
             {
               for (int j=0; j<num_precursors; ++j)
               {
-                for (gprime=first_grp; gprime<=last_grp; ++gprime)
+                for (size_t gprime=first_grp; gprime<=last_grp; ++gprime)
                 {
                   precursor_g += xs->chi_d[g][j]*xs->gamma[j]*
                                  xs->nu_d_sigma_fg[gprime]*

--- a/ChiModules/KEigenvalueSolver/initialize_k_solver.cc
+++ b/ChiModules/KEigenvalueSolver/initialize_k_solver.cc
@@ -29,14 +29,14 @@ void KEigenvalue::Solver::InitializeKSolver()
     **/
     num_precursors = 0;
     for (int x = 0; x < material_xs.size(); x++) {
-      if (material_xs[x]->J > 0) {
+      if (material_xs[x]->num_precursors > 0) {
         // Define the precursor mapping for this material
-        for (int j = 0; j < material_xs[x]->J; ++j) {
+        for (int j = 0; j < material_xs[x]->num_precursors; ++j) {
           material_xs[x]->precursor_map[j] = num_precursors + j;
         }
 
         // Increment the total number of precursors
-        num_precursors += material_xs[x]->J;
+        num_precursors += material_xs[x]->num_precursors;
       }
     }
 

--- a/ChiModules/KEigenvalueSolver/initialize_precursors.cc
+++ b/ChiModules/KEigenvalueSolver/initialize_precursors.cc
@@ -36,9 +36,9 @@ void KEigenvalue::Solver::InitializePrecursors()
       double* phi_newp = &phi_new_local[ir];
 
       // ----- If a fissial material with precursors
-      if ((xs->is_fissile) and (xs->J > 0)) {
+      if ((xs->is_fissile) and (xs->num_precursors > 0)) {
         // ----- Loop over precursors
-        for (int j = 0; j < xs->J; ++j)
+        for (int j = 0; j < xs->num_precursors; ++j)
         {
           int j_map = xs->precursor_map[j];
 

--- a/ChiModules/KEigenvalueSolver/k_eigenvalue_solver.h
+++ b/ChiModules/KEigenvalueSolver/k_eigenvalue_solver.h
@@ -30,9 +30,7 @@ public:
   void PowerIteration(LBSGroupset& groupset);
   
   // Iterative operations
-  void SetKSource(LBSGroupset& groupset,
-                  bool apply_mat_src=true,
-                  bool suppress_phi_old=false);
+  void SetKSource(LBSGroupset& groupset, SourceFlags source_flags);
   double ComputeProduction();
   void InitializePrecursors();
 

--- a/ChiModules/LinearBoltzmannSolver/GroupSet/lbs_groupset.h
+++ b/ChiModules/LinearBoltzmannSolver/GroupSet/lbs_groupset.h
@@ -86,7 +86,7 @@ public:
   void BuildMomDiscOperator(int scatt_order,
                             LinearBoltzmann::GeometryType geometry_type);
   void BuildSubsets();
-  void ZeroPsiDataStructures()
+  void ZeroAngularFluxDataStructures()
   {
     if (psi_to_be_saved)
       psi_new_local.assign(num_psi_unknowns_local,0.0);

--- a/ChiModules/LinearBoltzmannSolver/IterativeMethods/lbs_GMRES.cc
+++ b/ChiModules/LinearBoltzmannSolver/IterativeMethods/lbs_GMRES.cc
@@ -8,6 +8,8 @@
 
 #include "ChiPhysics/chi_physics.h"
 
+#include "ChiMath/PETScUtils/petsc_utils.h"
+
 #include "chi_log.h"
 extern ChiLog& chi_log;
 
@@ -21,8 +23,10 @@ extern ChiTimer chi_program_timer;
 /**Solves a groupset using GMRES.*/
 bool LinearBoltzmann::Solver::GMRES(LBSGroupset& groupset,
                                     int group_set_num,
-                                    SweepChunk* sweep_chunk,
+                                    SweepChunk& sweep_chunk,
                                     MainSweepScheduler& sweepScheduler,
+                                    SourceFlags lhs_src_scope,
+                                    SourceFlags rhs_src_scope,
                                     bool log_info /* = true*/)
 {
   constexpr bool WITH_DELAYED_PSI = true;
@@ -40,65 +44,53 @@ bool LinearBoltzmann::Solver::GMRES(LBSGroupset& groupset,
       << groupset.groups.back().id << "\n\n";
   }
 
+  //================================================== Get groupset dof sizes
+  size_t groupset_numgrps = groupset.groups.size();
+  auto num_delayed_ang_unknowns = groupset.angle_agg.GetNumberOfAngularUnknowns();
+  size_t local_size = local_node_count * num_moments * groupset_numgrps +
+                      num_delayed_ang_unknowns.first;
+  size_t globl_size = glob_node_count * num_moments * groupset_numgrps +
+                      num_delayed_ang_unknowns.second;
+
+  //================================================== Create PETSc vectors
+  phi_new = chi_math::PETScUtils::CreateVector(static_cast<int64_t>(local_size),
+                                               static_cast<int64_t>(globl_size));
+  Vec x_temp;
+  VecSet(phi_new,0.0);
+  VecDuplicate(phi_new,&phi_old);
+  VecDuplicate(phi_new,&q_fixed);
+  VecDuplicate(phi_new,&x_temp);
 
   //=================================================== Create Data context
   //                                                    available inside
   //                                                    Action
-  KSPDataContext data_context;
-  data_context.solver         = this;
-  data_context.sweep_chunk    = sweep_chunk;
-  data_context.group_set_num  = group_set_num;
-  data_context.groupset       = &groupset;
-  data_context.sweepScheduler = &sweepScheduler;
+  KSPDataContext data_context(*this, sweep_chunk, groupset, x_temp,
+                              sweepScheduler, lhs_src_scope);
 
   //=================================================== Create the matrix-shell
   Mat A;
-  int groupset_numgrps = groupset.groups.size();
-  auto num_ang_unknowns = groupset.angle_agg.GetNumberOfAngularUnknowns();
-  int local_size = local_dof_count*num_moments*groupset_numgrps +
-                   num_ang_unknowns.first;
-  int globl_size = glob_dof_count*num_moments*groupset_numgrps +
-                   num_ang_unknowns.second;
-  MatCreateShell(PETSC_COMM_WORLD,local_size,
-                                  local_size,
-                                  globl_size,
-                                  globl_size,
+  MatCreateShell(PETSC_COMM_WORLD,static_cast<int64_t>(local_size),
+                                  static_cast<int64_t>(local_size),
+                                  static_cast<int64_t>(globl_size),
+                                  static_cast<int64_t>(globl_size),
                                   &data_context,&A);
-  groupset.angle_agg.ZeroIncomingDelayedPsi();
 
   //================================================== Set the action-operator
-  MatShellSetOperation(A, MATOP_MULT, (void (*)(void)) LBSMatrixAction_Ax);
-
-  //================================================== Initial vector assembly
-  VecCreate(PETSC_COMM_WORLD,&phi_new);
-  VecCreate(PETSC_COMM_WORLD,&phi_old);
-  VecCreate(PETSC_COMM_WORLD,&q_fixed);
-
-  VecSetSizes(phi_new, local_size, globl_size);
-  VecSetType(phi_new,VECMPI);
-  VecSet(phi_new,0.0);
-  VecDuplicate(phi_new,&phi_old);
-  VecDuplicate(phi_new,&q_fixed);
-  VecDuplicate(phi_new,&data_context.x_temp);
+  MatShellSetOperation(A, MATOP_MULT, (void (*)()) LBSMatrixAction_Ax);
 
   //================================================== Create Krylov Solver
   KSP ksp;
   KSPCreate(PETSC_COMM_WORLD, &ksp);
   KSPSetType(ksp,KSPGMRES);
   KSPSetOperators(ksp,A,A);
-  data_context.krylov_solver = ksp;
-
-  PC pc;
-  KSPGetPC(ksp,&pc);
-  PCSetType(pc,PCNONE);
 
   KSPSetTolerances(ksp,1.e-50,
                    groupset.residual_tolerance,1.0e50,
                    groupset.max_iterations);
-  KSPGMRESSetRestart(ksp,groupset.gmres_restart_intvl);
-  KSPSetApplicationContext(ksp,&data_context);
-  KSPSetConvergenceTest(ksp,&KSPConvergenceTestNPT,NULL,NULL);
-  KSPSetInitialGuessNonzero(ksp,PETSC_TRUE);
+  KSPGMRESSetRestart(ksp, groupset.gmres_restart_intvl);
+  KSPSetApplicationContext(ksp, &data_context);
+  KSPSetConvergenceTest(ksp, &KSPConvergenceTestNPT, nullptr, nullptr);
+  KSPSetInitialGuessNonzero(ksp, PETSC_TRUE);
   KSPSetUp(ksp);
 
   //================================================== Compute b
@@ -107,13 +99,16 @@ bool LinearBoltzmann::Solver::GMRES(LBSGroupset& groupset,
     chi_log.Log(LOG_0) << chi_program_timer.GetTimeString() << " Computing b";
   }
 
-  SetSource(groupset,SourceFlags::USE_MATERIAL_SOURCE,
-                     SourceFlags::SUPPRESS_PHI_OLD);
+  //Prepare for sweep
+  SetSource(groupset, rhs_src_scope);
 
-  sweep_chunk->SetDestinationPhi(&phi_new_local);
-
-  groupset.ZeroPsiDataStructures();
+  sweep_chunk.SetSurfaceSourceActiveFlag(rhs_src_scope & APPLY_MATERIAL_SOURCE);
+  sweep_chunk.SetDestinationPhi(&phi_new_local);
+  groupset.angle_agg.ZeroIncomingDelayedPsi();
+  groupset.ZeroAngularFluxDataStructures();
   phi_new_local.assign(phi_new_local.size(),0.0);
+
+  //Sweep
   sweepScheduler.Sweep(sweep_chunk);
 
   //=================================================== Apply DSA
@@ -135,8 +130,8 @@ bool LinearBoltzmann::Solver::GMRES(LBSGroupset& groupset,
   AssembleVector(groupset,phi_old,phi_old_local.data(),WITH_DELAYED_PSI);
 
   //=================================================== Retool for GMRES
-  sweep_chunk->SetDestinationPhi(&phi_new_local);
-  sweep_chunk->suppress_surface_src = true; //Action of Ax specific
+  sweep_chunk.SetSurfaceSourceActiveFlag(lhs_src_scope & APPLY_MATERIAL_SOURCE);
+  sweep_chunk.SetDestinationPhi(&phi_new_local);
 
   double phi_old_norm=0.0;
   VecNorm(phi_old,NORM_2,&phi_old_norm);
@@ -173,7 +168,7 @@ bool LinearBoltzmann::Solver::GMRES(LBSGroupset& groupset,
   VecDestroy(&phi_new);
   VecDestroy(&phi_old);
   VecDestroy(&q_fixed);
-  VecDestroy(&data_context.x_temp);
+  VecDestroy(&x_temp);
   MatDestroy(&A);
 
 
@@ -185,8 +180,8 @@ bool LinearBoltzmann::Solver::GMRES(LBSGroupset& groupset,
       chi_log.ProcessEvent(source_event_tag,
                            ChiLog::EventOperation::AVERAGE_DURATION);
     size_t num_angles = groupset.quadrature->abscissae.size();
-    long int num_unknowns = (long int)glob_dof_count*
-                            (long int)num_angles*
+    long int num_unknowns = (long int)glob_node_count *
+                            (long int)num_angles *
                             (long int)groupset.groups.size();
 
     if (log_info)
@@ -204,7 +199,8 @@ bool LinearBoltzmann::Solver::GMRES(LBSGroupset& groupset,
         << chunk_overhead_ratio;
       chi_log.Log(LOG_0)
         << "        Sweep Time/Unknown (ns):       "
-        << sweep_time*1.0e9*chi_mpi.process_count/num_unknowns;
+        << sweep_time*1.0e9*chi_mpi.process_count/
+           static_cast<double>(num_unknowns);
       chi_log.Log(LOG_0)
         << "        Number of unknowns per sweep:  " << num_unknowns;
       chi_log.Log(LOG_0)

--- a/ChiModules/LinearBoltzmannSolver/IterativeMethods/lbs_GMRES.cc
+++ b/ChiModules/LinearBoltzmannSolver/IterativeMethods/lbs_GMRES.cc
@@ -180,9 +180,9 @@ bool LinearBoltzmann::Solver::GMRES(LBSGroupset& groupset,
       chi_log.ProcessEvent(source_event_tag,
                            ChiLog::EventOperation::AVERAGE_DURATION);
     size_t num_angles = groupset.quadrature->abscissae.size();
-    long int num_unknowns = (long int)glob_node_count *
-                            (long int)num_angles *
-                            (long int)groupset.groups.size();
+    size_t num_unknowns = glob_node_count *
+                          num_angles *
+                          groupset.groups.size();
 
     if (log_info)
     {

--- a/ChiModules/LinearBoltzmannSolver/IterativeMethods/lbs_classicrichardson.cc
+++ b/ChiModules/LinearBoltzmannSolver/IterativeMethods/lbs_classicrichardson.cc
@@ -126,9 +126,9 @@ bool LinearBoltzmann::Solver::ClassicRichardson(LBSGroupset& groupset,
       chi_log.ProcessEvent(source_event_tag,
                            ChiLog::EventOperation::AVERAGE_DURATION);
     size_t num_angles = groupset.quadrature->abscissae.size();
-    long int num_unknowns = (long int)glob_node_count *
-                            (long int)num_angles *
-                            (long int)groupset.groups.size();
+    size_t num_unknowns = glob_node_count *
+                          num_angles *
+                          groupset.groups.size();
 
     if (log_info)
     {

--- a/ChiModules/LinearBoltzmannSolver/IterativeMethods/lbs_classicrichardson.cc
+++ b/ChiModules/LinearBoltzmannSolver/IterativeMethods/lbs_classicrichardson.cc
@@ -17,8 +17,9 @@ extern ChiTimer chi_program_timer;
 /**Solves a groupset using classic richardson.*/
 bool LinearBoltzmann::Solver::ClassicRichardson(LBSGroupset& groupset,
                     int group_set_num,
-                    SweepChunk* sweep_chunk,
+                    SweepChunk& sweep_chunk,
                     MainSweepScheduler& sweepScheduler,
+                    SourceFlags source_flags,
                     bool log_info /* = true*/)
 {
   if (log_info)
@@ -36,7 +37,7 @@ bool LinearBoltzmann::Solver::ClassicRichardson(LBSGroupset& groupset,
   groupset.angle_agg.ZeroIncomingDelayedPsi();
 
   //================================================== Tool the sweep chunk
-  sweep_chunk->SetDestinationPhi(&phi_new_local);
+  sweep_chunk.SetDestinationPhi(&phi_new_local);
 
   //================================================== Now start iterating
   double pw_change = 0.0;
@@ -45,9 +46,9 @@ bool LinearBoltzmann::Solver::ClassicRichardson(LBSGroupset& groupset,
   bool converged = false;
   for (int k=0; k<groupset.max_iterations; k++)
   {
-    SetSource(groupset,SourceFlags::USE_MATERIAL_SOURCE,false);
+    SetSource(groupset,source_flags);
 
-    groupset.ZeroPsiDataStructures();
+    groupset.ZeroAngularFluxDataStructures();
     phi_new_local.assign(phi_new_local.size(),0.0); //Ensure phi_new=0.0
     sweepScheduler.Sweep(sweep_chunk);
 
@@ -125,8 +126,8 @@ bool LinearBoltzmann::Solver::ClassicRichardson(LBSGroupset& groupset,
       chi_log.ProcessEvent(source_event_tag,
                            ChiLog::EventOperation::AVERAGE_DURATION);
     size_t num_angles = groupset.quadrature->abscissae.size();
-    long int num_unknowns = (long int)glob_dof_count*
-                            (long int)num_angles*
+    long int num_unknowns = (long int)glob_node_count *
+                            (long int)num_angles *
                             (long int)groupset.groups.size();
 
     if (log_info)
@@ -141,7 +142,8 @@ bool LinearBoltzmann::Solver::ClassicRichardson(LBSGroupset& groupset,
         << sweep_time;
       chi_log.Log(LOG_0)
         << "        Sweep Time/Unknown (ns):       "
-        << sweep_time*1.0e9*chi_mpi.process_count/num_unknowns;
+        << sweep_time*1.0e9*chi_mpi.process_count/
+            static_cast<double>(num_unknowns);
       chi_log.Log(LOG_0)
         << "        Number of unknowns per sweep:  " << num_unknowns;
       chi_log.Log(LOG_0)

--- a/ChiModules/LinearBoltzmannSolver/IterativeOperations/lbs_matrixaction_Ax.cc
+++ b/ChiModules/LinearBoltzmannSolver/IterativeOperations/lbs_matrixaction_Ax.cc
@@ -7,61 +7,61 @@
 typedef chi_mesh::sweep_management::SweepScheduler MainSweepScheduler;
 //###################################################################
 /**Computes the action of the transport matrix on a vector.*/
-int LBSMatrixAction_Ax(Mat matrix, Vec krylov_vector, Vec Ax)
+int LinearBoltzmann::LBSMatrixAction_Ax(Mat matrix, Vec krylov_vector, Vec Ax)
 {
   constexpr bool WITH_DELAYED_PSI = true;
   KSPDataContext* context;
   MatShellGetContext(matrix,&context);
 
-  LinearBoltzmann::Solver* solver = context->solver;
-  SweepChunk* sweep_chunk = context->sweep_chunk;
-  LBSGroupset& groupset  = *context->groupset;
-  MainSweepScheduler* sweepScheduler = context->sweepScheduler;
+  //Shorten some names
+  LinearBoltzmann::Solver& solver = context->solver;
+  SweepChunk& sweep_chunk = context->sweep_chunk;
+  LBSGroupset& groupset  = context->groupset;
+  MainSweepScheduler& sweepScheduler = context->sweepScheduler;
+  SourceFlags& lhs_source_scope = context->lhs_scope;
 
   //============================================= Copy krylov vector into local
-  solver->DisAssembleVector(groupset,
-                            krylov_vector,
-                            solver->phi_old_local.data(),WITH_DELAYED_PSI);
+  solver.DisAssembleVector(groupset,
+                           krylov_vector,
+                           solver.phi_old_local.data(),WITH_DELAYED_PSI);
 
   //============================================= Setting the source using
   //                                             updated phi_old
-  solver->SetSource(*context->groupset,
-                    LinearBoltzmann::SourceFlags::USE_DLINV_SOURCE,
-                    false);
+  solver.SetSource(groupset, lhs_source_scope);
 
   //============================================= Sweeping the new source
-  groupset.ZeroPsiDataStructures();
-  solver->phi_new_local.assign(solver->phi_new_local.size(),0.0);
-  sweepScheduler->Sweep(sweep_chunk);
+  groupset.ZeroAngularFluxDataStructures();
+  solver.phi_new_local.assign(solver.phi_new_local.size(),0.0);
+  sweepScheduler.Sweep(sweep_chunk);
 
   //=================================================== Apply WGDSA
   if (groupset.apply_wgdsa)
   {
-    solver->AssembleWGDSADeltaPhiVector(groupset,
-                                        solver->phi_old_local.data(),
-                                        solver->phi_new_local.data());
+    solver.AssembleWGDSADeltaPhiVector(groupset,
+                                       solver.phi_old_local.data(),
+                                       solver.phi_new_local.data());
     ((chi_diffusion::Solver*)groupset.wgdsa_solver)->ExecuteS(true,false);
-    solver->DisAssembleWGDSADeltaPhiVector(groupset,
-                                           solver->phi_new_local.data());
+    solver.DisAssembleWGDSADeltaPhiVector(groupset,
+                                          solver.phi_new_local.data());
   }
   if (groupset.apply_tgdsa)
   {
-    solver->AssembleTGDSADeltaPhiVector(groupset,
-                                        solver->phi_old_local.data(),
-                                        solver->phi_new_local.data());
+    solver.AssembleTGDSADeltaPhiVector(groupset,
+                                       solver.phi_old_local.data(),
+                                       solver.phi_new_local.data());
     ((chi_diffusion::Solver*)groupset.tgdsa_solver)->ExecuteS(true,false);
-    solver->DisAssembleTGDSADeltaPhiVector(groupset,
-                                           solver->phi_new_local.data());
+    solver.DisAssembleTGDSADeltaPhiVector(groupset,
+                                          solver.phi_new_local.data());
   }
 
 
-  solver->AssembleVector(groupset,
-                         context->x_temp,
-                         solver->phi_new_local.data(),WITH_DELAYED_PSI);
+  solver.AssembleVector(groupset,
+                        context->operating_vector,
+                        solver.phi_new_local.data(),WITH_DELAYED_PSI);
 
 
   //============================================= Computing action
-  VecWAXPY(Ax,-1.0,context->x_temp,krylov_vector);
+  VecWAXPY(Ax,-1.0,context->operating_vector,krylov_vector);
 
   return 0;
 }

--- a/ChiModules/LinearBoltzmannSolver/IterativeOperations/lbs_matrixaction_Ax.h
+++ b/ChiModules/LinearBoltzmannSolver/IterativeOperations/lbs_matrixaction_Ax.h
@@ -1,10 +1,13 @@
 #ifndef LBS_MATRIXACTION_AX_H
 #define LBS_MATRIXACTION_AX_H
 
-#include <LinearBoltzmannSolver/lbs_linear_boltzmann_solver.h>
+#include "LinearBoltzmannSolver/lbs_linear_boltzmann_solver.h"
 #include <petscksp.h>
 
+namespace LinearBoltzmann
+{
 int LBSMatrixAction_Ax(Mat matrix, Vec krylov_vector, Vec Ax);
+}
 
 
 #endif

--- a/ChiModules/LinearBoltzmannSolver/IterativeOperations/lbs_setsweepchunk.cc
+++ b/ChiModules/LinearBoltzmannSolver/IterativeOperations/lbs_setsweepchunk.cc
@@ -5,13 +5,15 @@ typedef chi_mesh::sweep_management::SweepChunk SweepChunk;
 
 //###################################################################
 /**Sets up the sweek chunk for the given discretization method.*/
-SweepChunk* LinearBoltzmann::Solver::SetSweepChunk(LBSGroupset& groupset)
+std::shared_ptr<SweepChunk> LinearBoltzmann::Solver::
+  SetSweepChunk(LBSGroupset& groupset)
 {
-  auto pwl_sdm = std::dynamic_pointer_cast<SpatialDiscretization_PWLD>(discretization);
+  auto pwl_sdm =
+    std::dynamic_pointer_cast<SpatialDiscretization_PWLD>(discretization);
 
   //================================================== Setting up required
   //                                                   sweep chunks
-  SweepChunk* sweep_chunk = new LBSSweepChunkPWL(
+  auto sweep_chunk = std::make_shared<LBSSweepChunkPWL>(
         grid,                                    //Spatial grid of cells
         *pwl_sdm,                                //Spatial discretization
         cell_transport_views,                    //Cell transport views

--- a/ChiModules/LinearBoltzmannSolver/SweepChunks/lbs_sweepchunk_pwl.h
+++ b/ChiModules/LinearBoltzmannSolver/SweepChunks/lbs_sweepchunk_pwl.h
@@ -209,10 +209,10 @@ public:
                 {
                   const int j = fe_intgrl_values.FaceDofMapping(f,fj);
                   const double *psi = angle_set->PsiBndry(bndry_index,
-                                                    angle_num,
-                                                    cell.local_id,
-                                                    f, fj, gs_gi, gs_ss_begin,
-                                                    suppress_surface_src);
+                                                          angle_num,
+                                                          cell.local_id,
+                                                          f, fj, gs_gi, gs_ss_begin,
+                                                          surface_source_active);
                   const double mu_Nij = -mu*N[f][i][j];
                   Amat[i][j] += mu_Nij;
                   for (int gsg = 0; gsg < gs_ss_size; ++gsg)

--- a/ChiModules/LinearBoltzmannSolver/Tools/ksp_data_context.h
+++ b/ChiModules/LinearBoltzmannSolver/Tools/ksp_data_context.h
@@ -17,7 +17,7 @@ struct KSPDataContext
   Vec&                     operating_vector;
   chi_mesh::sweep_management::SweepScheduler& sweepScheduler;
   SourceFlags    lhs_scope;
-  size_t last_iteration = -1;
+  int64_t last_iteration = -1;
 
   KSPDataContext(LinearBoltzmann::Solver& in_solver,
                  SweepChunk& in_sweep_chunk,

--- a/ChiModules/LinearBoltzmannSolver/Tools/ksp_data_context.h
+++ b/ChiModules/LinearBoltzmannSolver/Tools/ksp_data_context.h
@@ -1,16 +1,38 @@
+#ifndef LBS_KSP_DATA_CONTEXT_H
+#define LBS_KSP_DATA_CONTEXT_H
 
+#include "../lbs_linear_boltzmann_solver.h"
+
+namespace LinearBoltzmann
+{
 
 //###################################################################
 /**This is a simple data structure of basically pointers to
  * objects needed in matrix free operations.*/
 struct KSPDataContext
 {
-  LinearBoltzmann::Solver* solver;
-  SweepChunk*      sweep_chunk;
-  int              group_set_num;
-  LBSGroupset*    groupset;
-  KSP              krylov_solver;
-  Vec              x_temp;
-  chi_mesh::sweep_management::SweepScheduler* sweepScheduler;
-  int last_iteration = -1;
+  LinearBoltzmann::Solver& solver;
+  SweepChunk&              sweep_chunk;
+  LBSGroupset&             groupset;
+  Vec&                     operating_vector;
+  chi_mesh::sweep_management::SweepScheduler& sweepScheduler;
+  SourceFlags    lhs_scope;
+  size_t last_iteration = -1;
+
+  KSPDataContext(LinearBoltzmann::Solver& in_solver,
+                 SweepChunk& in_sweep_chunk,
+                 LBSGroupset& in_groupset,
+                 Vec& in_operating_vector,
+                 chi_mesh::sweep_management::SweepScheduler& in_sweep_scheduler,
+                 SourceFlags in_lhs_scope) :
+    solver(in_solver),
+    sweep_chunk(in_sweep_chunk),
+    groupset(in_groupset),
+    operating_vector(in_operating_vector),
+    sweepScheduler(in_sweep_scheduler),
+    lhs_scope(in_lhs_scope) {}
 };
+
+}
+
+#endif //LBS_KSP_DATA_CONTEXT_H

--- a/ChiModules/LinearBoltzmannSolver/Tools/kspmonitor_npt.cc
+++ b/ChiModules/LinearBoltzmannSolver/Tools/kspmonitor_npt.cc
@@ -61,14 +61,14 @@ PetscErrorCode LinearBoltzmann::
 
 
   chi_log.Log(LOG_0) << iter_info.str() << std::endl;
-
+  const double SIXTY_SECOND_INTERVAL = 60000.0; //time in milliseconds
   if (context->groupset.iterative_method == NPT_GMRES)
   {
     if (context->last_iteration == n)
     {
       if (context->solver.options.write_restart_data)
       {
-        if ((chi_program_timer.GetTime()/60000.0) >
+        if ((chi_program_timer.GetTime()/SIXTY_SECOND_INTERVAL) >
           context->solver.last_restart_write +
           context->solver.options.write_restart_interval)
         {
@@ -80,7 +80,8 @@ PetscErrorCode LinearBoltzmann::
                             context->solver.phi_old_local.data(),
                             WITH_DELAYED_PSI);
 
-          context->solver.last_restart_write = chi_program_timer.GetTime()/60000.0;
+          context->solver.last_restart_write =
+            chi_program_timer.GetTime()/SIXTY_SECOND_INTERVAL;
           context->solver.WriteRestartData(
             context->solver.options.write_restart_folder_name,
             context->solver.options.write_restart_file_base);

--- a/ChiModules/LinearBoltzmannSolver/Tools/kspmonitor_npt.cc
+++ b/ChiModules/LinearBoltzmannSolver/Tools/kspmonitor_npt.cc
@@ -11,29 +11,10 @@ extern ChiLog&     chi_log;
 extern ChiTimer   chi_program_timer;
 
 //###################################################################
-/**Customized monitor for PETSc Krylov sub-space solvers.*/
-PetscErrorCode
-KSPMonitorNPT(KSP ksp, PetscInt n, PetscReal rnorm, void *monitordestroy)
-{
-  Vec Rhs;
-
-  KSPGetRhs(ksp,&Rhs);
-
-  double rhs_norm;
-  VecNorm(Rhs,NORM_2,&rhs_norm);
-
-  chi_log.Log(LOG_0) << "Iteration " << n << " Residual " << rnorm/rhs_norm;
-
-  return 0;
-}
-
-
-
-//###################################################################
 /**Customized convergence test.*/
-PetscErrorCode
-KSPConvergenceTestNPT(KSP ksp, PetscInt n, PetscReal rnorm,
-                      KSPConvergedReason* convergedReason, void *monitordestroy)
+PetscErrorCode LinearBoltzmann::
+  KSPConvergenceTestNPT(KSP ksp, PetscInt n, PetscReal rnorm,
+                        KSPConvergedReason* convergedReason, void*)
 {
   constexpr bool WITH_DELAYED_PSI = true;
   //======================================== Get data context
@@ -51,13 +32,13 @@ KSPConvergenceTestNPT(KSP ksp, PetscInt n, PetscReal rnorm,
   //======================================== Compute test criterion
   double tol;
   int64_t    maxIts;
-  KSPGetTolerances(ksp,NULL,&tol,NULL,&maxIts);
+  KSPGetTolerances(ksp, nullptr,&tol, nullptr,&maxIts);
 
   double relative_residual = rnorm/rhs_norm;
 
   //======================================== Print iteration information
   std::string offset;
-  if (context->groupset->apply_wgdsa || context->groupset->apply_tgdsa)
+  if (context->groupset.apply_wgdsa || context->groupset.apply_tgdsa)
     offset = std::string("    ");
 
   std::stringstream iter_info;
@@ -65,9 +46,9 @@ KSPConvergenceTestNPT(KSP ksp, PetscInt n, PetscReal rnorm,
     << chi_program_timer.GetTimeString() << " "
     << offset
     << "WGS groups ["
-    << context->groupset->groups.front().id
+    << context->groupset.groups.front().id
     << "-"
-    << context->groupset->groups.back().id
+    << context->groupset.groups.back().id
     << "]"
     << " Iteration " << std::setw(5) << n
     << " Residual " << std::setw(9) << relative_residual;
@@ -81,28 +62,28 @@ KSPConvergenceTestNPT(KSP ksp, PetscInt n, PetscReal rnorm,
 
   chi_log.Log(LOG_0) << iter_info.str() << std::endl;
 
-  if (context->groupset->iterative_method == NPT_GMRES)
+  if (context->groupset.iterative_method == NPT_GMRES)
   {
     if (context->last_iteration == n)
     {
-      if (context->solver->options.write_restart_data)
+      if (context->solver.options.write_restart_data)
       {
         if ((chi_program_timer.GetTime()/60000.0) >
-          context->solver->last_restart_write +
-          context->solver->options.write_restart_interval)
+          context->solver.last_restart_write +
+          context->solver.options.write_restart_interval)
         {
           Vec phi_new;
-          KSPBuildSolution(ksp,NULL,&phi_new);
+          KSPBuildSolution(ksp, nullptr,&phi_new);
 
-          context->solver->
-          DisAssembleVector(*context->groupset, phi_new,
-                            context->solver->phi_old_local.data(),
+          context->solver.
+          DisAssembleVector(context->groupset, phi_new,
+                            context->solver.phi_old_local.data(),
                             WITH_DELAYED_PSI);
 
-          context->solver->last_restart_write = chi_program_timer.GetTime()/60000.0;
-          context->solver->WriteRestartData(
-            context->solver->options.write_restart_folder_name,
-            context->solver->options.write_restart_file_base);
+          context->solver.last_restart_write = chi_program_timer.GetTime()/60000.0;
+          context->solver.WriteRestartData(
+            context->solver.options.write_restart_folder_name,
+            context->solver.options.write_restart_file_base);
         }
       }
     }

--- a/ChiModules/LinearBoltzmannSolver/Tools/kspmonitor_npt.h
+++ b/ChiModules/LinearBoltzmannSolver/Tools/kspmonitor_npt.h
@@ -1,10 +1,13 @@
+#ifndef LBS_KSP_MONITORS_H
+#define LBS_KSP_MONITORS_H
+
 #include <petscksp.h>
 
-PetscErrorCode KSPMonitorNPT(KSP ksp,
-                             PetscInt n,
-                             PetscReal rnorm,
-                             void *monitordestroy);
-
+namespace LinearBoltzmann
+{
 PetscErrorCode KSPConvergenceTestNPT(
                 KSP ksp, PetscInt n, PetscReal rnorm,
-                KSPConvergedReason* convergedReason, void *monitordestroy);
+                KSPConvergedReason* convergedReason, void* monitordestroy);
+}
+
+#endif //LBS_KSP_MONITORS_H

--- a/ChiModules/LinearBoltzmannSolver/lbs_01b_initmaterials.cc
+++ b/ChiModules/LinearBoltzmannSolver/lbs_01b_initmaterials.cc
@@ -91,23 +91,23 @@ void LinearBoltzmann::Solver::InitMaterials(std::set<int>& material_ids)
     }
 
     //====================================== Check number of groups legal
-    if (material_xs[matid_to_xs_map[mat_id]]->G < groups.size())
+    if (material_xs[matid_to_xs_map[mat_id]]->num_groups < groups.size())
     {
       chi_log.Log(LOG_ALLERROR)
         << "LBS-InitMaterials: Found material \"" << current_material->name << "\" has "
-        << material_xs[matid_to_xs_map[mat_id]]->G << " groups and"
+        << material_xs[matid_to_xs_map[mat_id]]->num_groups << " groups and"
         << " the simulation has " << groups.size() << " groups."
         << " The material must have a greater or equal amount of groups.";
       exit(EXIT_FAILURE);
     }
 
     //====================================== Check number of moments
-    if (material_xs[matid_to_xs_map[mat_id]]->L < options.scattering_order)
+    if (material_xs[matid_to_xs_map[mat_id]]->scattering_order < options.scattering_order)
     {
       chi_log.Log(LOG_0WARNING)
         << "LBS-InitMaterials: Found material \"" << current_material->name << "\" has "
         << "a scattering order of "
-        << material_xs[matid_to_xs_map[mat_id]]->L << " and"
+        << material_xs[matid_to_xs_map[mat_id]]->scattering_order << " and"
         << " the simulation has a scattering order of "
         << options.scattering_order << "."
         << " The higher moments will therefore not be used.";

--- a/ChiModules/LinearBoltzmannSolver/lbs_01d_initparrays.cc
+++ b/ChiModules/LinearBoltzmannSolver/lbs_01d_initparrays.cc
@@ -55,14 +55,14 @@ void LinearBoltzmann::Solver::InitializeParrays()
   }
 
   //================================================== Compute local # of dof
-  auto GxM = flux_moments_uk_man.GetTotalUnknownStructureSize();
-  local_dof_count = discretization->GetNumLocalDOFs(flux_moments_uk_man)/GxM;
-  glob_dof_count = discretization->GetNumGlobalDOFs(flux_moments_uk_man)/GxM;
+  auto& per_node = ChiMath::UNITARY_UNKNOWN_MANAGER;
+  local_node_count = discretization->GetNumLocalDOFs(per_node);
+  glob_node_count = discretization->GetNumGlobalDOFs(per_node);
 
   //================================================== Compute num of unknowns
   int num_grps = groups.size();
   int M = num_moments;
-  unsigned long long local_unknown_count = local_dof_count * num_grps * M;
+  unsigned long long local_unknown_count = local_node_count * num_grps * M;
 
   chi_log.Log(LOG_ALLVERBOSE_1) << "LBS Number of phi unknowns: "
                                 << local_unknown_count;

--- a/ChiModules/LinearBoltzmannSolver/lbs_02_main_execute.cc
+++ b/ChiModules/LinearBoltzmannSolver/lbs_02_main_execute.cc
@@ -56,20 +56,23 @@ void LinearBoltzmann::Solver::SolveGroupset(LBSGroupset& groupset,
 
   //================================================== Setting up required
   //                                                   sweep chunks
-  SweepChunk* sweep_chunk = SetSweepChunk(groupset);
+  auto sweep_chunk = SetSweepChunk(groupset);
   MainSweepScheduler sweepScheduler(SchedulingAlgorithm::DEPTH_OF_GRAPH,
                                     &groupset.angle_agg);
 
   if (groupset.iterative_method == NPT_CLASSICRICHARDSON)
   {
-    ClassicRichardson(groupset, group_set_num, sweep_chunk, sweepScheduler);
+    ClassicRichardson(groupset, group_set_num, *sweep_chunk, sweepScheduler,
+                      APPLY_MATERIAL_SOURCE |
+                      APPLY_SCATTER_SOURCE |
+                      APPLY_FISSION_SOURCE);
   }
   else if (groupset.iterative_method == NPT_GMRES)
   {
-    GMRES(groupset, group_set_num, sweep_chunk, sweepScheduler);
+    GMRES(groupset, group_set_num, *sweep_chunk, sweepScheduler,
+          APPLY_SCATTER_SOURCE | APPLY_FISSION_SOURCE,
+          APPLY_MATERIAL_SOURCE);
   }
-
-  delete sweep_chunk;
 
   if (options.write_restart_data)
     WriteRestartData(options.write_restart_folder_name,

--- a/ChiModules/LinearBoltzmannSolver/lbs_03d_wgdsa.cc
+++ b/ChiModules/LinearBoltzmannSolver/lbs_03d_wgdsa.cc
@@ -19,7 +19,7 @@ void LinearBoltzmann::Solver::InitWGDSA(LBSGroupset& groupset)
     scalar_uk_man.AddUnknown(chi_math::UnknownType::VECTOR_N, groupset.groups.size());
 
     //================================= Initialize field function
-    delta_phi_local.resize(local_dof_count*groupset.groups.size(),0.0);
+    delta_phi_local.resize(local_node_count * groupset.groups.size(), 0.0);
     int g = 0;
     int m = 0;
 
@@ -110,7 +110,7 @@ void LinearBoltzmann::Solver::AssembleWGDSADeltaPhiVector(LBSGroupset& groupset,
   int gss = groupset.groups.size();
 
   delta_phi_local.clear();
-  delta_phi_local.resize(local_dof_count*gss,0.0);
+  delta_phi_local.resize(local_node_count * gss, 0.0);
 
   int index = -1;
   for (const auto& cell : grid->local_cells)

--- a/ChiModules/LinearBoltzmannSolver/lbs_03e_tgdsa.cc
+++ b/ChiModules/LinearBoltzmannSolver/lbs_03e_tgdsa.cc
@@ -18,7 +18,7 @@ void LinearBoltzmann::Solver::InitTGDSA(LBSGroupset& groupset)
     scalar_uk_man.AddUnknown(chi_math::UnknownType::SCALAR);
 
     //================================= Initialize field function
-    delta_phi_local.resize(local_dof_count,0.0);
+    delta_phi_local.resize(local_node_count, 0.0);
     int g = 0;
     int m = 0;
     std::string text_name = std::string("Sum_Sigma_s_DeltaPhi_g") +
@@ -105,7 +105,7 @@ void LinearBoltzmann::Solver::AssembleTGDSADeltaPhiVector(LBSGroupset& groupset,
   int gsi = groupset.groups[0].id;
   int gss = groupset.groups.size();
 
-  delta_phi_local.resize(local_dof_count,0.0);
+  delta_phi_local.resize(local_node_count, 0.0);
 
   int index = -1;
   for (const auto& cell : grid->local_cells)

--- a/ChiTech/ChiMath/SpatialDiscretization/CellMappings/FE_PWL/pwl_cellbase.h
+++ b/ChiTech/ChiMath/SpatialDiscretization/CellMappings/FE_PWL/pwl_cellbase.h
@@ -10,34 +10,44 @@
 class CellMappingFE_PWL
 {
 protected:
+  /** Mesh. */
   chi_mesh::MeshContinuumPtr grid;
 public:
-  const int num_nodes;
-
   typedef std::vector<double> VecDbl;
   typedef std::vector<chi_mesh::Vector3> VecVec3;
-
+  /** Number of nodes of the cell. */
+  const int num_nodes;
+  /** For each cell face, map from the face node index to the corresponding
+   *  cell node index. More specifically, \p face_dof_mappings[f][fi], with
+   *  \p fi the face node index of the face identified by face index \p f,
+   *  contains the corresponding cell node index. */
   std::vector<std::vector<int>> face_dof_mappings;
 
 public:
+  /** Constructor. */
   explicit CellMappingFE_PWL(int num_dofs,
                              chi_mesh::MeshContinuumPtr ref_grid) :
     grid(std::move(ref_grid)),
     num_nodes(num_dofs)
   {}
 
+  /** Compute unit integrals. */
   virtual void
   ComputeUnitIntegrals(chi_math::finite_element::UnitIntegralData& ui_data);
 
+  /** Initialize volume quadrature point data and
+   *  surface quadrature point data for all faces. */
   virtual void
   InitializeAllQuadraturePointData(
     chi_math::finite_element::InternalQuadraturePointData& internal_data,
     std::vector<chi_math::finite_element::FaceQuadraturePointData>& faces_qp_data) {}
 
+  /** Initialize volume quadrature point data. */
   virtual void
   InitializeVolumeQuadraturePointData(
     chi_math::finite_element::InternalQuadraturePointData& internal_data) {}
 
+  /** Initialize surface quadrature point data for face index \p face. */
   virtual void
   InitializeFaceQuadraturePointData(
     unsigned int face,
@@ -71,6 +81,8 @@ public:
   {
     gradshape_values.resize(num_nodes, chi_mesh::Vector3());
   }
+
+  /** Destructor. */
   virtual ~CellMappingFE_PWL() = default;
 };
 

--- a/ChiTech/ChiMesh/SweepUtilities/AngleSet/angleset.h
+++ b/ChiTech/ChiMesh/SweepUtilities/AngleSet/angleset.h
@@ -62,7 +62,7 @@ public:
   int GetNumGrps();
 
   AngleSetStatus AngleSetAdvance(
-             SweepChunk *sweep_chunk,
+             SweepChunk& sweep_chunk,
              int angle_set_num,
              const std::vector<size_t>& timing_tags,
              ExecutionPermission permission = ExecutionPermission::EXECUTE);
@@ -77,7 +77,7 @@ public:
                    int fi,
                    int g,
                    int gs_ss_begin,
-                   bool suppress_surface_src);
+                   bool surface_source_active);
   double* ReflectingPsiOutBoundBndry(int bndry_map,
                                      int angle_num,
                                      int cell_local_id,

--- a/ChiTech/ChiMesh/SweepUtilities/AngleSetGroup/anglesetgroup.h
+++ b/ChiTech/ChiMesh/SweepUtilities/AngleSetGroup/anglesetgroup.h
@@ -19,7 +19,7 @@ private:
 public:
 
   //###################################################################
-  AngleSetStatus AngleSetGroupAdvance(SweepChunk *sweep_chunk,
+  AngleSetStatus AngleSetGroupAdvance(SweepChunk& sweep_chunk,
                                       int anglesetgroup_number,
                                       const std::vector<size_t>& timing_tags)
   {

--- a/ChiTech/ChiMesh/SweepUtilities/SweepScheduler/sweepscheduler.h
+++ b/ChiTech/ChiMesh/SweepUtilities/SweepScheduler/sweepscheduler.h
@@ -24,7 +24,6 @@ class chi_mesh::sweep_management::SweepScheduler
 private:
   SchedulingAlgorithm       scheduler_type;
   AngleAggregation*         angle_agg;
-  SweepChunk*               sweep_chunk;
 
 
   struct RULE_VALUES
@@ -54,16 +53,16 @@ public:
   SweepScheduler(SchedulingAlgorithm in_scheduler_type,
                  AngleAggregation* in_angle_agg);
 
-  void Sweep(SweepChunk* in_sweep_chunk=nullptr);
+  void Sweep(SweepChunk& in_sweep_chunk);
   double GetAverageSweepTime();
   std::vector<double> GetAngleSetTimings();
 
 private:
-  void ScheduleAlgoFIFO();
+  void ScheduleAlgoFIFO(SweepChunk& sweep_chunk);
 
   //02
   void InitializeAlgoDOG();
-  void ScheduleAlgoDOG();
+  void ScheduleAlgoDOG(SweepChunk& sweep_chunk);
 };
 
 #endif //CHI_SWEEPSCHEDULER_H

--- a/ChiTech/ChiMesh/SweepUtilities/SweepScheduler/sweepscheduler_dog.cc
+++ b/ChiTech/ChiMesh/SweepUtilities/SweepScheduler/sweepscheduler_dog.cc
@@ -115,7 +115,8 @@ void chi_mesh::sweep_management::SweepScheduler::InitializeAlgoDOG()
 
 //###################################################################
 /**Executes the Depth-Of-Graph algorithm.*/
-void chi_mesh::sweep_management::SweepScheduler::ScheduleAlgoDOG()
+void chi_mesh::sweep_management::SweepScheduler::
+  ScheduleAlgoDOG(SweepChunk& sweep_chunk)
 {
   typedef ExecutionPermission ExePerm;
   typedef AngleSetStatus Status;

--- a/ChiTech/ChiMesh/SweepUtilities/SweepScheduler/sweepscheduler_fifo.cc
+++ b/ChiTech/ChiMesh/SweepUtilities/SweepScheduler/sweepscheduler_fifo.cc
@@ -9,7 +9,8 @@ extern ChiLog& chi_log;
 
 //###################################################################
 /**Applies a First-In-First-Out sweep scheduling.*/
-void chi_mesh::sweep_management::SweepScheduler::ScheduleAlgoFIFO()
+void chi_mesh::sweep_management::SweepScheduler::
+  ScheduleAlgoFIFO(SweepChunk& sweep_chunk)
 {
   chi_log.LogEvent(sweep_event_tag, ChiLog::EventType::EVENT_BEGIN);
 

--- a/ChiTech/ChiMesh/SweepUtilities/SweepScheduler/sweepscheduler_sweep.cc
+++ b/ChiTech/ChiMesh/SweepUtilities/SweepScheduler/sweepscheduler_sweep.cc
@@ -6,14 +6,12 @@ extern ChiLog& chi_log;
 //###################################################################
 /**This is the entry point for sweeping.*/
 void chi_mesh::sweep_management::SweepScheduler::
-     Sweep(SweepChunk* in_sweep_chunk)
+     Sweep(SweepChunk& in_sweep_chunk)
 {
-  sweep_chunk = in_sweep_chunk;
-
   if (scheduler_type == SchedulingAlgorithm::FIRST_IN_FIRST_OUT)
-    ScheduleAlgoFIFO();
+    ScheduleAlgoFIFO(in_sweep_chunk);
   else if (scheduler_type == SchedulingAlgorithm::DEPTH_OF_GRAPH)
-    ScheduleAlgoDOG();
+    ScheduleAlgoDOG(in_sweep_chunk);
 }
 
 //###################################################################

--- a/ChiTech/ChiMesh/SweepUtilities/sweepchunk_base.h
+++ b/ChiTech/ChiMesh/SweepUtilities/sweepchunk_base.h
@@ -9,7 +9,7 @@ class chi_mesh::sweep_management::SweepChunk
 {
 public:
   std::vector<double>*        x;
-  bool                        suppress_surface_src;
+  bool                        surface_source_active;
 
   /**
    * Convenient typdef for the moment call back function. See moment_callbacks.
@@ -28,13 +28,19 @@ public:
   std::vector<MomentCallbackF> moment_callbacks;
 
   SweepChunk(std::vector<double>* destination_phi, bool suppress_src)
-    : x(destination_phi), suppress_surface_src(suppress_src)
+    : x(destination_phi), surface_source_active(suppress_src)
   {}
 
   /**Sets the location where flux moments are to be written.*/
   void SetDestinationPhi(std::vector<double>* destination_phi)
   {
     x = destination_phi;
+  }
+
+  /**Activates or deactives the surface src flag.*/
+  void SetSurfaceSourceActiveFlag(bool flag_value)
+  {
+    surface_source_active = flag_value;
   }
 
   virtual ~SweepChunk() = default;

--- a/ChiTech/ChiPhysics/PhysicsMaterial/transportxsections/material_property_transportxsections.h
+++ b/ChiTech/ChiPhysics/PhysicsMaterial/transportxsections/material_property_transportxsections.h
@@ -19,11 +19,11 @@ namespace chi_physics
 class TransportCrossSections : public chi_physics::MaterialProperty
 {
 public:
-  int G=0;                                ///< Total number of Groups
-  int L=0;                                ///< Legendre scattering order
-  int J=0;                                ///< Number of precursors
-  bool is_fissile = false;                ///< Fissile or not
-  std::vector<int> precursor_map;         ///< Precursor mapping
+  size_t num_groups=0;                     ///< Total number of Groups
+  size_t scattering_order=0;               ///< Legendre scattering order
+  size_t num_precursors=0;                 ///< Number of precursors
+  bool is_fissile = false;                 ///< Fissile or not
+  std::vector<size_t> precursor_map;       ///< Precursor mapping
 
   std::vector<double> sigma_tg;           ///< Total cross-section
   std::vector<double> sigma_fg;           ///< Sigmaf cross-section
@@ -68,7 +68,7 @@ private:
 private:
   void Reset()
   {
-    G=L=J=0;
+    num_groups= scattering_order= num_precursors=0;
 
     sigma_tg.clear();
     sigma_fg = sigma_captg = chi_g = nu_sigma_fg = ddt_coeff = sigma_tg;

--- a/ChiTech/ChiPhysics/PhysicsMaterial/transportxsections/prop_transportxs_00_general.cc
+++ b/ChiTech/ChiPhysics/PhysicsMaterial/transportxsections/prop_transportxs_00_general.cc
@@ -11,8 +11,8 @@ extern ChiLog& chi_log;
 chi_physics::TransportCrossSections::TransportCrossSections() :
   chi_physics::MaterialProperty(PropertyType::TRANSPORT_XSECTIONS)
 {
-  G = 0;
-  L = 0;
+  num_groups = 0;
+  scattering_order = 0;
 
   diffusion_initialized = false;
   scattering_initialized = false;
@@ -26,8 +26,8 @@ void chi_physics::TransportCrossSections::
   //======================================== Clear any previous data
   Reset();
 
-  G = in_G;
-  L = 0;
+  num_groups = in_G;
+  scattering_order = 0;
 
   sigma_tg.clear();
   sigma_tg.resize(in_G,in_sigmat);
@@ -52,8 +52,8 @@ void chi_physics::TransportCrossSections::
   //======================================== Clear any previous data
   Reset();
 
-  G = in_G;
-  L = 0;
+  num_groups = in_G;
+  scattering_order = 0;
 
   sigma_tg.resize(in_G,in_sigmat);
   sigma_tg.clear();
@@ -70,7 +70,7 @@ void chi_physics::TransportCrossSections::
 
   auto& ref_matrix = transfer_matrix.back();
 
-  if (G == 1)
+  if (num_groups == 1)
     ref_matrix.SetDiagonal(std::vector<double>(in_G,in_sigmat*c));
   else
     ref_matrix.SetDiagonal(std::vector<double>(in_G,in_sigmat*c*2.0/4.0));
@@ -137,13 +137,13 @@ void chi_physics::TransportCrossSections::
     //============================ Check number of groups
     if (cross_secs.size() == 1)
     {
-      num_grps_G = xs->G;
+      num_grps_G = xs->num_groups;
       if (xs->is_fissile)
-        num_precursors_J = xs->J;
+        num_precursors_J = xs->num_precursors;
     }
     else
     {
-      if (xs->G != num_grps_G)
+      if (xs->num_groups != num_grps_G)
       {
         chi_log.Log(LOG_ALLERROR)
           << "In call to TransportCrossSections::MakeCombined: "
@@ -153,10 +153,10 @@ void chi_physics::TransportCrossSections::
       if (xs->is_fissile)
       {
         if (num_precursors_J == 0) 
-          num_precursors_J = xs->J;
+          num_precursors_J = xs->num_precursors;
         else
         {
-          if (xs->J != num_precursors_J)
+          if (xs->num_precursors != num_precursors_J)
           {
             chi_log.Log(LOG_ALLERROR)
               << "In call to TransportCrossSections::MakeCombined: "
@@ -173,8 +173,8 @@ void chi_physics::TransportCrossSections::
     Nf_total = 1.0; //Avoids divide by 0 when non-fissile
 
   //======================================== Combine 1D cross-sections
-  this->G = num_grps_G;
-  this->J = num_precursors_J;
+  this->num_groups = num_grps_G;
+  this->num_precursors = num_precursors_J;
   sigma_tg.clear();
   sigma_fg.clear();
   sigma_captg.clear();
@@ -198,13 +198,13 @@ void chi_physics::TransportCrossSections::
   lambda.resize(num_precursors_J,0.0);
   gamma.resize(num_precursors_J,0.0);
   chi_d.resize(num_grps_G);
-  for (int g=0; g<G; ++g)
+  for (int g=0; g < num_groups; ++g)
     chi_d[g].resize(num_precursors_J,0.0);
   precursor_map.resize(num_precursors_J,0);
 
   for (size_t x=0; x<cross_secs.size(); ++x)
   {
-    this->L = std::max(this->L,cross_secs[x]->L);
+    this->scattering_order = std::max(this->scattering_order, cross_secs[x]->scattering_order);
 
     double N_i = combinations[x].second;
     double f_i = N_i/N_total;
@@ -221,13 +221,13 @@ void chi_physics::TransportCrossSections::
       nu_d_sigma_fg[g] += cross_secs[x]->nu_d_sigma_fg[g] * N_i;
       ddt_coeff    [g] += cross_secs[x]->ddt_coeff    [g] * f_i;
     }
-    if ((cross_secs[x]->is_fissile) and (cross_secs[x]->J > 0))
+    if ((cross_secs[x]->is_fissile) and (cross_secs[x]->num_precursors > 0))
     {
       for (int j=0; j<num_precursors_J; ++j)
       {
         lambda[j] += cross_secs[x]->lambda[j] * ff_i;
         gamma [j] += cross_secs[x]->gamma [j] * ff_i;
-        for (int g=0; g<G; g++)
+        for (int g=0; g < num_groups; g++)
           chi_d[g][j] += cross_secs[x]->chi_d[g][j] * ff_i;
       }
     }
@@ -239,14 +239,14 @@ void chi_physics::TransportCrossSections::
   // and therefore simply adding them together has to take
   // the sparse matrix's protection mechanisms into account.
   transfer_matrix.clear();
-  transfer_matrix.resize(this->L+1,
+  transfer_matrix.resize(this->scattering_order + 1,
                          chi_math::SparseMatrix(num_grps_G,num_grps_G));
   for (size_t x=0; x<cross_secs.size(); ++x)
   {
-    for (int m=0; m<(cross_secs[x]->L+1); ++m)
+    for (int m=0; m<(cross_secs[x]->scattering_order + 1); ++m)
     {
       auto& xs_tm = cross_secs[x]->transfer_matrix[m];
-      for (int i=0; i<G; ++i)
+      for (int i=0; i < num_groups; ++i)
       {
         for (auto j : xs_tm.rowI_indices[i])
         {

--- a/ChiTech/ChiPhysics/PhysicsMaterial/transportxsections/prop_transportxs_01_readfrompdt.cc
+++ b/ChiTech/ChiPhysics/PhysicsMaterial/transportxsections/prop_transportxs_01_readfrompdt.cc
@@ -76,8 +76,8 @@ void chi_physics::TransportCrossSections::
   file.getline(line,250);
 
   //====================================== Resizing cross-sections
-  G = num_grps_G;
-  L = scat_order;
+  num_groups = num_grps_G;
+  scattering_order = scat_order;
   sigma_tg.clear();
   sigma_tg.resize(num_grps_G,0.0);
   sigma_fg.resize(num_grps_G,0.0);
@@ -135,16 +135,16 @@ void chi_physics::TransportCrossSections::
   {
     mt_number = AdvanceToNextMT(file,file_name);
 
-    if (mt_number == 1)    Read1DXS(sigma_tg,file,G);
-    if (mt_number == 18)   Read1DXS(sigma_fg,file,G);
-    if (mt_number == 27)   Read1DXS(sigma_captg,file,G);
-    if (mt_number == 2018) Read1DXS(chi_g,file,G);
-    if (mt_number == 2452) Read1DXS(nu_sigma_fg,file,G);
+    if (mt_number == 1)    Read1DXS(sigma_tg, file, num_groups);
+    if (mt_number == 18)   Read1DXS(sigma_fg, file, num_groups);
+    if (mt_number == 27)   Read1DXS(sigma_captg, file, num_groups);
+    if (mt_number == 2018) Read1DXS(chi_g, file, num_groups);
+    if (mt_number == 2452) Read1DXS(nu_sigma_fg, file, num_groups);
 
     if (mt_number == mt_transfer)
     {
       ++mom;
-      for (int g=0; g<G; g++)
+      for (int g=0; g < num_groups; g++)
       {
         int sink=-1,gprime_first=-1, gprime_last=-2;
         file.getline(line,250);

--- a/ChiTech/ChiPhysics/PhysicsMaterial/transportxsections/prop_transportxs_01b_readfromchi.cc
+++ b/ChiTech/ChiPhysics/PhysicsMaterial/transportxsections/prop_transportxs_01b_readfromchi.cc
@@ -105,7 +105,7 @@ void chi_physics::TransportCrossSections::
   std::string sectionChecker;
 
   //num moments
-  int M = L;
+  int M = scattering_order;
 
   //#############################################
   /**Lambda for converting strings to doubles.*/
@@ -269,29 +269,29 @@ void chi_physics::TransportCrossSections::
 
 //    chi_log.Log(LOG_0) << line << " _" << first_word << "_";
 
-    if (first_word == "NUM_GROUPS") {line_stream >> G; grabbed_G = true;}
+    if (first_word == "NUM_GROUPS") {line_stream >> num_groups; grabbed_G = true;}
     if (first_word == "NUM_MOMENTS")
     {
       line_stream >> M;
       if (grabbed_G)
       {
-        sigma_tg.resize(G,0.0);
+        sigma_tg.resize(num_groups, 0.0);
         sigma_fg = sigma_captg = chi_g = nu_sigma_fg = ddt_coeff = sigma_tg;
         nu_p_sigma_fg = nu_d_sigma_fg = nu_sigma_fg;
-        transfer_matrix.resize(M,chi_math::SparseMatrix(G,G));
+        transfer_matrix.resize(M,chi_math::SparseMatrix(num_groups, num_groups));
       }
     }
     if (first_word == "NUM_PRECURSORS")
     {
-      line_stream >> J;
-      lambda.resize(J,0.0);
+      line_stream >> num_precursors;
+      lambda.resize(num_precursors, 0.0);
       gamma = lambda;
     
       if (grabbed_G)
       {
-        chi_d.resize(G);
-        for (int g=0; g<G; ++g)
-          chi_d[g].resize(J);
+        chi_d.resize(num_groups);
+        for (int g=0; g < num_groups; ++g)
+          chi_d[g].resize(num_precursors);
       }
     }
 
@@ -302,16 +302,16 @@ void chi_physics::TransportCrossSections::
       auto& f = file;
       auto& fw = first_word;
 
-      if (fw == "SIGMA_T_BEGIN")             Read1DXS ("SIGMA_T",sigma_tg,f,G,ln,ls);
-      if (fw == "SIGMA_F_BEGIN")             Read1DXS("SIGMA_F",sigma_fg,f,G,ln,ls);
-      if (fw == "NU_BEGIN")                  Read1DXS("NU",nu_sigma_fg,f,G,ln,ls);
-      if (fw == "NU_PROMPT_BEGIN")           Read1DXS("NU_PROMPT",nu_p_sigma_fg,f,G,ln,ls);
-      if (fw == "NU_DELAYED_BEGIN")          Read1DXS("NU_DELAYED",nu_d_sigma_fg,f,G,ln,ls);
-      if (fw == "CHI_PROMPT_BEGIN")          Read1DXS("CHI_PROMPT",chi_g,f,G,ln,ls);
-      if (fw == "DDT_COEFF_BEGIN")           Read1DXS("DDT_COEFF",ddt_coeff,f,G,ln,ls);
+      if (fw == "SIGMA_T_BEGIN")             Read1DXS ("SIGMA_T", sigma_tg, f, num_groups, ln, ls);
+      if (fw == "SIGMA_F_BEGIN")             Read1DXS("SIGMA_F", sigma_fg, f, num_groups, ln, ls);
+      if (fw == "NU_BEGIN")                  Read1DXS("NU", nu_sigma_fg, f, num_groups, ln, ls);
+      if (fw == "NU_PROMPT_BEGIN")           Read1DXS("NU_PROMPT", nu_p_sigma_fg, f, num_groups, ln, ls);
+      if (fw == "NU_DELAYED_BEGIN")          Read1DXS("NU_DELAYED", nu_d_sigma_fg, f, num_groups, ln, ls);
+      if (fw == "CHI_PROMPT_BEGIN")          Read1DXS("CHI_PROMPT", chi_g, f, num_groups, ln, ls);
+      if (fw == "DDT_COEFF_BEGIN")           Read1DXS("DDT_COEFF", ddt_coeff, f, num_groups, ln, ls);
 
       if (fw == "TRANSFER_MOMENTS_BEGIN")
-        ReadTransferMatrix("TRANSFER_MOMENTS",transfer_matrix,f,G,ln,ls);
+        ReadTransferMatrix("TRANSFER_MOMENTS", transfer_matrix, f, num_groups, ln, ls);
 
       for (auto& sig_f : sigma_fg) {
         if (sig_f > 0.0) {
@@ -320,11 +320,11 @@ void chi_physics::TransportCrossSections::
         }
       }
 
-      if ((J>0) and (is_fissile)) {
-        if (fw == "PRECURSOR_LAMBDA_BEGIN")    Read1DXS("PRECURSOR_LAMBDA",lambda,f,J,ln,ls);
-        if (fw == "PRECURSOR_GAMMA_BEGIN")     Read1DXS("PRECURSOR_GAMMA",gamma,f,J,ln,ls);
+      if ((num_precursors > 0) and (is_fissile)) {
+        if (fw == "PRECURSOR_LAMBDA_BEGIN")    Read1DXS("PRECURSOR_LAMBDA", lambda, f, num_precursors, ln, ls);
+        if (fw == "PRECURSOR_GAMMA_BEGIN")     Read1DXS("PRECURSOR_GAMMA", gamma, f, num_precursors, ln, ls);
         if (fw == "CHI_DELAYED_BEGIN")
-          ReadDelayedChi("CHI_DELAYED",chi_d,f,G,ln,ls);   
+          ReadDelayedChi("CHI_DELAYED", chi_d, f, num_groups, ln, ls);
       } 
     }
 
@@ -346,10 +346,10 @@ void chi_physics::TransportCrossSections::
     first_word = "";
     not_eof = bool(std::getline(file,line)); ++line_number;
   }
-  L = M-1;
+  scattering_order = M - 1;
 
   //changes nu_sigma_fg from nu to nu * sigma_fg
-  for (int i = 0; i<G;++i){
+  for (int i = 0; i < num_groups; ++i){
     nu_sigma_fg[i] = nu_sigma_fg[i]*sigma_fg[i];
     nu_p_sigma_fg[i] = nu_p_sigma_fg[i]*sigma_fg[i];
     nu_d_sigma_fg[i] = nu_d_sigma_fg[i]*sigma_fg[i];

--- a/ChiTech/ChiPhysics/PhysicsMaterial/transportxsections/prop_transportxs_02_diffparams.cc
+++ b/ChiTech/ChiPhysics/PhysicsMaterial/transportxsections/prop_transportxs_02_diffparams.cc
@@ -9,17 +9,17 @@ void chi_physics::TransportCrossSections::ComputeDiffusionParameters()
   if (diffusion_initialized)
     return;
 
-  diffg.resize(G,1.0);
-  sigma_s_gtog.resize(G,0.0);
-  sigma_rg.resize(G,0.1);
-  sigma_ag.resize(G,0.0);
-  for (int g=0; g<G; g++)
+  diffg.resize(num_groups, 1.0);
+  sigma_s_gtog.resize(num_groups, 0.0);
+  sigma_rg.resize(num_groups, 0.1);
+  sigma_ag.resize(num_groups, 0.0);
+  for (int g=0; g < num_groups; g++)
   {
     //====================================== Determine transport correction
     double sigs_g_1 = 0.0;
     if (transfer_matrix.size()>1)
     {
-      for (int gp=0; gp<G; gp++)
+      for (int gp=0; gp < num_groups; gp++)
       {
         int num_cols = transfer_matrix[1].rowI_indices[gp].size();
         for (int j=0; j<num_cols; j++)
@@ -65,11 +65,11 @@ void chi_physics::TransportCrossSections::ComputeDiffusionParameters()
   }//for g
 
   //====================================== Determine absorbtion x-section
-  for (int g=0; g<G; g++)
+  for (int g=0; g < num_groups; g++)
   {
     sigma_ag[g] = sigma_tg[g];
 
-    for (int g2=0; g2<G; g2++)
+    for (int g2=0; g2 < num_groups; g2++)
     {
       int num_cols = transfer_matrix[0].rowI_indices[g2].size();
       for (int j=0; j<num_cols; j++)

--- a/ChiTech/ChiPhysics/PhysicsMaterial/transportxsections/prop_transportxs_04_scatangles.cc
+++ b/ChiTech/ChiPhysics/PhysicsMaterial/transportxsections/prop_transportxs_04_scatangles.cc
@@ -23,15 +23,15 @@ void chi_physics::TransportCrossSections::ComputeDiscreteScattering(int in_L)
   std::vector<std::vector<double>> prob_gprime_g;        //Dense version of S[0]
   std::vector<std::vector<double>> prob_gprime_g_normed; //Normalized
 
-  prob_gprime_g.       resize(G,std::vector<double>(G,0.0));
-  prob_gprime_g_normed.resize(G,std::vector<double>(G,0.0));
-  std::vector<double>  prob_sum(G,0.0);
+  prob_gprime_g.       resize(num_groups, std::vector<double>(num_groups, 0.0));
+  prob_gprime_g_normed.resize(num_groups, std::vector<double>(num_groups, 0.0));
+  std::vector<double>  prob_sum(num_groups, 0.0);
 
   std::vector<std::vector<double>> prob_g_gprime_normed; //Transpose to be computed
-  prob_g_gprime_normed.resize(G,std::vector<double>(G,0.0));
+  prob_g_gprime_normed.resize(num_groups, std::vector<double>(num_groups, 0.0));
 
   //============================================= Extract the dense version
-  for (int g=0; g<G; g++)
+  for (int g=0; g < num_groups; g++)
   {
     int num_transfer = transfer_matrix[0].rowI_indices[g].size();
     for (int j=0; j<num_transfer; j++)
@@ -42,9 +42,9 @@ void chi_physics::TransportCrossSections::ComputeDiscreteScattering(int in_L)
   }//for g
 
   //============================================= Compute the column sum
-  for (int gp=0; gp<G; gp++)
+  for (int gp=0; gp < num_groups; gp++)
   {
-    for (int g=0; g<G; g++)
+    for (int g=0; g < num_groups; g++)
     {
       prob_gprime_g_normed[g][gp] = prob_gprime_g[g][gp];
 
@@ -57,16 +57,16 @@ void chi_physics::TransportCrossSections::ComputeDiscreteScattering(int in_L)
   //============================================= Compute normalization (CDF)
   //This step just normalizes a given row so
   //that its L1-norm is 1.0
-  for (int g=0; g<G; g++)
-    for (int gp=0; gp<G; gp++)
+  for (int g=0; g < num_groups; g++)
+    for (int gp=0; gp < num_groups; gp++)
       prob_gprime_g_normed[g][gp] /= prob_sum[gp];
 
 
   //============================================= copy cdf
   //This will make the CDF from 0.0 to 1.0
-  cdf_gprime_g.resize(G,std::vector<double>(G,0.0));
-  for (int gp=0; gp<G; gp++)
-    for (int g=0; g<G; g++)
+  cdf_gprime_g.resize(num_groups, std::vector<double>(num_groups, 0.0));
+  for (int gp=0; gp < num_groups; gp++)
+    for (int g=0; g < num_groups; g++)
       cdf_gprime_g[g][gp] = prob_gprime_g_normed[g][gp];
 
    cdf_gprime_g = chi_math::Transpose(cdf_gprime_g);
@@ -76,13 +76,13 @@ void chi_physics::TransportCrossSections::ComputeDiscreteScattering(int in_L)
   //the moments so we can construct the angles
   std::vector<std::vector<std::vector<double>>> moment_gprime_g_m;
   int max_ord = in_L;
-  if (in_L > L) max_ord = L;
+  if (in_L > scattering_order) max_ord = scattering_order;
 
-  moment_gprime_g_m.resize(G);
-  for (int gp=0; gp<G; gp++)
+  moment_gprime_g_m.resize(num_groups);
+  for (int gp=0; gp < num_groups; gp++)
   {
-    moment_gprime_g_m[gp].resize(G);
-    for (int g=0; g<G; g++)
+    moment_gprime_g_m[gp].resize(num_groups);
+    for (int g=0; g < num_groups; g++)
     {
       moment_gprime_g_m[gp][g].resize(max_ord+1,0.0);
       for (int m=0; m<=max_ord; m++)
@@ -94,12 +94,12 @@ void chi_physics::TransportCrossSections::ComputeDiscreteScattering(int in_L)
 
   //============================================= Compute angles
   GolubFischer gb;
-  scat_angles_gprime_g.resize(G);
-  for (int gp=0; gp<G; gp++)
+  scat_angles_gprime_g.resize(num_groups);
+  for (int gp=0; gp < num_groups; gp++)
   {
-    scat_angles_gprime_g[gp].resize(G);
+    scat_angles_gprime_g[gp].resize(num_groups);
 
-    for (int g=0; g<G; g++)
+    for (int g=0; g < num_groups; g++)
     {
       if (transfer_matrix[0].ValueIJ(g,gp) < 1.0e-16) continue;
 

--- a/ChiTech/ChiPhysics/PhysicsMaterial/transportxsections/prop_transportxs_05_pushlua.cc
+++ b/ChiTech/ChiPhysics/PhysicsMaterial/transportxsections/prop_transportxs_05_pushlua.cc
@@ -11,11 +11,11 @@ void chi_physics::TransportCrossSections::PushLuaTable(lua_State *L)
   lua_settable(L,-3);
 
   lua_pushstring(L,"G");
-  lua_pushnumber(L,G);
+  lua_pushnumber(L, num_groups);
   lua_settable(L,-3);
 
   lua_pushstring(L,"L");
-  lua_pushnumber(L,this->L);
+  lua_pushnumber(L,this->scattering_order);
   lua_settable(L,-3);
 
   int g=0;


### PR DESCRIPTION
Changed the nomenclature in the TransportCrossSections class to be more informative.

G -> num_groups
L -> scattering_order
J -> num_precursors

This addresses issue #133.