### PR TITLE
Cell Centered Precursors

### DIFF
--- a/ChiModules/KEigenvalueSolver/initialize_k_solver.cc
+++ b/ChiModules/KEigenvalueSolver/initialize_k_solver.cc
@@ -12,33 +12,5 @@ using namespace LinearBoltzmann;
 void KEigenvalue::Solver::InitializeKSolver()
 {
   LinearBoltzmann::Solver::Initialize();
-
   phi_prev_local.resize(phi_old_local.size(), 0.0);
-
-  //======================================== Initialize precursors
-  if (options.use_precursors)
-  {
-    //clear precursor properties
-    num_precursors = 0.0;
-    max_num_precursors_per_material = 0.0;
-
-    //accumulate precursor count and set max
-    for (auto& xs : material_xs)
-    {
-      num_precursors += xs->num_precursors;
-      if (xs->num_precursors > max_num_precursors_per_material)
-        max_num_precursors_per_material = xs->num_precursors;
-    }
-
-
-    if (num_precursors > 0)
-    {
-      precursor_uk_man.AddUnknown(chi_math::UnknownType::VECTOR_N,
-                                  max_num_precursors_per_material);
-
-      size_t local_precursor_dof_count =
-          discretization->GetNumLocalDOFs(precursor_uk_man);
-      precursor_new_local.resize(local_precursor_dof_count, 0.0);
-    }
-  }//if use precursors
 }

--- a/ChiModules/KEigenvalueSolver/initialize_precursors.cc
+++ b/ChiModules/KEigenvalueSolver/initialize_precursors.cc
@@ -32,8 +32,7 @@ void KEigenvalue::Solver::InitializePrecursors()
       for (int i = 0; i < num_nodes; ++i)
       {
         size_t ir = transport_view.MapDOF(i, 0, 0);
-        size_t jr = discretization->MapDOFLocal(cell, i, precursor_uk_man, 0, 0);
-        double* Nj_newp = &precursor_new_local[jr];
+        size_t jr = cell.local_id * max_precursors_per_material;
 
         // Contribute if precursors live on this material
         if (xs->num_precursors > 0)

--- a/ChiModules/KEigenvalueSolver/k_eigenvalue_solver.h
+++ b/ChiModules/KEigenvalueSolver/k_eigenvalue_solver.h
@@ -21,13 +21,7 @@ public:
   size_t max_iterations = 1000;
   double tolerance = 1.0e-8;
 
-  size_t num_precursors;
-  size_t max_num_precursors_per_material;
-
-  chi_math::UnknownManager precursor_uk_man;
-
   std::vector<double> phi_prev_local;
-  std::vector<double> precursor_new_local;
 
   explicit Solver(const std::string& in_text_name) :
     LinearBoltzmann::Solver(in_text_name) {}

--- a/ChiModules/LinearBoltzmannSolver/lbs_01b_initmaterials.cc
+++ b/ChiModules/LinearBoltzmannSolver/lbs_01b_initmaterials.cc
@@ -118,10 +118,25 @@ void LinearBoltzmann::Solver::InitMaterials(std::set<int>& material_ids)
       << material_xs[matid_to_xs_map[mat_id]]->transfer_matrices.size() << "\n";
   }//for material id
 
+  num_groups = int(groups.size());
+
   chi_log.Log(LOG_0)
     << "Materials Initialized:\n" << materials_list.str() << "\n";
 
   MPI_Barrier(MPI_COMM_WORLD);
+
+  //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% Initialize precursor
+  //                                                   properties
+  num_precursors = 0;
+  max_precursors_per_material = 0;
+  for (auto& xs : material_xs)
+  {
+    num_precursors += xs->num_precursors;
+    if (xs->num_precursors > max_precursors_per_material)
+      max_precursors_per_material = xs->num_precursors;
+  }
+  if (num_precursors == 0)
+    options.use_precursors = false;
 
   //%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% Initialize Diffusion
   //                                                   properties

--- a/ChiModules/LinearBoltzmannSolver/lbs_01b_initmaterials.cc
+++ b/ChiModules/LinearBoltzmannSolver/lbs_01b_initmaterials.cc
@@ -118,7 +118,7 @@ void LinearBoltzmann::Solver::InitMaterials(std::set<int>& material_ids)
       << material_xs[matid_to_xs_map[mat_id]]->transfer_matrices.size() << "\n";
   }//for material id
 
-  num_groups = int(groups.size());
+  num_groups = groups.size();
 
   chi_log.Log(LOG_0)
     << "Materials Initialized:\n" << materials_list.str() << "\n";

--- a/ChiModules/LinearBoltzmannSolver/lbs_01d_initparrays.cc
+++ b/ChiModules/LinearBoltzmannSolver/lbs_01d_initparrays.cc
@@ -49,6 +49,14 @@ void LinearBoltzmann::Solver::InitializeParrays()
     }
   }
 
+  //============================================= Setup precursor vector
+  if (options.use_precursors)
+  {
+    size_t num_precursor_dofs =
+        grid->local_cells.size() * max_precursors_per_material;
+    precursor_new_local.assign(num_precursor_dofs, 0.0);
+  }
+
   //================================================== Read Restart data
   if (options.read_restart_data)
     ReadRestartData(options.read_restart_folder_name,

--- a/ChiModules/LinearBoltzmannSolver/lbs_02_main_execute.cc
+++ b/ChiModules/LinearBoltzmannSolver/lbs_02_main_execute.cc
@@ -41,6 +41,9 @@ void LinearBoltzmann::Solver::Execute()
     MPI_Barrier(MPI_COMM_WORLD);
   }
 
+  if (options.use_precursors)
+    ComputePrecursors();
+
   chi_log.Log(LOG_0) << "NPTransport solver execution completed\n";
 }
 

--- a/ChiModules/LinearBoltzmannSolver/lbs_compute_precursors.cc
+++ b/ChiModules/LinearBoltzmannSolver/lbs_compute_precursors.cc
@@ -12,7 +12,7 @@ void LinearBoltzmann::Solver::ComputePrecursors()
 {
   auto pwl =
       std::dynamic_pointer_cast<SpatialDiscretization_FE>(discretization);
-  const int J = max_precursors_per_material;
+  const size_t J = max_precursors_per_material;
 
   precursor_new_local.assign(precursor_new_local.size(), 0.0);
 
@@ -37,7 +37,7 @@ void LinearBoltzmann::Solver::ComputePrecursors()
     auto xs = material_xs[xs_id];
 
     //======================================== Loop over precursors
-    for (int j = 0; j < xs->num_precursors; ++j)
+    for (size_t j = 0; j < xs->num_precursors; ++j)
     {
       size_t dof = cell.local_id * J + j;
       const double coeff = xs->precursor_yield[j] /

--- a/ChiModules/LinearBoltzmannSolver/lbs_compute_precursors.cc
+++ b/ChiModules/LinearBoltzmannSolver/lbs_compute_precursors.cc
@@ -1,0 +1,61 @@
+#include "lbs_linear_boltzmann_solver.h"
+
+#include "ChiMath/SpatialDiscretization/FiniteElement/PiecewiseLinear/pwl.h"
+
+#include "chi_log.h"
+extern ChiLog& chi_log;
+
+
+//###################################################################
+/**Compute the steady state delayed neutron precursor concentrations.*/
+void LinearBoltzmann::Solver::ComputePrecursors()
+{
+  auto pwl =
+      std::dynamic_pointer_cast<SpatialDiscretization_FE>(discretization);
+  const int J = max_precursors_per_material;
+
+  precursor_new_local.assign(precursor_new_local.size(), 0.0);
+
+  //================================================== Loop over cells
+  for (auto& cell : grid->local_cells)
+  {
+    const auto& fe_values = pwl->GetUnitIntegrals(cell);
+    const auto& transport_view = cell_transport_views[cell.local_id];
+    const double volume = transport_view.Volume();
+
+    //==================== Obtain xs
+    int cell_matid = cell.material_id;
+    int xs_id = matid_to_xs_map[cell_matid];
+
+    if ((xs_id < 0) || (xs_id >= material_xs.size()))
+    {
+      chi_log.Log(LOG_ALLERROR)
+          << "Cross-section lookup error\n";
+      exit(EXIT_FAILURE);
+    }
+
+    auto xs = material_xs[xs_id];
+
+    //======================================== Loop over precursors
+    for (int j = 0; j < xs->num_precursors; ++j)
+    {
+      size_t dof = cell.local_id * J + j;
+      const double coeff = xs->precursor_yield[j] /
+                           xs->precursor_lambda[j];
+
+      //=================================== Loop over nodes
+      for (int i = 0; i < transport_view.NumNodes(); ++i)
+      {
+        const size_t  uk_map = transport_view.MapDOF(i, 0, 0);
+        const double IntV_ShapeI = fe_values.IntV_shapeI(i);
+
+        //============================== Loop over groups
+        for (int g = 0; g < groups.size(); ++g)
+          precursor_new_local[dof] += coeff * xs->nu_delayed_sigma_f[g] *
+                                      phi_new_local[uk_map + g] *
+                                      IntV_ShapeI / volume;
+      }//for node i
+    }//for precursor j
+
+  }//for cell
+}

--- a/ChiModules/LinearBoltzmannSolver/lbs_linear_boltzmann_solver.h
+++ b/ChiModules/LinearBoltzmannSolver/lbs_linear_boltzmann_solver.h
@@ -89,8 +89,8 @@ public:
   chi_math::UnknownManager flux_moments_uk_man;
 
   size_t max_cell_dof_count = 0;
-  unsigned long long local_node_count = 0;
-  unsigned long long glob_node_count = 0;
+  uint64_t local_node_count = 0;
+  uint64_t glob_node_count = 0;
 
   Vec phi_new = nullptr, phi_old = nullptr, q_fixed = nullptr;
   std::vector<double> q_moments_local, ext_src_moments_local;

--- a/ChiModules/LinearBoltzmannSolver/lbs_linear_boltzmann_solver.h
+++ b/ChiModules/LinearBoltzmannSolver/lbs_linear_boltzmann_solver.h
@@ -61,7 +61,7 @@ public:
   double last_restart_write=0.0;
   LinearBoltzmann::Options options;    //In chi_npt_structs.h
 
-  int num_moments;
+  size_t num_moments;
   size_t num_groups;
   size_t num_precursors;
   size_t max_precursors_per_material;

--- a/ChiModules/LinearBoltzmannSolver/lbs_linear_boltzmann_solver.h
+++ b/ChiModules/LinearBoltzmannSolver/lbs_linear_boltzmann_solver.h
@@ -61,7 +61,10 @@ public:
   double last_restart_write=0.0;
   LinearBoltzmann::Options options;    //In chi_npt_structs.h
 
-  int num_moments=0;
+  int num_moments;
+  int num_groups;
+  int num_precursors;
+  int max_precursors_per_material;
 
   std::vector<LBSGroup> groups;
   std::vector<LBSGroupset> groupsets;
@@ -84,6 +87,7 @@ public:
   std::vector<std::shared_ptr<SweepBndry>>          sweep_boundaries;
 
   chi_math::UnknownManager flux_moments_uk_man;
+  chi_math::UnknownManager precursor_uk_man;
 
   size_t max_cell_dof_count = 0;
   unsigned long long local_node_count = 0;
@@ -94,6 +98,7 @@ public:
   std::vector<double> phi_new_local, phi_old_local;
   std::vector<double> delta_phi_local;
   std::vector<std::vector<double>> psi_new_local;
+  std::vector<double> precursor_new_local;
 
  public:
   //00

--- a/ChiModules/LinearBoltzmannSolver/lbs_linear_boltzmann_solver.h
+++ b/ChiModules/LinearBoltzmannSolver/lbs_linear_boltzmann_solver.h
@@ -87,7 +87,6 @@ public:
   std::vector<std::shared_ptr<SweepBndry>>          sweep_boundaries;
 
   chi_math::UnknownManager flux_moments_uk_man;
-  chi_math::UnknownManager precursor_uk_man;
 
   size_t max_cell_dof_count = 0;
   unsigned long long local_node_count = 0;
@@ -203,6 +202,9 @@ public:
   //compute_balance
   void ZeroOutflowBalanceVars(LBSGroupset& groupset);
   void ComputeBalance();
+
+  //precursors
+  void ComputePrecursors();
 };
 
 }

--- a/ChiModules/LinearBoltzmannSolver/lbs_linear_boltzmann_solver.h
+++ b/ChiModules/LinearBoltzmannSolver/lbs_linear_boltzmann_solver.h
@@ -62,9 +62,9 @@ public:
   LinearBoltzmann::Options options;    //In chi_npt_structs.h
 
   int num_moments;
-  int num_groups;
-  int num_precursors;
-  int max_precursors_per_material;
+  size_t num_groups;
+  size_t num_precursors;
+  size_t max_precursors_per_material;
 
   std::vector<LBSGroup> groups;
   std::vector<LBSGroupset> groupsets;


### PR DESCRIPTION
## Notes

Currently, only the maximum number of precursors that exist on a material are stored per node. This is done to eliminate the possibility of potentially very sparse vectors in problems with many materials. With this infrastructure, nodally define precursors only make sense with PWLD and FV. With PWLC, nodally defined precursors do not make sense because interfaces between materials can have different precursor species on either side. The obvious issue here is that we have `max_precursors_per_material` slots to store up to `2 * max_precursors_per_material`. For this reason, it makes more sense to store cell averaged precursors. 

### Changes to `LinearBoltzmann::Solver`

- Added precursor initialization to `LinearBoltzmann::Solver::InitMaterials` and `LinearBoltzmann::Solver::InitPArrays`
- Added `LinearBoltzmann::Solver::ComputePrecursors` routine to compute steady state precursor concentrations.
- Call `ComputePrecursors` at the end of the `Execute` routine
- Added `num_groups`, `num_precursors`, and `max_precursors_per_material` attributes

