### PR TITLE
STL headers

### DIFF
--- a/ChiTech/ChiDataTypes/byte_array.h
+++ b/ChiTech/ChiDataTypes/byte_array.h
@@ -1,6 +1,7 @@
 #ifndef CHITECH_BYTE_ARRAY_H
 #define CHITECH_BYTE_ARRAY_H
 
+#include <cstddef>
 #include <vector>
 #include <stdexcept>
 

--- a/ChiTech/ChiDataTypes/varying.h
+++ b/ChiTech/ChiDataTypes/varying.h
@@ -3,6 +3,7 @@
 
 #include "chi_data_types.h"
 
+#include <cstddef>
 #include <iostream>
 #include <vector>
 #include <memory>

--- a/ChiTech/ChiMesh/MeshCutting/cutmesh_2D_cutcell.cc
+++ b/ChiTech/ChiMesh/MeshCutting/cutmesh_2D_cutcell.cc
@@ -3,6 +3,7 @@
 #include "ChiMesh/MeshContinuum/chi_meshcontinuum.h"
 
 #include <algorithm>
+#include <functional>
 
 //###################################################################
 /**Cuts a polygon.*/

--- a/ChiTech/ChiMesh/MeshCutting/cutmesh_3D_cutcell.cc
+++ b/ChiTech/ChiMesh/MeshCutting/cutmesh_3D_cutcell.cc
@@ -7,6 +7,7 @@ extern ChiLog& chi_log;
 
 #include <queue>
 #include <algorithm>
+#include <functional>
 
 //###################################################################
 /***/


### PR DESCRIPTION
Explicitly include utilised STL header files to permit compilation with various versions library versions. Tested for backwards compatibility on all GCC major releases down to GCC-7.