### PR TITLE
Tiny bug fix

### DIFF
--- a/ChiModules/KEigenvalueSolver/IterativeMethods/power_iteration.cc
+++ b/ChiModules/KEigenvalueSolver/IterativeMethods/power_iteration.cc
@@ -147,7 +147,8 @@ void KEigenvalue::Solver::PowerIteration(LBSGroupset& groupset)
     if (k_converged) break;
   }//for k iterations
 
-  InitializePrecursors();
+  if (options.use_precursors)
+    InitializePrecursors();
   
   double sweep_time = SweepScheduler.GetAverageSweepTime();
   double source_time=


### PR DESCRIPTION
Introduced a check for whether or not to initialize the precursor vector after the power iteration routine. This fixes a bug encountered when running the solver without using precursors.