### PR TITLE
Regression tests now run locally on TAMU cluster.

### DIFF
--- a/ChiTech/ChiMath/SpatialDiscretization/CellMappings/FE_PWL/pwl_slab_03_compunitintgls.cc
+++ b/ChiTech/ChiMath/SpatialDiscretization/CellMappings/FE_PWL/pwl_slab_03_compunitintgls.cc
@@ -59,10 +59,10 @@ void SlabMappingFE_PWL::
   IntS_shapeI_shapeJ[0][0][0] =  1.0;
   IntS_shapeI_shapeJ[0][0][1] =  0.0;
   IntS_shapeI_shapeJ[0][1][0] =  0.0;
-  IntS_shapeI_shapeJ[0][1][1] =  1.0;
+  IntS_shapeI_shapeJ[0][1][1] =  0.0;
 
   //Right face
-  IntS_shapeI_shapeJ[1][0][0] =  1.0;
+  IntS_shapeI_shapeJ[1][0][0] =  0.0;
   IntS_shapeI_shapeJ[1][0][1] =  0.0;
   IntS_shapeI_shapeJ[1][1][0] =  0.0;
   IntS_shapeI_shapeJ[1][1][1] =  1.0;

--- a/ChiTest/Z_Run_all.py
+++ b/ChiTest/Z_Run_all.py
@@ -29,15 +29,12 @@ print("")
 test_number = 0
 num_failed = 0
 
-# Determine if we are on TACC or tamu cluster
+# Determine if we are on TACC
 # (each test will require a separate job)
 hostname = subprocess.check_output(['hostname']).decode('utf-8')
 tacc = False
-tamu = False
 if "tacc.utexas.edu" in hostname:
     tacc = True
-elif "ne.tamu.edu" in hostname and "orchard" in hostname:
-    tamu = True
 
 def format3(number):
     return "{:3d}".format(number)
@@ -112,38 +109,6 @@ def run_test_tacc(file_name, comment, num_procs,
     if passed:
         os.system(f"rm ChiTest/{file_name}.job ChiTest/{file_name}.o ChiTest/{file_name}.e")
 
-def run_test_tamu(file_name, comment, num_procs,
-		search_strings_vals_tols):
-    test_name = format_filename(file_name) + " " + comment + " " + str(num_procs) + " MPI Processes"
-    print("Running Test " + format3(test_number) + " " + test_name, end='', flush=True)
-    if print_only: print(""); return
-    with open(f"ChiTest/{file_name}.job", 'w') as job_file:
-        job_file.write(textwrap.dedent(f"""
-            #!/usr/bin/bash
-            #
-            #SBATCH -J {file_name} # Job name
-            #SBATCH -o ChiTest/{file_name}.o # output file
-            #SBATCH -e ChiTest/{file_name}.e # error file
-            #SBATCH -p class # Queue (partition) name
-            #SBATCH -N {num_procs // 48 + 1} # Total # of nodes
-            #SBATCH -n {num_procs} # Total # of mpi tasks
-            #SBATCH -t 00:05:00 # Runtime (hh:mm:ss)
-            #SBATCH -A class # Allocation name (req'd if you have more than 1)
-
-            mpiexec -n {num_procs} {kpath_to_exe} ChiTest/{file_name}.lua master_export=false
-            """
-        ).strip())
-    os.system(f"sbatch -W ChiTest/{file_name}.job > /dev/null")  # -W means wait for job to finish
-    with open(f"ChiTest/{file_name}.o", 'r') as outfile:
-        out = outfile.read()
-
-    passed = parse_output(out, search_strings_vals_tols)
-
-    # Cleanup
-    if passed:
-        os.system(f"rm ChiTest/{file_name}.job ChiTest/{file_name}.o ChiTest/{file_name}.e")
-
-
 def run_test_local(file_name, comment, num_procs,
 		search_strings_vals_tols):
     test_name = format_filename(file_name) + " " + comment + " " + str(num_procs) + " MPI Processes"
@@ -167,9 +132,6 @@ def run_test(file_name, comment, num_procs,
        (not tests_to_run):
         if tacc:
             run_test_tacc(file_name, comment, num_procs,
-                search_strings_vals_tols)
-        elif tamu:
-            run_test_tamu(file_name, comment, num_procs,
                 search_strings_vals_tols)
         else:
             run_test_local(file_name, comment, num_procs,


### PR DESCRIPTION
Originally, each test was submitted as a seperate job. On the new
cluster, modules can't be loaded from the head node and an interactive
job must be started to run tests:

srun --pty --ntasks=4 /bin/bash

Once this interactive job is started, modules may be loaded and
regression tests executed locally.