### PR TITLE
Test runner - more thorough checking for cluster

### DIFF
--- a/ChiTest/Z_Run_all.py
+++ b/ChiTest/Z_Run_all.py
@@ -36,7 +36,7 @@ tacc = False
 tamu = False
 if "tacc.utexas.edu" in hostname:
     tacc = True
-elif "ne.tamu.edu" in hostname:
+elif "ne.tamu.edu" in hostname and "orchard" in hostname:
     tamu = True
 
 def format3(number):


### PR DESCRIPTION
The logic presently employed to determine whether or not the test runner is executed on the NUEN cluster returns a positive result when executed on any NUEN departmental machine for which the hostname contains ```ne.tamu.edu```. This modification provides a more comprehensive examination of the hostname.