### PR TITLE
Modified precursor behavior to reduce vector sizes with many materials.

### DIFF
--- a/ChiModules/KEigenvalueSolver/initialize_k_solver.cc
+++ b/ChiModules/KEigenvalueSolver/initialize_k_solver.cc
@@ -17,40 +17,28 @@ void KEigenvalue::Solver::InitializeKSolver()
   phi_prev_local.resize(phi_old_local.size(),0.0);
 
   // ----- Init precursors
-  if (options.use_precursors) {
-    num_precursors = 0;
+  if (options.use_precursors)
+  {
+    //clear precursor properties
+    num_precursors = 0.0;
+    max_num_precursors_per_node = 0.0;
 
-    // ----- Count precursors and define mapping
-    /** This computes the total number of precursors
-     // in the problem across all materials and assigns
-     //  a global mapping to the material. For example,
-     //  if material 0 has 6 precursors and material 1
-     //  has 6, the global mapping will give material 0
-     //  precursor IDs 0-5 and material 1 will receive
-     //  precursor IDs 6-11.
-    **/
-    precursor_map.clear();
-
-    // Loop over materials
-    for (auto& xs : material_xs) {
-      // Material precursor mapping vector
-      std::vector<size_t> mat_map;
-
-      // Define the precursor mapping for this material
-      for (size_t j = 0; j < xs->num_precursors; ++j)
-         mat_map.emplace_back(num_precursors + j);
-
-      // Increment the total number of precursors
+    //========== Loop over materials
+    for (auto& xs : material_xs)
+    {
       num_precursors += xs->num_precursors;
-
-      // Add mapping to the precursor map
-      precursor_map.emplace_back(mat_map);
+      if (xs->num_precursors > max_num_precursors_per_node)
+        max_num_precursors_per_node = xs->num_precursors;
     }
 
-    // -----Initialize precursor unknown manager and vector
-    if (num_precursors > 0) {
-      auto pwl = std::static_pointer_cast<SpatialDiscretization_PWLD>(discretization);
-      Nj_unk_man.AddUnknown(chi_math::UnknownType::VECTOR_N, num_precursors);
+    // ----- Initialize precursor unknown manager and vector
+    if (num_precursors > 0)
+    {
+      typedef SpatialDiscretization_PWLD  PWLD;
+      auto pwl = std::static_pointer_cast<PWLD>(discretization);
+
+      Nj_unk_man.AddUnknown(chi_math::UnknownType::VECTOR_N,
+                            max_num_precursors_per_node);
 
       int local_Nj_dof_count = pwl->GetNumLocalDOFs(Nj_unk_man);
       Nj_new_local.resize(local_Nj_dof_count, 0.0);

--- a/ChiModules/KEigenvalueSolver/k_eigenvalue_solver.h
+++ b/ChiModules/KEigenvalueSolver/k_eigenvalue_solver.h
@@ -18,26 +18,11 @@ private:
 public:
 
   // Total number of precursors on all materials
-  size_t num_precursors;
+  size_t  num_precursors;
+  size_t  max_num_precursors_per_node;
 
   // Current estimate of the k-eigenvalue
   double k_eff = 1.0;
-
-  /** This is a local-to-global index mapping for the precursors
-  //  defined on each material. The precursor vector Nj_new_local
-  //  stores all precursor concentrations defined in the problem
-  //  on each node, whether a precursor exists on the material a
-  //  node is located on. This necessitates a global numbering
-  //  system for the precursors. The TransportCrossSections
-  // class defines all precursor information locally, with indices
-  // from 0 to num_precursors - 1 for that material. The precursor_map
-  // is a vector of vectors containing the global numbering of the
-  // precursor species. The outer vector is of the same length as
-  // the number of material_xs vector. Each of the inner vectors have
-  // length corresponding to num_precursors for the corresponding
-  // TransportCrossSection object.
-  **/
-  std::vector<std::vector<size_t>> precursor_map;
 
   // Additional phi vector
   std::vector<double> phi_prev_local;


### PR DESCRIPTION
## Highlights

- Modified precursor mapping behaviors
- Removed `precursor_map` member in `KEigenvalue::Solver`
-  Mapping of precursors in the precursor vector is now done via local precursor indices.

### Comments

- As the number of materials grows, the number of precursors stored on a node will grow dramatically. This change addresses that the vector does not grow too large.
- This change does present a problem if precursors ever want to be visualized, however, this bridge can be crossed when/if we ever need that.