### PR TITLE
Fixed bug for inv_velocity combining

### DIFF
--- a/ChiTech/ChiPhysics/PhysicsMaterial/transportxsections/prop_transportxs_00_general.cc
+++ b/ChiTech/ChiPhysics/PhysicsMaterial/transportxsections/prop_transportxs_00_general.cc
@@ -235,7 +235,7 @@ void chi_physics::TransportCrossSections::
 
       if (x == 0)
         inv_velocity[g] = cross_secs[x]->inv_velocity[g];
-      else
+      else if (inv_velocity[g] != cross_secs[x]->inv_velocity[g]);
       {
         chi_log.Log(LOG_ALLERROR)
             << "In call to " << __FUNCTION__


### PR DESCRIPTION
This PR is a result of a bug found by @pbehne in #160 in the `MakeCombined` routine.

When combining cross-sections, each group's inverse velocity term should agree across cross-section sets. In its current state, the routine keeps the first cross-section set's inverse velocity term and then throws an error if more than one cross-section set is provided via:

```
if (x == 0)
    inv_velocity[g] = cross_secs[x]->inv_velocity[g]
else
    error
```

Per the error message, this is incorrect and should read:

```
if (x == 0)
    inv_velocity[g] = cross_secs[x]->inv_velocity[g]
else if (inv_velocity[g] != cross_secs[x]->inv_velocity[g])
    error
```

This change has been made.
