### PR TITLE
Added volume to CellLBSView.

### DIFF
--- a/ChiModules/LinearBoltzmannSolver/lbs_01d_initparrays.cc
+++ b/ChiModules/LinearBoltzmannSolver/lbs_01d_initparrays.cc
@@ -72,20 +72,20 @@ void LinearBoltzmann::Solver::InitializeParrays()
   chi_mesh::Vector3 jhat(0.0, 1.0, 0.0);
   chi_mesh::Vector3 khat(0.0, 0.0, 1.0);
 
+  auto pwl =
+      std::dynamic_pointer_cast<SpatialDiscretization_FE>(discretization);
+
   cell_transport_views.clear();
   cell_transport_views.reserve(grid->local_cells.size());
   for (auto& cell : grid->local_cells)
   {
-    auto pwl =
-        std::dynamic_pointer_cast<SpatialDiscretization_FE>(discretization);
-    auto& fe_values = pwl->GetUnitIntegrals(cell);
-
     size_t num_nodes  = discretization->GetCellNumNodes(cell);
     int    mat_id     = cell.material_id;
     int    xs_mapping = matid_to_xs_map[mat_id];
 
     //compute cell volumes
     double cell_volume = 0.0;
+    auto& fe_values = pwl->GetUnitIntegrals(cell);
     for (int i = 0; i < fe_values.NumNodes(); ++i)
       cell_volume += fe_values.IntV_shapeI(i);
 

--- a/ChiModules/LinearBoltzmannSolver/lbs_01d_initparrays.cc
+++ b/ChiModules/LinearBoltzmannSolver/lbs_01d_initparrays.cc
@@ -76,9 +76,18 @@ void LinearBoltzmann::Solver::InitializeParrays()
   cell_transport_views.reserve(grid->local_cells.size());
   for (auto& cell : grid->local_cells)
   {
+    auto pwl =
+        std::dynamic_pointer_cast<SpatialDiscretization_FE>(discretization);
+    auto& fe_values = pwl->GetUnitIntegrals(cell);
+
     size_t num_nodes  = discretization->GetCellNumNodes(cell);
     int    mat_id     = cell.material_id;
     int    xs_mapping = matid_to_xs_map[mat_id];
+
+    //compute cell volumes
+    double cell_volume = 0.0;
+    for (int i = 0; i < fe_values.NumNodes(); ++i)
+      cell_volume += fe_values.IntV_shapeI(i);
 
     size_t cell_phi_address = block_MG_counter;
 
@@ -117,6 +126,7 @@ void LinearBoltzmann::Solver::InitializeParrays()
                                       num_grps,
                                       num_moments,
                                       xs_mapping,
+                                      cell_volume,
                                       face_local_flags,
                                       cell_on_boundary);
     block_MG_counter += num_nodes * num_grps * num_moments;

--- a/ChiModules/LinearBoltzmannSolver/lbs_structs.h
+++ b/ChiModules/LinearBoltzmannSolver/lbs_structs.h
@@ -60,6 +60,7 @@ private:
   int num_grps;
   int num_grps_moms;
   int xs_mapping;
+  double volume;
   std::vector<bool> face_local_flags = {};
   std::vector<double> outflow;
 
@@ -69,6 +70,7 @@ public:
               int in_num_grps,
               int in_num_moms,
               int in_xs_mapping,
+              double in_volume,
               const std::vector<bool>& in_face_local_flags,
               bool cell_on_boundary) :
     phi_address(in_phi_address),
@@ -76,6 +78,7 @@ public:
     num_grps(in_num_grps),
     num_grps_moms(in_num_grps*in_num_moms),
     xs_mapping(in_xs_mapping),
+    volume(in_volume),
     face_local_flags(in_face_local_flags)
   {
     if (cell_on_boundary)
@@ -92,6 +95,8 @@ public:
   bool IsFaceLocal(int f) const {return face_local_flags[f];}
 
   int NumNodes() const {return num_nodes;}
+
+  double Volume() const {return volume;}
 
   void ZeroOutflow(     ) {outflow.assign(outflow.size(),0.0);}
   void ZeroOutflow(int g) {if (g<outflow.size()) outflow[g]=0.0;}


### PR DESCRIPTION
This pull requests adds cell volumes to CellLBSView.

Delayed neutron precursors being defined at the nodes is only applicable for PWD discretizations. In PWC discretizations, precursors cannot be defined at vertices because at material interfaces there may be different (or no) precursors on each bordering cell. For generalization, the precursors should be defined at cell centers. This requires the precursor production term in the precursor equation to use the cell-averaged flux, which requires division by the cell volume. This additionally allows for easy computation of any other cell-averaged quantities that may be of interest.

NOTE: Previous PR closed due to having unrelated changes from #198 .

