### PR TITLE
Added fissile cross section checks.

### DIFF
--- a/ChiModules/LinearBoltzmannSolver/lbs_01b_initmaterials.cc
+++ b/ChiModules/LinearBoltzmannSolver/lbs_01b_initmaterials.cc
@@ -112,38 +112,7 @@ void LinearBoltzmann::Solver::InitMaterials(std::set<int>& material_ids)
         << options.scattering_order << "."
         << " The higher moments will therefore not be used.";
     }
-
-    //====================================== Check fission cross sections
-    if (material_xs[matid_to_xs_map[mat_id]]->is_fissile)
-    {
-      auto xs =
-          std::static_pointer_cast<chi_physics::TransportCrossSections>(
-              material_xs[matid_to_xs_map[mat_id]]);
-
-      //check what quantities have been provided
-      bool has_total = false;
-      bool has_prompt = false;
-      for (size_t g = 0; g < xs->num_groups; ++g)
-      {
-        if (xs->nu[g] > 0.0 and xs->chi[g] > 0.0)
-          has_total = true;
-        if (xs->nu_prompt[g] > 0.0 and xs->chi_prompt[g] > 0.0)
-          has_prompt = true;
-      }
-
-      //ensure correct quantities have been provided
-      if (not options.use_precursors)
-      {
-        if (not has_total and has_prompt)
-        {
-          chi_log.Log(LOG_ALLWARNING)
-              << __FUNCTION__ << ": Total nu/chi were not provided for "
-              << "a calculation without precursors. Setting nu/chi to "
-              << "the nu/chi prompt values.";
-        }
-      }
-    }
-
+    
     materials_list
       << " number of moments "
       << material_xs[matid_to_xs_map[mat_id]]->transfer_matrices.size() << "\n";

--- a/ChiModules/LinearBoltzmannSolver/lbs_01b_initmaterials.cc
+++ b/ChiModules/LinearBoltzmannSolver/lbs_01b_initmaterials.cc
@@ -50,7 +50,7 @@ void LinearBoltzmann::Solver::InitMaterials(std::set<int>& material_ids)
     //====================================== Extract properties
     using MatProperty = chi_physics::PropertyType;
     bool found_transport_xs = false;
-    for (auto property : current_material->properties)
+    for (const auto& property : current_material->properties)
     {
       if (property->Type() == MatProperty::TRANSPORT_XSECTIONS)
       {
@@ -111,6 +111,37 @@ void LinearBoltzmann::Solver::InitMaterials(std::set<int>& material_ids)
         << " the simulation has a scattering order of "
         << options.scattering_order << "."
         << " The higher moments will therefore not be used.";
+    }
+
+    //====================================== Check fission cross sections
+    if (material_xs[matid_to_xs_map[mat_id]]->is_fissile)
+    {
+      auto xs =
+          std::static_pointer_cast<chi_physics::TransportCrossSections>(
+              material_xs[matid_to_xs_map[mat_id]]);
+
+      //check what quantities have been provided
+      bool has_total = false;
+      bool has_prompt = false;
+      for (size_t g = 0; g < xs->num_groups; ++g)
+      {
+        if (xs->nu[g] > 0.0 and xs->chi[g] > 0.0)
+          has_total = true;
+        if (xs->nu_prompt[g] > 0.0 and xs->chi_prompt[g] > 0.0)
+          has_prompt = true;
+      }
+
+      //ensure correct quantities have been provided
+      if (not options.use_precursors)
+      {
+        if (not has_total and has_prompt)
+        {
+          chi_log.Log(LOG_ALLWARNING)
+              << __FUNCTION__ << ": Total nu/chi were not provided for "
+              << "a calculation without precursors. Setting nu/chi to "
+              << "the nu/chi prompt values.";
+        }
+      }
     }
 
     materials_list

--- a/ChiTech/ChiPhysics/PhysicsMaterial/transportxsections/prop_transportxs_00_general.cc
+++ b/ChiTech/ChiPhysics/PhysicsMaterial/transportxsections/prop_transportxs_00_general.cc
@@ -236,18 +236,16 @@ void chi_physics::TransportCrossSections::
       if (x == 0)
         inv_velocity[g] = cross_secs[x]->inv_velocity[g];
       else if (inv_velocity[g] != cross_secs[x]->inv_velocity[g])
-      {
-        chi_log.Log(LOG_ALLERROR)
+        chi_log.Log(LOG_ALLWARNING)
             << "In call to " << __FUNCTION__
             << ": all materials must have the same inverse velocity "
-            << "term per group. Invalid inverse velocity encountered "
-            << "in material " << x << ", group " << g << ".";
-        exit(EXIT_FAILURE);
-      }
+            << "term per group. Invalid value encountered in "
+            << "material " << x << " group " << g << ". Using the "
+            << "value from the first cross-section set.";
     }
 
     //======================================== Compute precursor
-    // Here, all precursors are across all materials are stored.
+    // Here, all precursors across all materials are stored.
     // The decay constants and delayed spectrum are what they are,
     // however, some special treatment must be given to the yields.
     // Because the yield tells us what fraction of delayed neutrons
@@ -259,11 +257,11 @@ void chi_physics::TransportCrossSections::
     {
       for (size_t j = 0; j < cross_secs[x]->num_precursors; ++j)
       {
-        size_t j_map = precursor_count + j;
-        precursor_lambda[j_map] = cross_secs[x]->precursor_lambda[j];
-        precursor_yield [j_map] = cross_secs[x]->precursor_yield [j] * pf_i;
-        for (int g=0; g < num_groups; g++)
-          chi_delayed[g][j_map] = cross_secs[x]->chi_delayed[g][j];
+        size_t count = precursor_count + j;
+        precursor_lambda[count] = cross_secs[x]->precursor_lambda[j];
+        precursor_yield [count] = cross_secs[x]->precursor_yield [j] * pf_i;
+        for (size_t g = 0; g < num_groups; ++g)
+          chi_delayed[g][count] = cross_secs[x]->chi_delayed[g][j];
       }
       precursor_count += cross_secs[x]->num_precursors;
     }

--- a/ChiTech/ChiPhysics/PhysicsMaterial/transportxsections/prop_transportxs_01b_readfromchi.cc
+++ b/ChiTech/ChiPhysics/PhysicsMaterial/transportxsections/prop_transportxs_01b_readfromchi.cc
@@ -5,7 +5,7 @@ extern ChiLog& chi_log;
 
 #include <string>
 
-double eps = std::numeric_limits<float>::epsilon();
+double eps = 1.0e-8;
 
 /**\defgroup ChiXSFile Chi-Tech Cross-section format 1
  *\ingroup LuaPhysicsMaterials

--- a/ChiTech/ChiPhysics/PhysicsMaterial/transportxsections/prop_transportxs_01b_readfromchi.cc
+++ b/ChiTech/ChiPhysics/PhysicsMaterial/transportxsections/prop_transportxs_01b_readfromchi.cc
@@ -627,7 +627,6 @@ void chi_physics::TransportCrossSections::
         }
       }
 
-
       if (num_lambdas != num_precursors)
       {
         chi_log.Log(LOG_ALLERROR)


### PR DESCRIPTION
### Highlights

- This PR is meant to resolve #146 
- Added various checks to ensure fission related cross sections are appropriate for the application.
- Enforce that `nu`/`chi`, `nu_prompt`/`chi_prompt`, or both are provided in all problems with fission.
- Enforce that `precursor_lambda`, `precursor_yield`, `nu_delayed`, and `chi_delayed` are provided if `num_precursors` is non-zero
-  Enforce unit `precursor_yield` and all `chi` spectra.
- If prompt and delayed quantities are provided, automatically compute `nu = nu_prompt + nu_delayed` and `chi` from `nu`- and `precursor_yield`-weighted prompt and delayed spectra.