### PR TITLE
File path bug fix for mesh vtk export.

### DIFF
--- a/ChiTech/ChiMesh/MeshContinuum/chi_meshcontinuum_exportvtk.cc
+++ b/ChiTech/ChiMesh/MeshContinuum/chi_meshcontinuum_exportvtk.cc
@@ -209,12 +209,15 @@ void chi_mesh::MeshContinuum::ExportCellsToVTK(const char* baseName)
     bool is_global_mesh =
       chi_mesh::GetCurrentHandler()->volume_mesher->options.mesh_global;
 
-    for (int p=0; p<chi_mpi.process_count; p++)
+    // Cut off path to base_filename
+    std::string filename_short = base_filename.substr(base_filename.find_last_of("/\\")+1);
+
+    for (int p=0; p<chi_mpi.process_count; ++p)
     {
       if (is_global_mesh and p!=0) continue;
 
       ofile << "      <Piece Source=\""
-            << base_filename +
+            << filename_short +
                std::string("_") +
                std::to_string(p) +
                std::string(".vtu")


### PR DESCRIPTION
When writing the PVTU file during the exportation of a mesh,
each Piece Source included any full or relative path included in the
base_filename variable. Since the pvtu and vtu files reside in the same
folder, this path is incorrect and should be omitted to allow paraview
to locate the vtu files when reading the pvtu. This commit corrects this
issue.

This is exactly the same fix at #161 for the field function export.