### PR TITLE
Quick-fix for introduced bug

### DIFF
--- a/ChiTech/ChiPhysics/PhysicsMaterial/transportxsections/prop_transportxs_00_general.cc
+++ b/ChiTech/ChiPhysics/PhysicsMaterial/transportxsections/prop_transportxs_00_general.cc
@@ -235,7 +235,7 @@ void chi_physics::TransportCrossSections::
 
       if (x == 0)
         inv_velocity[g] = cross_secs[x]->inv_velocity[g];
-      else if (inv_velocity[g] != cross_secs[x]->inv_velocity[g]);
+      else if (inv_velocity[g] != cross_secs[x]->inv_velocity[g])
       {
         chi_log.Log(LOG_ALLERROR)
             << "In call to " << __FUNCTION__


### PR DESCRIPTION
Fixed a bug introduced in #182 . The only change was the removal of a semi-colon that broke the `KEigenvaleTransport1D_1G` regression test by throwing an error in the `MakeCombined` routine. The regression tests now pass with this change.