### PR TITLE
Fixup Installation Instructions

### DIFF
--- a/ChiDoc/Install_linux.md
+++ b/ChiDoc/Install_linux.md
@@ -96,7 +96,7 @@ into the directory containing the "configure" script and execute the following:
 
 ```bash
 ./configure  \
---prefix=$PWD/install  \
+--prefix=</path/to/install>  \
 --download-hypre=1  \
 --with-ssl=0  \
 --with-debugging=0  \
@@ -107,6 +107,7 @@ into the directory containing the "configure" script and execute the following:
 --download-parmetis=1  \
 --download-superlu_dist=1  \
 --with-cxx-dialect=C++11  \
+--with-64-bit-indices \
 CFLAGS='-fPIC -fopenmp'  \
 CXXFLAGS='-fPIC -fopenmp'  \
 FFLAGS='-fPIC -fopenmp'  \
@@ -118,6 +119,9 @@ CXXOPTFLAGS='-O3 -march=native -mtune=native'  \
 FOPTFLAGS='-O3 -march=native -mtune=native'  \
 PETSC_DIR=$PWD
 ```
+
+The installation prefix ```</path/to/install>``` must be replaced with
+the desired installation directory for this script to execute properly.
 
 If the configuration fails then consult PETSc's user documentation.
 

--- a/ChiDoc/Install_macos.md
+++ b/ChiDoc/Install_macos.md
@@ -62,7 +62,7 @@ into the directory containing the "configure" script and execute the following:
 
 ```bash
 ./configure  \
---prefix=$PWD/install  \
+--prefix=</path/to/install>  \
 --download-hypre=1  \
 --with-ssl=0  \
 --with-debugging=0  \
@@ -73,6 +73,7 @@ into the directory containing the "configure" script and execute the following:
 --download-parmetis=1  \
 --download-superlu_dist=1  \
 --with-cxx-dialect=C++11  \
+--with-64-bit-indices \
 CFLAGS='-fPIC -fopenmp'  \
 CXXFLAGS='-fPIC -fopenmp'  \
 FFLAGS='-fPIC -fopenmp'  \
@@ -84,6 +85,9 @@ CXXOPTFLAGS='-O3 -march=native -mtune=native'  \
 FOPTFLAGS='-O3 -march=native -mtune=native'  \
 PETSC_DIR=$PWD
 ```
+
+The installation prefix ```</path/to/install>``` must be replaced with 
+the desired installation directory for this script to execute properly.
 
 If the configuration fails then consult PETSc's user documentation.
 


### PR DESCRIPTION
## Modified PETSc Installation Instructions
- Added `--with-64-bit-indices` flag to PETSC configure script. This used to be present but for some reason currently is not. 
- Changed `--prefix=$PWD/install` to `--prefix=</path/to/install>` due to PETSc's recommendation to install in a separate directory.
