### PR TITLE
Always build FE cell matrices.

### DIFF
--- a/ChiModules/DiffusionSolver/Solver/main_initialize.cc
+++ b/ChiModules/DiffusionSolver/Solver/main_initialize.cc
@@ -37,19 +37,19 @@ int chi_diffusion::Solver::Initialize(bool verbose)
     using namespace chi_math::finite_element;
     case PWLC: {
       discretization =
-        SpatialDiscretization_PWLC::New(grid, COMPUTE_UNIT_INTEGRALS);
+        SpatialDiscretization_PWLC::New(grid);
       unknown_manager.AddUnknown(chi_math::UnknownType::SCALAR);
       break;
     }
     case PWLD_MIP: {
       discretization =
-        SpatialDiscretization_PWLD::New(grid, COMPUTE_UNIT_INTEGRALS);
+        SpatialDiscretization_PWLD::New(grid);
       unknown_manager.AddUnknown(chi_math::UnknownType::SCALAR);
       break;
     }
     case PWLD_MIP_GAGG: {
       discretization =
-        SpatialDiscretization_PWLD::New(grid, COMPUTE_UNIT_INTEGRALS);
+        SpatialDiscretization_PWLD::New(grid);
       unknown_manager.AddUnknown(chi_math::UnknownType::VECTOR_N, G);
       break;
     }

--- a/ChiModules/LBSCurvilinear/lbs_curvilinear_solver.cc
+++ b/ChiModules/LBSCurvilinear/lbs_curvilinear_solver.cc
@@ -254,9 +254,7 @@ LBSCurvilinear::Solver::InitializeSpatialDiscretization()
 {
   chi_log.Log(LOG_0) << "Initializing spatial discretization.\n";
 
-  const auto setup_flags =
-    chi_math::finite_element::COMPUTE_CELL_MAPPINGS |
-    chi_math::finite_element::COMPUTE_UNIT_INTEGRALS;
+  const auto setup_flags = chi_math::finite_element::NO_FLAGS_SET;
   auto qorder = chi_math::QuadratureOrder::INVALID_ORDER;
   auto system = chi_math::CoordinateSystemType::UNDEFINED;
 

--- a/ChiModules/LinearBoltzmannSolver/lbs_01c_init_spat_discr.cc
+++ b/ChiModules/LinearBoltzmannSolver/lbs_01c_init_spat_discr.cc
@@ -15,8 +15,7 @@ void LinearBoltzmann::Solver::InitializeSpatialDiscretization()
   using namespace chi_math::finite_element;
   chi_log.Log(LOG_0) << "Initializing spatial discretization.\n";
   discretization =
-    SpatialDiscretization_PWLD::New(grid, COMPUTE_CELL_MAPPINGS |
-                                          COMPUTE_UNIT_INTEGRALS);
+    SpatialDiscretization_PWLD::New(grid);
 
 
   MPI_Barrier(MPI_COMM_WORLD);

--- a/ChiModules/LinearBoltzmannSolver/lbs_linear_boltzmann_solver.h
+++ b/ChiModules/LinearBoltzmannSolver/lbs_linear_boltzmann_solver.h
@@ -3,7 +3,7 @@
 
 #include "ChiPhysics/SolverBase/chi_solver.h"
 
-#include "GroupSet/lbs_groupset.h"
+#include "Groupset/lbs_groupset.h"
 #include "ChiPhysics/PhysicsMaterial/transportxsections/material_property_transportxsections.h"
 #include "ChiPhysics/PhysicsMaterial/material_property_isotropic_mg_src.h"
 #include "ChiMath/SpatialDiscretization/spatial_discretization.h"

--- a/ChiTech/ChiMath/SpatialDiscretization/FiniteElement/PiecewiseLinear/pwl.h
+++ b/ChiTech/ChiMath/SpatialDiscretization/FiniteElement/PiecewiseLinear/pwl.h
@@ -19,223 +19,141 @@
  * or a Discontinuous Finite Element Method (DFEM). */
 class SpatialDiscretization_PWLD : public SpatialDiscretization_FE
 {
-public:
-  std::vector<std::shared_ptr<CellMappingFE_PWL>> cell_mappings;
-
 private:
-  bool                     mapping_initialized=false;
-  bool                     nb_mapping_initialized=false;
+  typedef chi_math::finite_element::UnitIntegralData UIData;
+  typedef chi_math::finite_element::InternalQuadraturePointData QPDataVol;
+  typedef chi_math::finite_element::FaceQuadraturePointData QPDataFace;
+
+  std::map<uint64_t, chi_mesh::Cell*>  neighbor_cells;
+  std::map<uint64_t, std::shared_ptr<CellMappingFE_PWL>> neighbor_cell_fe_views;
+  std::map<uint64_t, UIData> nb_fe_unit_integrals;
+  std::map<uint64_t, QPDataVol> nb_fe_vol_qp_data;
+  std::map<uint64_t, std::vector<QPDataFace>> nb_fe_srf_qp_data;
+
+  //00
+  explicit SpatialDiscretization_PWLD(chi_mesh::MeshContinuumPtr& in_grid,
+      chi_math::finite_element::SetupFlags setup_flags,
+      chi_math::QuadratureOrder qorder,
+      chi_math::CoordinateSystemType in_cs_type);
+
+  //01
+  std::shared_ptr<CellMappingFE_PWL> MakeCellMappingFE(const chi_mesh::Cell& cell) const;
+
+  void PreComputeCellSDValues() override;
+
+  void PreComputeNeighborCellSDValues();
+
+  //02
+  void OrderNodes();
+
 public:
+  unsigned int local_base_block_size = 0;
+  unsigned int globl_base_block_size = 0;
+  int local_block_address = 0;
+
+  std::vector<std::shared_ptr<CellMappingFE_PWL>> cell_mappings;
+  std::vector<int> cell_local_block_address;
+  std::vector<std::pair<int,int>> neighbor_cell_block_address;
+  std::vector<int> locJ_block_size;
+
   chi_math::QuadratureLine          line_quad_order_arbitrary;
   chi_math::QuadratureTriangle      tri_quad_order_arbitrary;
   chi_math::QuadratureQuadrilateral quad_quad_order_arbitrary;
   chi_math::QuadratureTetrahedron   tet_quad_order_arbitrary;
   chi_math::QuadratureHexahedron    hex_quad_order_arbitrary;
 
-//  std::map<int,int> node_mapping;
-
-  int              local_block_address = 0;
-  std::vector<int> cell_local_block_address;
-  std::vector<std::pair<int,int>> neighbor_cell_block_address;
-
-//  std::vector<int> locJ_block_address;
-  std::vector<int> locJ_block_size;
-
-  unsigned int local_base_block_size=0;
-  unsigned int globl_base_block_size=0;
-
-private:
-  std::map<uint64_t, chi_mesh::Cell*>  neighbor_cells;
-  std::map<uint64_t, std::shared_ptr<CellMappingFE_PWL>> neighbor_cell_fe_views;
-
-private:
-  typedef chi_math::finite_element::UnitIntegralData UIData;
-  typedef chi_math::finite_element::InternalQuadraturePointData QPDataVol;
-  typedef chi_math::finite_element::FaceQuadraturePointData QPDataFace;
-
-  std::map<uint64_t, UIData>                  nb_fe_unit_integrals;
-  std::map<uint64_t, QPDataVol>               nb_fe_vol_qp_data;
-  std::map<uint64_t, std::vector<QPDataFace>> nb_fe_srf_qp_data;
-
-  bool nb_integral_data_initialized=false;
-  bool nb_qp_data_initialized=false;
-
-private:
-  chi_math::finite_element::UnitIntegralData            scratch_intgl_data;
-  chi_math::finite_element::InternalQuadraturePointData scratch_vol_qp_data;
-  chi_math::finite_element::FaceQuadraturePointData     scratch_face_qp_data;
-
-private:
-  //00
-  explicit
-  SpatialDiscretization_PWLD(chi_mesh::MeshContinuumPtr& in_grid,
-                             chi_math::finite_element::SetupFlags setup_flags,
-                             chi_math::QuadratureOrder qorder,
-                             chi_math::CoordinateSystemType in_cs_type);
-
-public:
   //prevent anything else other than a shared pointer
-  static
-  std::shared_ptr<SpatialDiscretization_PWLD>
-  New(chi_mesh::MeshContinuumPtr& in_grid,
-      chi_math::finite_element::SetupFlags setup_flags=
+  static std::shared_ptr<SpatialDiscretization_PWLD> New(
+      chi_mesh::MeshContinuumPtr& in_grid,
+      chi_math::finite_element::SetupFlags setup_flags =
       chi_math::finite_element::SetupFlags::NO_FLAGS_SET,
       chi_math::QuadratureOrder qorder =
       chi_math::QuadratureOrder::SECOND,
       chi_math::CoordinateSystemType in_cs_type =
       chi_math::CoordinateSystemType::CARTESIAN)
-  { if (in_grid == nullptr) throw std::invalid_argument(
-      "Null supplied as grid to SpatialDiscretization_PWLD.");
+  { 
+    if (in_grid == nullptr) throw std::invalid_argument(
+          "Null supplied as grid to SpatialDiscretization_PWLD.");
     return std::shared_ptr<SpatialDiscretization_PWLD>(
-    new SpatialDiscretization_PWLD(in_grid, setup_flags, qorder, in_cs_type));}
+    new SpatialDiscretization_PWLD(in_grid, setup_flags, qorder, in_cs_type));
+  }
 
   //01
-private:
-  std::shared_ptr<CellMappingFE_PWL> MakeCellMappingFE(const chi_mesh::Cell& cell) const;
-
-public:
-
-  void PreComputeCellSDValues() override;
-  void PreComputeNeighborCellSDValues();
   std::shared_ptr<CellMappingFE_PWL> GetCellMappingFE(uint64_t cell_local_index);
+
   chi_mesh::Cell&  GetNeighborCell(uint64_t cell_glob_index);
+
   std::shared_ptr<CellMappingFE_PWL> GetNeighborCellMappingFE(uint64_t cell_glob_index);
 
-private:
-  //02
-  void OrderNodes();
-
-public:
   //03
   void BuildSparsityPattern(std::vector<int64_t>& nodal_nnz_in_diag,
-                            std::vector<int64_t>& nodal_nnz_off_diag,
-                            chi_math::UnknownManager& unknown_manager) override;
+      std::vector<int64_t>& nodal_nnz_off_diag,
+      chi_math::UnknownManager& unknown_manager) override;
 
   //04
   int64_t MapDOF(const chi_mesh::Cell& cell,
-                 unsigned int node,
-                 const chi_math::UnknownManager& unknown_manager,
-                 unsigned int unknown_id,
-                 unsigned int component) const override;
+      unsigned int node,
+      const chi_math::UnknownManager& unknown_manager,
+      unsigned int unknown_id,
+      unsigned int component) const override;
+
   int64_t MapDOFLocal(const chi_mesh::Cell& cell,
-                      unsigned int node,
-                      const chi_math::UnknownManager& unknown_manager,
-                      unsigned int unknown_id,
-                      unsigned int component) const override;
+      unsigned int node,
+      const chi_math::UnknownManager& unknown_manager,
+      unsigned int unknown_id,
+      unsigned int component) const override;
 
   int64_t MapDOF(const chi_mesh::Cell& cell, unsigned int node) const override
-  { return MapDOF(cell,node,ChiMath::UNITARY_UNKNOWN_MANAGER,0,0); }
+  { 
+    return MapDOF(cell,node,ChiMath::UNITARY_UNKNOWN_MANAGER,0,0);
+  }
+
   int64_t MapDOFLocal(const chi_mesh::Cell& cell, unsigned int node) const override
-  { return MapDOFLocal(cell,node,ChiMath::UNITARY_UNKNOWN_MANAGER,0,0); }
+  { 
+    return MapDOFLocal(cell,node,ChiMath::UNITARY_UNKNOWN_MANAGER,0,0);
+  }
 
   //05
   size_t GetNumLocalDOFs(chi_math::UnknownManager& unknown_manager) override;
+
   size_t GetNumGlobalDOFs(chi_math::UnknownManager& unknown_manager) override;
-//  unsigned int GetNumGhostDOFs(chi_mesh::MeshContinuumPtr grid,
-//                               chi_math::UnknownManager* unknown_manager);
-//
-//  std::vector<int> GetGhostDOFIndices(chi_mesh::MeshContinuumPtr grid,
-//                                      chi_math::UnknownManager* unknown_manager,
-//                                      unsigned int unknown_id=0);
 
   size_t GetCellNumNodes(const chi_mesh::Cell& cell) const override
-  {return cell.vertex_ids.size();}
+  {
+    return cell.vertex_ids.size();
+  }
 
   void LocalizePETScVector(Vec petsc_vector,
-                           std::vector<double>& local_vector,
-                           chi_math::UnknownManager& unknown_manager)
-                           override;
+      std::vector<double>& local_vector,
+      chi_math::UnknownManager& unknown_manager) override;
 
   //FE-utils
   const chi_math::finite_element::UnitIntegralData&
-    GetUnitIntegrals(const chi_mesh::Cell& cell) override
+      GetUnitIntegrals(const chi_mesh::Cell& cell) override
   {
     if (ref_grid->IsCellLocal(cell.global_id))
-    {
-      if (integral_data_initialized)
-        return fe_unit_integrals.at(cell.local_id);
-      else
-      {
-        auto cell_fe_view = GetCellMappingFE(cell.local_id);
-        scratch_intgl_data.Reset();
-        cell_fe_view->ComputeUnitIntegrals(scratch_intgl_data);
-        return scratch_intgl_data;
-      }
-    }
-    else
-    {
-      if (nb_integral_data_initialized)
-        return nb_fe_unit_integrals.at(cell.global_id);
-      else
-      {
-        auto cell_fe_view = GetNeighborCellMappingFE(cell.global_id);
-        cell_fe_view->ComputeUnitIntegrals(scratch_intgl_data);
-        return scratch_intgl_data;
-      }
-    }
+      return fe_unit_integrals.at(cell.local_id);
+    return nb_fe_unit_integrals.at(cell.global_id);
   }
 
   const chi_math::finite_element::InternalQuadraturePointData&
-    GetQPData_Volumetric(const chi_mesh::Cell& cell) override
+      GetQPData_Volumetric(const chi_mesh::Cell& cell) override
   {
     if (ref_grid->IsCellLocal(cell.global_id))
-    {
-      if (qp_data_initialized)
-        return fe_vol_qp_data.at(cell.local_id);
-      else
-      {
-        auto cell_fe_view = GetCellMappingFE(cell.local_id);
-        cell_fe_view->InitializeVolumeQuadraturePointData(scratch_vol_qp_data);
-        return scratch_vol_qp_data;
-      }
-    }
-    else
-    {
-      if (nb_qp_data_initialized)
-        return nb_fe_vol_qp_data.at(cell.global_id);
-      else
-      {
-        auto cell_fe_view = GetNeighborCellMappingFE(cell.global_id);
-        cell_fe_view->InitializeVolumeQuadraturePointData(scratch_vol_qp_data);
-        return scratch_vol_qp_data;
-      }
-    }
+      return fe_vol_qp_data.at(cell.local_id);
+    return nb_fe_vol_qp_data.at(cell.global_id);
   }
 
   const chi_math::finite_element::FaceQuadraturePointData&
-    GetQPData_Surface(const chi_mesh::Cell& cell,
-                      const unsigned int face) override
+      GetQPData_Surface(const chi_mesh::Cell& cell, const unsigned int face) override
   {
     if (ref_grid->IsCellLocal(cell.global_id))
     {
-      if (qp_data_initialized)
-      {
-        const auto& face_data = fe_srf_qp_data.at(cell.local_id);
-
-        return face_data.at(face);
-      }
-      else
-      {
-        auto cell_fe_view = GetCellMappingFE(cell.local_id);
-        cell_fe_view->InitializeFaceQuadraturePointData(face, scratch_face_qp_data);
-        return scratch_face_qp_data;
-      }
+      const auto& face_data = fe_srf_qp_data.at(cell.local_id);
+      return face_data.at(face);
     }
-    else
-    {
-      if (nb_qp_data_initialized)
-      {
-        const auto& face_data = nb_fe_srf_qp_data.at(cell.global_id);
-
-        return face_data.at(face);
-      }
-      else
-      {
-        auto cell_fe_view = GetNeighborCellMappingFE(cell.global_id);
-        cell_fe_view->InitializeFaceQuadraturePointData(face, scratch_face_qp_data);
-        return scratch_face_qp_data;
-      }
-    }
+    const auto& face_data = nb_fe_srf_qp_data.at(cell.global_id);
+    return face_data.at(face);
   }
 };
 

--- a/ChiTech/ChiMath/SpatialDiscretization/FiniteElement/PiecewiseLinear/pwl_00_constrdestr.cc
+++ b/ChiTech/ChiMath/SpatialDiscretization/FiniteElement/PiecewiseLinear/pwl_00_constrdestr.cc
@@ -30,71 +30,64 @@ SpatialDiscretization_PWLD::
                 << " Communicating partition neighbors.";
   ref_grid->CommunicatePartitionNeighborCells(neighbor_cells);
 
-  if (setup_flags == chi_math::finite_element::COMPUTE_UNIT_INTEGRALS)
+  int qorder_min = static_cast<int>(chi_math::QuadratureOrder::INVALID_ORDER);
+  switch (cs_type)
   {
-    int qorder_min = static_cast<int>(chi_math::QuadratureOrder::INVALID_ORDER);
-    switch (cs_type)
+    case chi_math::CoordinateSystemType::CARTESIAN:
     {
-      case chi_math::CoordinateSystemType::CARTESIAN:
-      {
-        qorder_min = static_cast<int>(chi_math::QuadratureOrder::SECOND);
-        break;
-      }
-      case chi_math::CoordinateSystemType::CYLINDRICAL:
-      {
-        qorder_min = static_cast<int>(chi_math::QuadratureOrder::THIRD);
-        break;
-      }
-      case chi_math::CoordinateSystemType::SPHERICAL:
-      {
-        qorder_min = static_cast<int>(chi_math::QuadratureOrder::FOURTH);
-        break;
-      }
-      default:
-        throw std::invalid_argument("SpatialDiscretization_PWLD::SpatialDiscretization_PWLD : "
-                                    "Unsupported coordinate system type encountered.");
+      qorder_min = static_cast<int>(chi_math::QuadratureOrder::SECOND);
+      break;
     }
-
-    if (static_cast<int>(line_quad_order_arbitrary.order) < qorder_min)
-      chi_log.Log(LOG_ALLWARNING)
-        << "SpatialDiscretization_PWLD::SpatialDiscretization_PWLD : "
-        << "static_cast<int>(line_quad_order_arbitrary.order) < "
-        << qorder_min << ".";
-
-    if (static_cast<int>(tri_quad_order_arbitrary.order) < qorder_min)
-      chi_log.Log(LOG_ALLWARNING)
-        << "SpatialDiscretization_PWLD::SpatialDiscretization_PWLD : "
-        << "static_cast<int>(tri_quad_order_arbitrary.order) < "
-        << qorder_min << ".";
-
-    if (static_cast<int>(quad_quad_order_arbitrary.order) < qorder_min)
-      chi_log.Log(LOG_ALLWARNING)
-        << "SpatialDiscretization_PWLD::SpatialDiscretization_PWLD : "
-        << "static_cast<int>(quad_quad_order_arbitrary.order) < "
-        << qorder_min << ".";
-
-    if (static_cast<int>(tet_quad_order_arbitrary.order) < qorder_min)
-      chi_log.Log(LOG_ALLWARNING)
-        << "SpatialDiscretization_PWLD::SpatialDiscretization_PWLD : "
-        << "static_cast<int>(tet_quad_order_arbitrary.order) < "
-        << qorder_min << ".";
-
-    if (static_cast<int>(hex_quad_order_arbitrary.order) < qorder_min)
-      chi_log.Log(LOG_ALLWARNING)
-        << "SpatialDiscretization_PWLD::SpatialDiscretization_PWLD : "
-        << "static_cast<int>(hex_quad_order_arbitrary.order) < "
-        << qorder_min << ".";
+    case chi_math::CoordinateSystemType::CYLINDRICAL:
+    {
+      qorder_min = static_cast<int>(chi_math::QuadratureOrder::THIRD);
+      break;
+    }
+    case chi_math::CoordinateSystemType::SPHERICAL:
+    {
+      qorder_min = static_cast<int>(chi_math::QuadratureOrder::FOURTH);
+      break;
+    }
+    default:
+      throw std::invalid_argument("SpatialDiscretization_PWLD::SpatialDiscretization_PWLD : "
+                                  "Unsupported coordinate system type encountered.");
   }
 
-  if (setup_flags != chi_math::finite_element::NO_FLAGS_SET)
-  {
-    PreComputeCellSDValues();
-    PreComputeNeighborCellSDValues();
-  }
+  if (static_cast<int>(line_quad_order_arbitrary.order) < qorder_min)
+    chi_log.Log(LOG_ALLWARNING)
+      << "SpatialDiscretization_PWLD::SpatialDiscretization_PWLD : "
+      << "static_cast<int>(line_quad_order_arbitrary.order) < "
+      << qorder_min << ".";
+
+  if (static_cast<int>(tri_quad_order_arbitrary.order) < qorder_min)
+    chi_log.Log(LOG_ALLWARNING)
+      << "SpatialDiscretization_PWLD::SpatialDiscretization_PWLD : "
+      << "static_cast<int>(tri_quad_order_arbitrary.order) < "
+      << qorder_min << ".";
+
+  if (static_cast<int>(quad_quad_order_arbitrary.order) < qorder_min)
+    chi_log.Log(LOG_ALLWARNING)
+      << "SpatialDiscretization_PWLD::SpatialDiscretization_PWLD : "
+      << "static_cast<int>(quad_quad_order_arbitrary.order) < "
+      << qorder_min << ".";
+
+  if (static_cast<int>(tet_quad_order_arbitrary.order) < qorder_min)
+    chi_log.Log(LOG_ALLWARNING)
+      << "SpatialDiscretization_PWLD::SpatialDiscretization_PWLD : "
+      << "static_cast<int>(tet_quad_order_arbitrary.order) < "
+      << qorder_min << ".";
+
+  if (static_cast<int>(hex_quad_order_arbitrary.order) < qorder_min)
+    chi_log.Log(LOG_ALLWARNING)
+      << "SpatialDiscretization_PWLD::SpatialDiscretization_PWLD : "
+      << "static_cast<int>(hex_quad_order_arbitrary.order) < "
+      << qorder_min << ".";
+
+  PreComputeCellSDValues();
+  PreComputeNeighborCellSDValues();
 
   OrderNodes();
   chi_log.Log() << chi_program_timer.GetTimeString()
                 << " Done creating Piecewise Linear Discontinuous "
                    "Finite Element spatial discretizaiton.";
 }
-

--- a/ChiTech/ChiMath/SpatialDiscretization/FiniteElement/PiecewiseLinear/pwl_01_addviewofcont.cc
+++ b/ChiTech/ChiMath/SpatialDiscretization/FiniteElement/PiecewiseLinear/pwl_01_addviewofcont.cc
@@ -123,44 +123,28 @@ void SpatialDiscretization_PWLD::PreComputeCellSDValues()
   //                                                 for each cell
   {
     using namespace chi_math::finite_element;
-    if (setup_flags & SetupFlags::COMPUTE_CELL_MAPPINGS)
-    {
-      if (!mapping_initialized)
-      {
-        chi_log.Log() << chi_program_timer.GetTimeString()
-                      << " Computing cell views";
-        for (const auto& cell : ref_grid->local_cells)
-          cell_mappings.push_back(MakeCellMappingFE(cell));
-
-        mapping_initialized = true;
-      }
-    }
+    chi_log.Log() << chi_program_timer.GetTimeString()
+                  << " Computing cell views";
+    for (const auto& cell : ref_grid->local_cells)
+      cell_mappings.push_back(MakeCellMappingFE(cell));
   }
   MPI_Barrier(MPI_COMM_WORLD);
 
   //============================================= Unit integrals
   {
     using namespace chi_math::finite_element;
-    if (setup_flags & SetupFlags::COMPUTE_UNIT_INTEGRALS)
+    chi_log.Log() << chi_program_timer.GetTimeString()
+                  << " Computing unit integrals.";
+    fe_unit_integrals.reserve(num_local_cells);
+    for (size_t lc=0; lc<num_local_cells; ++lc)
     {
-      if (not integral_data_initialized)
-      {
-        chi_log.Log() << chi_program_timer.GetTimeString()
-                      << " Computing unit integrals.";
-        fe_unit_integrals.reserve(num_local_cells);
-        for (size_t lc=0; lc<num_local_cells; ++lc)
-        {
-          UIData ui_data;
+      UIData ui_data;
 
-          auto cell_fe_view = GetCellMappingFE(lc);
-          cell_fe_view->ComputeUnitIntegrals(ui_data);
+      auto cell_fe_view = GetCellMappingFE(lc);
+      cell_fe_view->ComputeUnitIntegrals(ui_data);
 
-          fe_unit_integrals.push_back(std::move(ui_data));
-        }
-
-        integral_data_initialized = true;
-      }
-    }//if compute unit intgrls
+      fe_unit_integrals.push_back(std::move(ui_data));
+    }
   }
   MPI_Barrier(MPI_COMM_WORLD);
 
@@ -168,27 +152,19 @@ void SpatialDiscretization_PWLD::PreComputeCellSDValues()
   //============================================= Quadrature data
   {
     using namespace chi_math::finite_element;
-    if (setup_flags & SetupFlags::COMPUTE_QP_DATA)
+    chi_log.Log() << chi_program_timer.GetTimeString()
+                  << " Computing quadrature data.";
+    fe_vol_qp_data.reserve(num_local_cells);
+    fe_srf_qp_data.reserve(num_local_cells);
+    for (size_t lc=0; lc<num_local_cells; ++lc)
     {
-      if (not qp_data_initialized)
-      {
-        chi_log.Log() << chi_program_timer.GetTimeString()
-                      << " Computing quadrature data.";
-        fe_vol_qp_data.reserve(num_local_cells);
-        fe_srf_qp_data.reserve(num_local_cells);
-        for (size_t lc=0; lc<num_local_cells; ++lc)
-        {
-          fe_vol_qp_data.emplace_back();
-          fe_srf_qp_data.emplace_back();
+      fe_vol_qp_data.emplace_back();
+      fe_srf_qp_data.emplace_back();
 
-          auto cell_fe_view = GetCellMappingFE(lc);
-          cell_fe_view->InitializeAllQuadraturePointData(fe_vol_qp_data.back(),
-                                                         fe_srf_qp_data.back());
-        }
-
-        qp_data_initialized = true;
-      }
-    }//if init qp data
+      auto cell_fe_view = GetCellMappingFE(lc);
+      cell_fe_view->InitializeAllQuadraturePointData(fe_vol_qp_data.back(),
+                                                     fe_srf_qp_data.back());
+    }
   }
 }//AddViewOfLocalContinuum
 
@@ -199,80 +175,55 @@ void SpatialDiscretization_PWLD::PreComputeNeighborCellSDValues()
   //================================================== Populate cell fe views
   {
     using namespace chi_math::finite_element;
-    if (setup_flags & SetupFlags::COMPUTE_CELL_MAPPINGS)
+    chi_log.Log() << chi_program_timer.GetTimeString()
+                  << " Computing neighbor cell views.";
+    for (auto& cell_map : neighbor_cells)
     {
-      if (not nb_mapping_initialized)
-      {
-        chi_log.Log() << chi_program_timer.GetTimeString()
-                      << " Computing neighbor cell views.";
-        for (auto& cell_map : neighbor_cells)
-        {
-          const auto& cell = *cell_map.second;
+      const auto& cell = *cell_map.second;
 
-          neighbor_cell_fe_views.insert(
-            std::make_pair(cell.global_id, MakeCellMappingFE(cell)));
-        }//for num cells
-
-        nb_mapping_initialized = true;
-      }
-    }
+      neighbor_cell_fe_views.insert(
+        std::make_pair(cell.global_id, MakeCellMappingFE(cell)));
+    }//for num cells
   }
   MPI_Barrier(MPI_COMM_WORLD);
 
   //============================================= Unit integrals
   {
     using namespace chi_math::finite_element;
-    if (setup_flags & SetupFlags::COMPUTE_UNIT_INTEGRALS)
+    chi_log.Log() << chi_program_timer.GetTimeString()
+                  << " Computing neighbor unit integrals.";
+    for (auto& nb_cell : neighbor_cells)
     {
-      if (not nb_integral_data_initialized)
-      {
-        chi_log.Log() << chi_program_timer.GetTimeString()
-                      << " Computing neighbor unit integrals.";
-        for (auto& nb_cell : neighbor_cells)
-        {
-          uint64_t cell_global_id = nb_cell.first;
-          auto cell_fe_view = GetNeighborCellMappingFE(cell_global_id);
+      uint64_t cell_global_id = nb_cell.first;
+      auto cell_fe_view = GetNeighborCellMappingFE(cell_global_id);
 
-          UIData ui_data;
-          cell_fe_view->ComputeUnitIntegrals(ui_data);
+      UIData ui_data;
+      cell_fe_view->ComputeUnitIntegrals(ui_data);
 
-          nb_fe_unit_integrals.insert(std::make_pair(cell_global_id,std::move(ui_data)));
-        }
-
-        nb_integral_data_initialized = true;
-      }
-    }//if compute unit intgrls
+      nb_fe_unit_integrals.insert(std::make_pair(cell_global_id,std::move(ui_data)));
+    }
   }
 
 
   //============================================= Quadrature data
   {
     using namespace chi_math::finite_element;
-    if (setup_flags & SetupFlags::COMPUTE_QP_DATA)
+    chi_log.Log() << chi_program_timer.GetTimeString()
+                  << " Computing neighbor quadrature data.";
+    for (auto& nb_cell : neighbor_cells)
     {
-      if (not nb_qp_data_initialized)
-      {
-        chi_log.Log() << chi_program_timer.GetTimeString()
-                      << " Computing neighbor quadrature data.";
-        for (auto& nb_cell : neighbor_cells)
-        {
-          uint64_t cell_global_id = nb_cell.first;
-          auto cell_fe_view = GetNeighborCellMappingFE(cell_global_id);
+      uint64_t cell_global_id = nb_cell.first;
+      auto cell_fe_view = GetNeighborCellMappingFE(cell_global_id);
 
-          QPDataVol qp_data_vol;
-          std::vector<QPDataFace> qp_data_srf;
-          cell_fe_view->InitializeAllQuadraturePointData(qp_data_vol,
-                                                         qp_data_srf);
+      QPDataVol qp_data_vol;
+      std::vector<QPDataFace> qp_data_srf;
+      cell_fe_view->InitializeAllQuadraturePointData(qp_data_vol,
+                                                     qp_data_srf);
 
-          nb_fe_vol_qp_data.insert(std::make_pair(cell_global_id,std::move(qp_data_vol)));
-          nb_fe_srf_qp_data.insert(std::make_pair(cell_global_id,std::move(qp_data_srf)));
-        }
-
-        nb_qp_data_initialized = true;
-      }
-    }//if init qp data
+      nb_fe_vol_qp_data.insert(std::make_pair(cell_global_id,std::move(qp_data_vol)));
+      nb_fe_srf_qp_data.insert(std::make_pair(cell_global_id,std::move(qp_data_srf)));
+    }
   }
-
 }//AddViewOfNeighborContinuums
 
 
@@ -281,24 +232,17 @@ void SpatialDiscretization_PWLD::PreComputeNeighborCellSDValues()
 std::shared_ptr<CellMappingFE_PWL>
   SpatialDiscretization_PWLD::GetCellMappingFE(uint64_t cell_local_index)
 {
-  if (mapping_initialized)
+  try
   {
-    try
-    {
-      return cell_mappings.at(cell_local_index);
-    }
-    catch (const std::out_of_range& o)
-    {
-      chi_log.Log(LOG_ALLERROR)
-        << "SpatialDiscretization_PWL::MapFeView "
-           "Failure to map Finite Element View. The view is either not"
-           "available or the supplied local index is invalid.";
-      exit(EXIT_FAILURE);
-    }
+    return cell_mappings.at(cell_local_index);
   }
-  else
+  catch (const std::out_of_range& o)
   {
-    return MakeCellMappingFE(ref_grid->local_cells[cell_local_index]);
+    chi_log.Log(LOG_ALLERROR)
+      << "SpatialDiscretization_PWL::MapFeView "
+         "Failure to map Finite Element View. The view is either not"
+         "available or the supplied local index is invalid.";
+    exit(EXIT_FAILURE);
   }
 }
 
@@ -335,19 +279,11 @@ std::shared_ptr<CellMappingFE_PWL> SpatialDiscretization_PWLD::
   }
 
   //=================================== Now check neighbor cells
-  if (nb_mapping_initialized)
-  {
-    auto neighbor_location = neighbor_cell_fe_views.find(cell_glob_index);
+  auto neighbor_location = neighbor_cell_fe_views.find(cell_glob_index);
 
-    if (neighbor_location != neighbor_cell_fe_views.end())
-      return neighbor_cell_fe_views.at(cell_glob_index);
-    else
-      throw std::logic_error(std::string(__FUNCTION__) +
-                             " Mapping of neighbor cell failed.");
-  }
+  if (neighbor_location != neighbor_cell_fe_views.end())
+    return neighbor_cell_fe_views.at(cell_glob_index);
   else
-  {
-    return MakeCellMappingFE(GetNeighborCell(cell_glob_index));
-  }
-
+    throw std::logic_error(std::string(__FUNCTION__) +
+                           " Mapping of neighbor cell failed.");
 }

--- a/ChiTech/ChiMath/SpatialDiscretization/FiniteElement/PiecewiseLinear/pwlc.h
+++ b/ChiTech/ChiMath/SpatialDiscretization/FiniteElement/PiecewiseLinear/pwlc.h
@@ -19,163 +19,116 @@
  * or a Discontinuous Finite Element Method (DFEM). */
 class SpatialDiscretization_PWLC : public SpatialDiscretization_FE
 {
-public:
-  std::vector<std::shared_ptr<CellMappingFE_PWL>> cell_mappings;
-
 private:
-  bool                     mapping_initialized=false;
+  //00
+  explicit SpatialDiscretization_PWLC(chi_mesh::MeshContinuumPtr& in_grid,
+      chi_math::finite_element::SetupFlags setup_flags,
+      chi_math::QuadratureOrder qorder,
+      chi_math::CoordinateSystemType in_cs_type);
+
+  //01
+  std::shared_ptr<CellMappingFE_PWL> MakeCellMappingFE(const chi_mesh::Cell& cell) const;
+
+  void PreComputeCellSDValues() override;
+
+  //02
+  void OrderNodes();
+
 public:
+  unsigned int local_base_block_size=0;
+  unsigned int globl_base_block_size=0;
+  int local_block_address = 0;
+
+  std::vector<std::shared_ptr<CellMappingFE_PWL>> cell_mappings;
+  std::vector<int> locJ_block_address;
+  std::vector<int> locJ_block_size;
+  std::map<int,int> node_mapping;
+
   chi_math::QuadratureLine          line_quad_order_arbitrary;
   chi_math::QuadratureTriangle      tri_quad_order_arbitrary;
   chi_math::QuadratureQuadrilateral quad_quad_order_arbitrary;
   chi_math::QuadratureTetrahedron   tet_quad_order_arbitrary;
   chi_math::QuadratureHexahedron    hex_quad_order_arbitrary;
 
-  std::map<int,int> node_mapping;
-
-  int local_block_address = 0;
-//  std::vector<int> cell_local_block_address;
-//  std::vector<std::pair<int,int>> neighbor_cell_block_address;
-
-  std::vector<int> locJ_block_address;
-  std::vector<int> locJ_block_size;
-
-  unsigned int local_base_block_size=0;
-  unsigned int globl_base_block_size=0;
-
-private:
-//  std::vector<chi_mesh::Cell*> neighbor_cells;
-//  std::vector<CellPWLFEValues*> neighbor_cell_fe_views;
-
-private:
-  chi_math::finite_element::UnitIntegralData            scratch_intgl_data;
-  chi_math::finite_element::InternalQuadraturePointData scratch_vol_qp_data;
-  chi_math::finite_element::FaceQuadraturePointData     scratch_face_qp_data;
-
-private:
-  //00
-  explicit
-  SpatialDiscretization_PWLC(chi_mesh::MeshContinuumPtr& in_grid,
-                             chi_math::finite_element::SetupFlags setup_flags,
-                             chi_math::QuadratureOrder qorder,
-                             chi_math::CoordinateSystemType in_cs_type);
-
-public:
   //prevent anything else other than a shared pointer
-  static
-  std::shared_ptr<SpatialDiscretization_PWLC>
-  New(chi_mesh::MeshContinuumPtr& in_grid,
+  static std::shared_ptr<SpatialDiscretization_PWLC> New(
+      chi_mesh::MeshContinuumPtr& in_grid,
       chi_math::finite_element::SetupFlags setup_flags=
       chi_math::finite_element::SetupFlags::NO_FLAGS_SET,
       chi_math::QuadratureOrder qorder =
       chi_math::QuadratureOrder::SECOND,
       chi_math::CoordinateSystemType in_cs_type =
       chi_math::CoordinateSystemType::CARTESIAN)
-  { if (in_grid == nullptr) throw std::invalid_argument(
-      "Null supplied as grid to SpatialDiscretization_PWLC.");
+  { 
+    if (in_grid == nullptr) throw std::invalid_argument(
+        "Null supplied as grid to SpatialDiscretization_PWLC.");
     return std::shared_ptr<SpatialDiscretization_PWLC>(
-    new SpatialDiscretization_PWLC(in_grid, setup_flags, qorder, in_cs_type));}
+    new SpatialDiscretization_PWLC(in_grid, setup_flags, qorder, in_cs_type));
+  }
 
   //01
-private:
-  std::shared_ptr<CellMappingFE_PWL> MakeCellMappingFE(const chi_mesh::Cell& cell) const;
-
-public:
-
-  void PreComputeCellSDValues() override;
-//  void PreComputeNeighborCellSDValues(chi_mesh::MeshContinuumPtr grid);
   std::shared_ptr<CellMappingFE_PWL> GetCellMappingFE(uint64_t cell_local_index);
 
-private:
-  //02
-  void OrderNodes();
-
-public:
   //03
   void BuildSparsityPattern(std::vector<int64_t>& nodal_nnz_in_diag,
-                            std::vector<int64_t>& nodal_nnz_off_diag,
-                            chi_math::UnknownManager& unknown_manager) override;
+      std::vector<int64_t>& nodal_nnz_off_diag,
+      chi_math::UnknownManager& unknown_manager) override;
 
   //04 Mappings
   int64_t MapDOF(const chi_mesh::Cell& cell,
-                 unsigned int node,
-                 const chi_math::UnknownManager& unknown_manager,
-                 unsigned int unknown_id,
-                 unsigned int component) const override;
+      unsigned int node,
+      const chi_math::UnknownManager& unknown_manager,
+      unsigned int unknown_id,
+      unsigned int component) const override;
+
   int64_t MapDOFLocal(const chi_mesh::Cell& cell,
-                      unsigned int node,
-                      const chi_math::UnknownManager& unknown_manager,
-                      unsigned int unknown_id,
-                      unsigned int component) const override;
+      unsigned int node,
+      const chi_math::UnknownManager& unknown_manager,
+      unsigned int unknown_id,
+      unsigned int component) const override;
 
   int64_t MapDOF(const chi_mesh::Cell& cell, unsigned int node) const override
-  { return MapDOF(cell,node,ChiMath::UNITARY_UNKNOWN_MANAGER,0,0); }
+  { 
+    return MapDOF(cell,node,ChiMath::UNITARY_UNKNOWN_MANAGER,0,0);
+  }
+
   int64_t MapDOFLocal(const chi_mesh::Cell& cell, unsigned int node) const override
-  { return MapDOFLocal(cell,node,ChiMath::UNITARY_UNKNOWN_MANAGER,0,0); }
+  {
+     return MapDOFLocal(cell,node,ChiMath::UNITARY_UNKNOWN_MANAGER,0,0);
+  }
 
   //05
   size_t GetNumLocalDOFs(chi_math::UnknownManager& unknown_manager) override;
+
   size_t GetNumGlobalDOFs(chi_math::UnknownManager& unknown_manager) override;
-//  unsigned int GetNumGhostDOFs(chi_mesh::MeshContinuumPtr grid,
-//                               chi_math::UnknownManager* unknown_manager);
-//
-//  std::vector<int> GetGhostDOFIndices(chi_mesh::MeshContinuumPtr grid,
-//                                      chi_math::UnknownManager* unknown_manager,
-//                                      unsigned int unknown_id=0);
 
   size_t GetCellNumNodes(const chi_mesh::Cell& cell) const override
-  {return cell.vertex_ids.size();}
+  {
+    return cell.vertex_ids.size();
+  }
 
   void LocalizePETScVector(Vec petsc_vector,
-                           std::vector<double>& local_vector,
-                           chi_math::UnknownManager& unknown_manager)
-                           override;
+      std::vector<double>& local_vector,
+      chi_math::UnknownManager& unknown_manager) override;
 
   //FE-utils
   const chi_math::finite_element::UnitIntegralData&
-  GetUnitIntegrals(const chi_mesh::Cell& cell) override
+      GetUnitIntegrals(const chi_mesh::Cell& cell) override
   {
-    if (integral_data_initialized)
-      return fe_unit_integrals.at(cell.local_id);
-    else
-    {
-      auto cell_fe_view = GetCellMappingFE(cell.local_id);
-      scratch_intgl_data.Reset();
-      cell_fe_view->ComputeUnitIntegrals(scratch_intgl_data);
-      return scratch_intgl_data;
-    }
+    return fe_unit_integrals.at(cell.local_id);
   }
 
   const chi_math::finite_element::InternalQuadraturePointData&
-  GetQPData_Volumetric(const chi_mesh::Cell& cell) override
+      GetQPData_Volumetric(const chi_mesh::Cell& cell) override
   {
-    if (qp_data_initialized)
-      return fe_vol_qp_data.at(cell.local_id);
-    else
-    {
-      auto cell_fe_view = GetCellMappingFE(cell.local_id);
-      cell_fe_view->InitializeVolumeQuadraturePointData(scratch_vol_qp_data);
-      return scratch_vol_qp_data;
-    }
+    return fe_vol_qp_data.at(cell.local_id);
   }
 
   const chi_math::finite_element::FaceQuadraturePointData&
-  GetQPData_Surface(const chi_mesh::Cell& cell,
-                    const unsigned int face) override
+      GetQPData_Surface(const chi_mesh::Cell& cell, const unsigned int face) override
   {
-    if (qp_data_initialized)
-    {
-      const auto& face_data = fe_srf_qp_data.at(cell.local_id);
-
-      return face_data.at(face);
-    }
-    else
-    {
-      auto cell_fe_view = GetCellMappingFE(cell.local_id);
-      cell_fe_view->InitializeFaceQuadraturePointData(face, scratch_face_qp_data);
-      return scratch_face_qp_data;
-    }
-
+    const auto& face_data = fe_srf_qp_data.at(cell.local_id);
+    return face_data.at(face);
   }
 };
 

--- a/ChiTech/ChiMath/SpatialDiscretization/FiniteElement/PiecewiseLinear/pwlc_00_constrdestr.cc
+++ b/ChiTech/ChiMath/SpatialDiscretization/FiniteElement/PiecewiseLinear/pwlc_00_constrdestr.cc
@@ -26,64 +26,60 @@ SpatialDiscretization_PWLC::
                 << " Creating Piecewise Linear Continuous "
                    "Finite Element spatial discretizaiton.";
 
-  if (setup_flags == chi_math::finite_element::COMPUTE_UNIT_INTEGRALS)
+  int qorder_min = static_cast<int>(chi_math::QuadratureOrder::INVALID_ORDER);
+  switch (cs_type)
   {
-    int qorder_min = static_cast<int>(chi_math::QuadratureOrder::INVALID_ORDER);
-    switch (cs_type)
+    case chi_math::CoordinateSystemType::CARTESIAN:
     {
-      case chi_math::CoordinateSystemType::CARTESIAN:
-      {
-        qorder_min = static_cast<int>(chi_math::QuadratureOrder::SECOND);
-        break;
-      }
-      case chi_math::CoordinateSystemType::CYLINDRICAL:
-      {
-        qorder_min = static_cast<int>(chi_math::QuadratureOrder::THIRD);
-        break;
-      }
-      case chi_math::CoordinateSystemType::SPHERICAL:
-      {
-        qorder_min = static_cast<int>(chi_math::QuadratureOrder::FOURTH);
-        break;
-      }
-      default:
-        throw std::invalid_argument("SpatialDiscretization_PWLC::SpatialDiscretization_PWLC : "
-                                    "Unsupported coordinate system type encountered.");
+      qorder_min = static_cast<int>(chi_math::QuadratureOrder::SECOND);
+      break;
     }
-
-    if (static_cast<int>(line_quad_order_arbitrary.order) < qorder_min)
-      chi_log.Log(LOG_ALLWARNING)
-        << "SpatialDiscretization_PWLC::SpatialDiscretization_PWLC : "
-        << "static_cast<int>(line_quad_order_arbitrary.order) < "
-        << qorder_min << ".";
-
-    if (static_cast<int>(tri_quad_order_arbitrary.order) < qorder_min)
-      chi_log.Log(LOG_ALLWARNING)
-        << "SpatialDiscretization_PWLC::SpatialDiscretization_PWLC : "
-        << "static_cast<int>(tri_quad_order_arbitrary.order) < "
-        << qorder_min << ".";
-
-    if (static_cast<int>(quad_quad_order_arbitrary.order) < qorder_min)
-      chi_log.Log(LOG_ALLWARNING)
-        << "SpatialDiscretization_PWLC::SpatialDiscretization_PWLC : "
-        << "static_cast<int>(quad_quad_order_arbitrary.order) < "
-        << qorder_min << ".";
-
-    if (static_cast<int>(tet_quad_order_arbitrary.order) < qorder_min)
-      chi_log.Log(LOG_ALLWARNING)
-        << "SpatialDiscretization_PWLC::SpatialDiscretization_PWLC : "
-        << "static_cast<int>(tet_quad_order_arbitrary.order) < "
-        << qorder_min << ".";
-
-    if (static_cast<int>(hex_quad_order_arbitrary.order) < qorder_min)
-      chi_log.Log(LOG_ALLWARNING)
-        << "SpatialDiscretization_PWLC::SpatialDiscretization_PWLC : "
-        << "static_cast<int>(hex_quad_order_arbitrary.order) < "
-        << qorder_min << ".";
+    case chi_math::CoordinateSystemType::CYLINDRICAL:
+    {
+      qorder_min = static_cast<int>(chi_math::QuadratureOrder::THIRD);
+      break;
+    }
+    case chi_math::CoordinateSystemType::SPHERICAL:
+    {
+      qorder_min = static_cast<int>(chi_math::QuadratureOrder::FOURTH);
+      break;
+    }
+    default:
+      throw std::invalid_argument("SpatialDiscretization_PWLC::SpatialDiscretization_PWLC : "
+                                  "Unsupported coordinate system type encountered.");
   }
 
-  if (setup_flags != chi_math::finite_element::NO_FLAGS_SET)
-    PreComputeCellSDValues();
+  if (static_cast<int>(line_quad_order_arbitrary.order) < qorder_min)
+    chi_log.Log(LOG_ALLWARNING)
+      << "SpatialDiscretization_PWLC::SpatialDiscretization_PWLC : "
+      << "static_cast<int>(line_quad_order_arbitrary.order) < "
+      << qorder_min << ".";
+
+  if (static_cast<int>(tri_quad_order_arbitrary.order) < qorder_min)
+    chi_log.Log(LOG_ALLWARNING)
+      << "SpatialDiscretization_PWLC::SpatialDiscretization_PWLC : "
+      << "static_cast<int>(tri_quad_order_arbitrary.order) < "
+      << qorder_min << ".";
+
+  if (static_cast<int>(quad_quad_order_arbitrary.order) < qorder_min)
+    chi_log.Log(LOG_ALLWARNING)
+      << "SpatialDiscretization_PWLC::SpatialDiscretization_PWLC : "
+      << "static_cast<int>(quad_quad_order_arbitrary.order) < "
+      << qorder_min << ".";
+
+  if (static_cast<int>(tet_quad_order_arbitrary.order) < qorder_min)
+    chi_log.Log(LOG_ALLWARNING)
+      << "SpatialDiscretization_PWLC::SpatialDiscretization_PWLC : "
+      << "static_cast<int>(tet_quad_order_arbitrary.order) < "
+      << qorder_min << ".";
+
+  if (static_cast<int>(hex_quad_order_arbitrary.order) < qorder_min)
+    chi_log.Log(LOG_ALLWARNING)
+      << "SpatialDiscretization_PWLC::SpatialDiscretization_PWLC : "
+      << "static_cast<int>(hex_quad_order_arbitrary.order) < "
+      << qorder_min << ".";
+
+  PreComputeCellSDValues();
 
   OrderNodes();
   chi_log.Log() << chi_program_timer.GetTimeString()

--- a/ChiTech/ChiMath/SpatialDiscretization/FiniteElement/finite_element.h
+++ b/ChiTech/ChiMath/SpatialDiscretization/FiniteElement/finite_element.h
@@ -13,10 +13,7 @@ namespace finite_element
   //#############################################
   enum SetupFlags : int
   {
-    NO_FLAGS_SET           = 0,
-    COMPUTE_CELL_MAPPINGS  = (1 << 0),
-    COMPUTE_UNIT_INTEGRALS = (1 << 1),
-    COMPUTE_QP_DATA        = (1 << 2)
+    NO_FLAGS_SET = 0
   };
 
   inline SetupFlags
@@ -61,8 +58,6 @@ namespace finite_element
                     std::vector<MatVec3> in_IntS_shapeI_gradshapeJ,
                     std::vector<std::vector<int>> in_face_dof_mappings,
                     size_t in_num_nodes);
-
-    void Reset();
 
     double IntV_gradShapeI_gradShapeJ(unsigned int i,
                                       unsigned int j) const;

--- a/ChiTech/ChiMath/SpatialDiscretization/FiniteElement/finite_element_intgrldata.cc
+++ b/ChiTech/ChiMath/SpatialDiscretization/FiniteElement/finite_element_intgrldata.cc
@@ -28,22 +28,6 @@ namespace finite_element
     m_num_nodes                  = in_num_nodes;
   }
 
-  void UnitIntegralData::Reset()
-  {
-    m_IntV_gradShapeI_gradShapeJ.clear();
-    m_IntV_shapeI_gradshapeJ.clear();
-    m_IntV_shapeI_shapeJ.clear();
-    m_IntV_shapeI.clear();
-    m_IntV_gradshapeI.clear();
-
-    m_IntS_shapeI_shapeJ.clear();
-    m_IntS_shapeI.clear();
-    m_IntS_shapeI_gradshapeJ.clear();
-
-    m_face_dof_mappings.clear();
-    m_num_nodes=0;
-  }
-
   double UnitIntegralData::
     IntV_gradShapeI_gradShapeJ(unsigned int i,
                                unsigned int j) const

--- a/ChiTech/ChiMath/SpatialDiscretization/FiniteElement/spatial_discretization_FE.h
+++ b/ChiTech/ChiMath/SpatialDiscretization/FiniteElement/spatial_discretization_FE.h
@@ -19,9 +19,6 @@ protected:
   std::vector<QPDataVol>               fe_vol_qp_data;
   std::vector<std::vector<QPDataFace>> fe_srf_qp_data;
 
-  bool integral_data_initialized=false;
-  bool qp_data_initialized=false;
-
   const chi_math::finite_element::SetupFlags setup_flags;
 
 protected:
@@ -40,37 +37,16 @@ protected:
 public:
   virtual
   const chi_math::finite_element::UnitIntegralData&
-    GetUnitIntegrals(const chi_mesh::Cell& cell)
-  {
-    if (not integral_data_initialized)
-      throw std::invalid_argument("SpatialDiscretization_FE::GetUnitIntegrals "
-                                  "called without integrals being initialized."
-                                  " Set flag COMPUTE_UNIT_INTEGRALS.");
-    return fe_unit_integrals[cell.local_id];
-  }
+    GetUnitIntegrals(const chi_mesh::Cell& cell) = 0;
 
   virtual
   const chi_math::finite_element::InternalQuadraturePointData&
-    GetQPData_Volumetric(const chi_mesh::Cell& cell)
-  {
-    if (not qp_data_initialized)
-      throw std::invalid_argument("SpatialDiscretization_FE::GetQPData_Volumetric "
-                                  "called without integrals being initialized."
-                                  " Set flag INIT_QP_DATA.");
-    return fe_vol_qp_data[cell.local_id];
-  }
+    GetQPData_Volumetric(const chi_mesh::Cell& cell) = 0;
 
   virtual
   const chi_math::finite_element::FaceQuadraturePointData&
     GetQPData_Surface(const chi_mesh::Cell& cell,
-                      const unsigned int face)
-  {
-    if (not qp_data_initialized)
-      throw std::invalid_argument("SpatialDiscretization_FE::GetQPData_Surface "
-                                  "called without integrals being initialized."
-                                  " Set flag INIT_QP_DATA.");
-    return fe_srf_qp_data[cell.local_id][face];
-  }
+                      const unsigned int face) = 0;
 
   virtual ~SpatialDiscretization_FE() = default;
 };

--- a/ChiTech/ChiMath/SpatialDiscretization/FiniteVolume/fv.h
+++ b/ChiTech/ChiMath/SpatialDiscretization/FiniteVolume/fv.h
@@ -32,6 +32,9 @@ private:
   explicit
   SpatialDiscretization_FV(chi_mesh::MeshContinuumPtr& in_grid,
                            chi_math::CoordinateSystemType in_cs_type);
+  //01
+  void PreComputeCellSDValues() override;
+  void PreComputeNeighborCellSDValues();
 
 public:
   virtual ~SpatialDiscretization_FV() = default;
@@ -43,10 +46,6 @@ public:
       chi_math::CoordinateSystemType::CARTESIAN)
   { return std::shared_ptr<SpatialDiscretization_FV>(
     new SpatialDiscretization_FV(in_grid, in_cs_type));}
-
-  //01
-  void PreComputeCellSDValues() override;
-  void PreComputeNeighborCellSDValues();
 
   CellFVValues* MapFeView(uint64_t cell_local_index);
   CellFVValues* MapNeighborFeView(uint64_t cell_global_index);


### PR DESCRIPTION
This commit modifies the code to always build and store the various finite element matrices. These changes simplify the code ahead of additional changes that will introduce more granular control over which matrices are built and when. In addition, always storing the matrices prevents the need to construct them on the fly.  Finally, these simplifications will allow for an easier transition to new array data structures that will provide a performance boost and pave the way for use of GPUs.