### PR TITLE
File path bug fix in WritePVTU

### DIFF
--- a/ChiTech/ChiPhysics/FieldFunction/fieldfunction_exportvtk.cc
+++ b/ChiTech/ChiPhysics/FieldFunction/fieldfunction_exportvtk.cc
@@ -12,7 +12,6 @@ extern ChiMPI& chi_mpi;
 #include <vtkCellType.h>
 
 #include <fstream>
-#include <sstream>
 
 //###################################################################
 /**Exports a field function to VTK format.
@@ -121,10 +120,7 @@ void chi_physics::FieldFunction::WritePVTU(const std::string& base_filename,
     chi_mesh::GetCurrentHandler()->volume_mesher->options.mesh_global;
   
   // Cut off path to base_filename
-  std::string filename_short;
-  std::istringstream iss(base_filename);
-  while (std::getline(iss, filename_short, '/'))
-    continue;
+  std::string filename_short = base_filename.substr(base_filename.find_last_of("/\\")+1);
 
   for (int p=0; p<chi_mpi.process_count; p++)
   {

--- a/ChiTech/ChiPhysics/FieldFunction/fieldfunction_exportvtk.cc
+++ b/ChiTech/ChiPhysics/FieldFunction/fieldfunction_exportvtk.cc
@@ -12,7 +12,7 @@ extern ChiMPI& chi_mpi;
 #include <vtkCellType.h>
 
 #include <fstream>
-#include<sstream>
+#include <sstream>
 
 //###################################################################
 /**Exports a field function to VTK format.

--- a/ChiTech/ChiPhysics/FieldFunction/fieldfunction_exportvtk.cc
+++ b/ChiTech/ChiPhysics/FieldFunction/fieldfunction_exportvtk.cc
@@ -122,7 +122,7 @@ void chi_physics::FieldFunction::WritePVTU(const std::string& base_filename,
   // Cut off path to base_filename
   std::string filename_short = base_filename.substr(base_filename.find_last_of("/\\")+1);
 
-  for (int p=0; p<chi_mpi.process_count; p++)
+  for (int p=0; p<chi_mpi.process_count; ++p)
   {
     if (is_global_mesh and p!=0) continue;
 

--- a/ChiTech/ChiPhysics/FieldFunction/fieldfunction_exportvtk.cc
+++ b/ChiTech/ChiPhysics/FieldFunction/fieldfunction_exportvtk.cc
@@ -12,6 +12,7 @@ extern ChiMPI& chi_mpi;
 #include <vtkCellType.h>
 
 #include <fstream>
+#include<sstream>
 
 //###################################################################
 /**Exports a field function to VTK format.
@@ -118,13 +119,19 @@ void chi_physics::FieldFunction::WritePVTU(const std::string& base_filename,
 
   bool is_global_mesh =
     chi_mesh::GetCurrentHandler()->volume_mesher->options.mesh_global;
+  
+  // Cut off path to base_filename
+  std::string filename_short;
+  std::istringstream iss(base_filename);
+  while (std::getline(iss, filename_short, '/'))
+    continue;
 
   for (int p=0; p<chi_mpi.process_count; p++)
   {
     if (is_global_mesh and p!=0) continue;
 
     ofile << "      <Piece Source=\""
-          << base_filename +
+          << filename_short +
              std::string("_") +
              std::to_string(p) +
              std::string(".vtu")


### PR DESCRIPTION
When writing the PVTU file during the exportation of a field function,
each Piece Source included any full or relative path included in the
base_filename variable. Since the pvtu and vtu files reside in the same
folder, this path is incorrect and should be omitted to allow paraview
to locate the vtu files when reading the pvtu. This commit corrects this
issue.