### PR TITLE
XS Allocation Fixup

### DIFF
--- a/framework/ChiPhysics/PhysicsMaterial/transportxsections/lua/xsections_lua_utils.cc
+++ b/framework/ChiPhysics/PhysicsMaterial/transportxsections/lua/xsections_lua_utils.cc
@@ -11,7 +11,7 @@
 ;
 
 //###################################################################
-/**Creates a stand-alone transport cross-section.
+/**Creates a stand-alone transport cross section.
  *
  *
 
@@ -27,7 +27,7 @@ chiPhysicsMaterialSetProperty(materials[2],
                               EXISTING,
                               xs_graphite_clean)
 \endcode
- * \return Returns a handle to the cross-section.
+ * \return Returns a handle to the cross section.
  *
 \ingroup LuaTransportXSs
  */
@@ -44,9 +44,9 @@ int chiPhysicsTransportXSCreate(lua_State* L)
 }
 
 //###################################################################
-/**Sets the properties of a transport cross-section.
+/**Sets the properties of a transport cross section.
 
- \param XS_handle int Handle to the cross-section to be modified.
+ \param XS_handle int Handle to the cross section to be modified.
  \param OperationIndex int Method used for setting the xs property.
  \param Information varying Varying information depending on the operation.
 
@@ -59,8 +59,8 @@ information. As a simple example consider the case where the user would like
 to set a single constant thermal conductivity. This can be achieved with \n
 FROM_ARRAY\n
 Sets a property based on a Lua array indexed from 1 to N. Internally
-will be converted to 0 to N-1. This method can be used to set mutligroup
-cross-sections or sources.
+will be converted to 0 to N-1. This method can be used to set mutli-group
+cross sections or sources.
 \n
 SIMPLEXS0\n
 Makes a simple material with no transfer matrix just \f$\sigma_t \f$. Expects two
@@ -82,7 +82,7 @@ values: \n
 ####_
 
 CHI_XSFILE\n
-Loads transport cross-sections from CHI type cross-section files. Expects
+Loads transport cross sections from CHI type cross section files. Expects
 to be followed by a filepath specifying the xs-file.
 
 
@@ -119,7 +119,7 @@ int chiPhysicsTransportXSSet(lua_State* L)
   }
   catch(const std::out_of_range& o){
     chi::log.LogAllError()
-      << "ERROR: Invalid cross-section handle"
+      << "ERROR: Invalid cross section handle"
       << " in call to chiPhysicsTransportXSSet."
       << std::endl;
     chi::Exit(EXIT_FAILURE);
@@ -169,9 +169,9 @@ int chiPhysicsTransportXSSet(lua_State* L)
 }
 
 //###################################################################
-/**Obtains a lua table of all the cross-section values.
+/**Obtains a lua table of all the cross section values.
 
- \param XS_handle int Handle to the cross-section to be modified.
+ \param XS_handle int Handle to the cross section to be modified.
 
  ## _
 
@@ -203,7 +203,7 @@ int chiPhysicsTransportXSGet(lua_State* L)
   }
   catch(const std::out_of_range& o){
     chi::log.LogAllError()
-      << "ERROR: Invalid cross-section handle"
+      << "ERROR: Invalid cross section handle"
       << " in call to " << __FUNCTION__ << "."
       << std::endl;
     chi::Exit(EXIT_FAILURE);
@@ -215,7 +215,7 @@ int chiPhysicsTransportXSGet(lua_State* L)
 }
 
 //###################################################################
-/**Makes a combined cross-section from multiple other cross-sections.
+/**Makes a combined cross section from multiple other cross sections.
 
  \param Combinations table A lua-table with each element another table
                            containing a handle to an existing xs and a
@@ -245,7 +245,7 @@ chiPhysicsMaterialSetProperty(materials[1],
                               aerated_graphite)
 \endcode
 
- \return Returns a handle to another cross-section object that contains the
+ \return Returns a handle to another cross section object that contains the
          desired combination.
 
 \ingroup LuaTransportXSs
@@ -306,7 +306,7 @@ int chiPhysicsTransportXSMakeCombined(lua_State* L)
     chi::log.Log() << "  Element handle: " << elem.first
                        << " scalar value: " << elem.second;
 
-  //======================================== Make the new cross-section
+  //======================================== Make the new cross section
   auto new_xs = std::make_shared<chi_physics::TransportCrossSections>();
 
   new_xs->MakeCombined(combinations);
@@ -319,10 +319,10 @@ int chiPhysicsTransportXSMakeCombined(lua_State* L)
 }
 
 //###################################################################
-/**Sets a combined cross-section from multiple other cross-sections. This
- function can be called multiple times on the same cross-section handle.
+/**Sets a combined cross section from multiple other cross sections. This
+ function can be called multiple times on the same cross section handle.
 
- \param XS_handle int Handle to the cross-section to be modified.
+ \param XS_handle int Handle to the cross section to be modified.
  \param Combinations table A lua-table with each element another table
                            containing a handle to an existing xs and a
                            scalar multiplier.
@@ -373,7 +373,7 @@ int chiPhysicsTransportXSSetCombined(lua_State* L)
   }
   catch(const std::out_of_range& o){
     chi::log.LogAllError()
-      << "ERROR: Invalid cross-section handle"
+      << "ERROR: Invalid cross section handle"
       << " in call to " << __FUNCTION__ << "."
       << std::endl;
     chi::Exit(EXIT_FAILURE);
@@ -429,7 +429,7 @@ int chiPhysicsTransportXSSetCombined(lua_State* L)
 //###################################################################
 /** Exports a cross section to ChiTech format.
  *
-\param XS_handle int Handle to the cross-section to be exported.
+\param XS_handle int Handle to the cross section to be exported.
 \param file_name string The name of the file to which the XS is to be exported.
 
 \ingroup LuaTransportXSs
@@ -453,7 +453,7 @@ int chiPhysicsTransportXSExportToChiTechFormat(lua_State* L)
   }
   catch(const std::out_of_range& o){
     chi::log.LogAllError()
-      << "ERROR: Invalid cross-section handle"
+      << "ERROR: Invalid cross section handle"
       << " in call to " << __FUNCTION__ << "."
       << std::endl;
     chi::Exit(EXIT_FAILURE);

--- a/framework/ChiPhysics/PhysicsMaterial/transportxsections/prop_transportxs_00_general.cc
+++ b/framework/ChiPhysics/PhysicsMaterial/transportxsections/prop_transportxs_00_general.cc
@@ -148,9 +148,7 @@ MakeCombined(std::vector<std::pair<int, double> > &combinations)
 
   unsigned int n_grps = 0;
   unsigned int n_precs = 0;
-
   double Nf_total = 0.0; //total density of fissile materials
-  double Np_total = 0.0; //total density of materials with precursors
 
   //loop over cross-sections
   for (auto combo : combinations)
@@ -380,7 +378,7 @@ ComputeAbsorption()
   // estimate from a transfer matrix
   else
   {
-    chi::log.LogAllWarning()
+    chi::log.Log0Warning()
         << "Estimating absorption from the transfer matrices.";
 
     const auto& S0 = transfer_matrices[0];
@@ -404,11 +402,10 @@ ComputeAbsorption()
 
       // TODO: Should negative absorption be allowed?
       if (sigma_a[g] < 0.0)
-        chi::log.LogAllWarning()
+        chi::log.Log0Warning()
             << "Negative absorption cross-section encountered "
             << "in group " << g << " when estimating from the "
             << "transfer matrices";
     }//for g
   }//if scattering present
-
 }

--- a/framework/ChiPhysics/PhysicsMaterial/transportxsections/prop_transportxs_00_general.cc
+++ b/framework/ChiPhysics/PhysicsMaterial/transportxsections/prop_transportxs_00_general.cc
@@ -157,18 +157,8 @@ MakeCombined(std::vector<std::pair<int, double> > &combinations)
   {
     //get the cross-section from the lua stack
     std::shared_ptr<chi_physics::TransportCrossSections> xs;
-    try
-    {
-      xs = chi::GetStackItemPtr(chi::trnsprt_xs_stack, combo.first);
-    }
-    catch(const std::out_of_range& o)
-    {
-      chi::log.LogAllError()
-        << "ERROR: Invalid cross-section handle"
-        << " in call to chiPhysicsMaterialSetProperty."
-        << std::endl;
-      chi::Exit(EXIT_FAILURE);
-    }
+    xs = chi::GetStackItemPtr(chi::trnsprt_xs_stack, combo.first,
+                              std::string(__FUNCTION__));
     xsecs.push_back(xs);
 
     //increment densities

--- a/framework/ChiPhysics/PhysicsMaterial/transportxsections/prop_transportxs_00_general.cc
+++ b/framework/ChiPhysics/PhysicsMaterial/transportxsections/prop_transportxs_00_general.cc
@@ -92,7 +92,7 @@ MakeSimple1(int n_grps, double sigma, double c)
   sigma_t.resize(n_grps, sigma);
   transfer_matrices.emplace_back(n_grps, n_grps);
 
-  // When multi-group, assign half the scattering cross-section
+  // When multi-group, assign half the scattering cross section
   // to within-group scattering. The other half will be used for
   // up/down-scattering.
 
@@ -100,7 +100,7 @@ MakeSimple1(int n_grps, double sigma, double c)
   double scale = (num_groups == 1)? 1.0 : 0.5;
   S.SetDiagonal(std::vector<double>(n_grps, sigma * c * scale));
 
-  // Set the up/down-scattering cross-sections.
+  // Set the up/down-scattering cross sections.
   // Summary:
   //     1) The half of groups with higher energies down-scatter to the next
   //        lowest energy group half the time and to the same group half the
@@ -136,7 +136,7 @@ MakeSimple1(int n_grps, double sigma, double c)
 
 
 //######################################################################
-/** Populates the cross-section from a combination of others. */
+/** Populates the cross section from a combination of others. */
 void chi_physics::TransportCrossSections::
 MakeCombined(std::vector<std::pair<int, double> > &combinations)
 {
@@ -150,10 +150,10 @@ MakeCombined(std::vector<std::pair<int, double> > &combinations)
   unsigned int n_precs = 0;
   double Nf_total = 0.0; //total density of fissile materials
 
-  //loop over cross-sections
+  //loop over cross sections
   for (auto combo : combinations)
   {
-    //get the cross-section from the lua stack
+    //get the cross section from the lua stack
     std::shared_ptr<chi_physics::TransportCrossSections> xs;
     xs = chi::GetStackItemPtr(chi::trnsprt_xs_stack, combo.first,
                               std::string(__FUNCTION__));
@@ -171,13 +171,13 @@ MakeCombined(std::vector<std::pair<int, double> > &combinations)
       n_grps = xs->num_groups;
     else if (xs->num_groups != n_grps)
       throw std::logic_error(
-          "Incompatible cross-sections encountered.\n"
-          "All cross-sections being combined must have the "
+          "Incompatible cross sections encountered.\n"
+          "All cross sections being combined must have the "
           "same number of energy groups.");
 
     //increment number of precursors
     n_precs += xs->num_precursors;
-  }//for cross-section
+  }//for cross section
 
   // Check that the fissile and precursor densities are greater than
   // machine precision. If this condition is not met, the material is assumed
@@ -185,14 +185,14 @@ MakeCombined(std::vector<std::pair<int, double> > &combinations)
   if (Nf_total < 1.0e-12)
     is_fissionable = false;
 
-  // Check to ensure that all fissionable cross-sections contain either
+  // Check to ensure that all fissionable cross sections contain either
   // prompt/delayed fission data or total fission data
   if (n_precs > 0)
     for (const auto& xs : xsecs)
       if (xs->is_fissionable && xs->num_precursors == 0)
         throw std::logic_error(
-            "Incompatible cross-sections encountered.\n"
-            "If any fissionable cross-sections specify prompt/delayed "
+            "Incompatible cross sections encountered.\n"
+            "If any fissionable cross sections specify prompt/delayed "
             "fission data, all must specify prompt/delayed data.");
 
   //============================================================
@@ -206,7 +206,7 @@ MakeCombined(std::vector<std::pair<int, double> > &combinations)
     scattering_order = std::max(scattering_order,
                                 xs->scattering_order);
 
-  //mandatory cross-sections
+  //mandatory cross sections
   sigma_t.assign(n_grps, 0.0);
   sigma_a.assign(n_grps, 0.0);
 
@@ -265,10 +265,10 @@ MakeCombined(std::vector<std::pair<int, double> > &combinations)
       ff_i = N_i / Nf_total;
 
     //============================================================
-    // Combine cross-sections
+    // Combine cross sections
     //============================================================
 
-    // Here, raw cross-sections are scaled by densities and spectra by
+    // Here, raw cross sections are scaled by densities and spectra by
     // fractional densities. The latter is done to preserve a unit spectra.
     for (unsigned int g = 0; g < n_grps; ++g)
     {
@@ -327,16 +327,16 @@ MakeCombined(std::vector<std::pair<int, double> > &combinations)
       inv_velocity = xsecs[x]->inv_velocity;
     else if (xsecs[x]->inv_velocity != inv_velocity)
       throw std::logic_error(
-          "Invalid cross-sections encountered.\n"
-          "All cross-sections being combined must share a group "
+          "Invalid cross sections encountered.\n"
+          "All cross sections being combined must share a group "
           "structure. This implies that the inverse speeds for "
-          "each of the cross-sections must be equivalent.");
+          "each of the cross sections must be equivalent.");
 
     //============================================================
     // Combine transfer matrices
     //============================================================
 
-    // This step is somewhat tricky. The cross-sections aren't guaranteed
+    // This step is somewhat tricky. The cross sections aren't guaranteed
     // to have the same sparsity patterns and therefore simply adding them
     // together has to take the sparse matrix's protection mechanisms into
     // account.
@@ -356,9 +356,9 @@ MakeCombined(std::vector<std::pair<int, double> > &combinations)
         }
       }
     }
-  }//for cross-sections
+  }//for cross sections
 
-  //perform checks for the cross-sections
+  //perform checks for the cross sections
 
   Finalize();
 }
@@ -384,7 +384,7 @@ ComputeAbsorption()
     const auto& S0 = transfer_matrices[0];
     for (size_t g = 0; g < num_groups; ++g)
     {
-      // estimate the scattering cross-section
+      // estimate the scattering cross section
       double sig_s = 0.0;
       for (size_t row = 0; row < S0.NumRows(); ++row)
       {
@@ -403,7 +403,7 @@ ComputeAbsorption()
       // TODO: Should negative absorption be allowed?
       if (sigma_a[g] < 0.0)
         chi::log.Log0Warning()
-            << "Negative absorption cross-section encountered "
+            << "Negative absorption cross section encountered "
             << "in group " << g << " when estimating from the "
             << "transfer matrices";
     }//for g

--- a/framework/ChiPhysics/PhysicsMaterial/transportxsections/prop_transportxs_01_readfromchi.cc
+++ b/framework/ChiPhysics/PhysicsMaterial/transportxsections/prop_transportxs_01_readfromchi.cc
@@ -577,7 +577,6 @@ void chi_physics::TransportCrossSections::
         ReadTransferMatrices("TRANSFER_MOMENTS", transfer_matrices,
                              scattering_order + 1, num_groups,
                              f, ls, ln);
-
     }//try
 
     catch (const std::runtime_error& err)

--- a/framework/ChiPhysics/PhysicsMaterial/transportxsections/prop_transportxs_01_readfromchi.cc
+++ b/framework/ChiPhysics/PhysicsMaterial/transportxsections/prop_transportxs_01_readfromchi.cc
@@ -253,17 +253,17 @@ void chi_physics::TransportCrossSections::
   // Open Chi XS file
   //============================================================
 
-  chi::log.Log() << "Reading Chi cross-section file \"" << file_name << "\"\n";
+  chi::log.Log()
+      << "Reading Chi cross-section file \"" << file_name << "\"\n";
+
   //opens and checks if open
   std::ifstream file;
   file.open(file_name);
   if (!file.is_open())
-  {
-    chi::log.LogAllError() << "Failed to open chi cross-section file \""
-                           << file_name << "\" in call to "
-                           << "TransportCrossSections::MakeFromChixsFile\n";
-    chi::Exit(EXIT_FAILURE);
-  }
+    throw std::runtime_error(
+        "Failed to open Chi cross-section file "
+        "\"" + file_name + "\" in call to " +
+        std::string(__FUNCTION__));
 
   //============================================================
   // Define utility functions for parsing
@@ -562,18 +562,27 @@ void chi_physics::TransportCrossSections::
 
     catch (const std::runtime_error& err)
     {
-      chi::log.LogAllError()
-        << "Error reading xs-file \"" + file_name + "\". "
-        << "Line number " << line_number << ". "
-        << err.what();
-      chi::Exit(EXIT_FAILURE);
+      throw std::runtime_error(
+          "Error reading Chi cross-section file "
+          "\"" + file_name + "\".\n" +
+          "Line number " + std::to_string(line_number) +
+          "\n" + err.what());
+    }
+
+    catch (const std::out_of_range& err)
+    {
+      throw std::out_of_range(
+          "Error reading Chi cross-section file "
+          "\"" + file_name + "\".\n" +
+          "Line number " + std::to_string(line_number) +
+          "\n" + err.what());
     }
 
     catch (...)
     {
-      chi::log.LogAllError()
-        << "Unknown error in " << std::string(__FUNCTION__);
-      chi::Exit(EXIT_FAILURE);
+      throw std::runtime_error(
+          "Unknown error encountered in " +
+          std::string (__FUNCTION__ ));
     }
 
     word = "";

--- a/framework/ChiPhysics/PhysicsMaterial/transportxsections/prop_transportxs_01_readfromchi.cc
+++ b/framework/ChiPhysics/PhysicsMaterial/transportxsections/prop_transportxs_01_readfromchi.cc
@@ -515,7 +515,7 @@ void chi_physics::TransportCrossSections::
       }
 
       //==================================================
-      // Cross-Section Data
+      // Cross Section Data
       //==================================================
 
       if (fw == "SIGMA_T_BEGIN")

--- a/framework/ChiPhysics/PhysicsMaterial/transportxsections/prop_transportxs_01_readfromchi.cc
+++ b/framework/ChiPhysics/PhysicsMaterial/transportxsections/prop_transportxs_01_readfromchi.cc
@@ -317,13 +317,13 @@ void chi_physics::TransportCrossSections::
   auto Read1DData =
       [](const std::string& keyword,
          std::vector<double>& destination,
-         const unsigned int n,
+         const unsigned int N,
          std::ifstream& file,
          std::istringstream& line_stream,
          unsigned int& line_number)
       {
         //init storage
-        destination.assign(n, 0.0);
+        destination.assign(N, 0.0);
 
         //book-keeping
         std::string line;
@@ -340,11 +340,11 @@ void chi_physics::TransportCrossSections::
           //get data from current line
           line_stream >> i >> value;
           destination.at(i) = value;
-          if (count++ >= n)
+          if (count++ >= N)
             throw std::runtime_error(
                 "To many entries encountered when parsing "
                 "1D data.\nThe expected number of entries is " +
-                std::to_string(n));
+                std::to_string(N));
 
           //go to next line
           std::getline(file, line);
@@ -358,16 +358,16 @@ void chi_physics::TransportCrossSections::
   auto ReadTransferMatrices =
       [](const std::string& keyword,
          std::vector<TransferMatrix>& destination,
-         const unsigned int n,  //# of moments
-         const unsigned int m,  //# of groups
+         const unsigned int M,  //# of moments
+         const unsigned int G,  //# of groups
          std::ifstream& file,
          std::istringstream& line_stream,
          unsigned int& line_number)
       {
         //init storage
         destination.clear();
-        for (unsigned int i = 0; i < n; ++i)
-          destination.emplace_back(m, m);
+        for (unsigned int i = 0; i < M; ++i)
+          destination.emplace_back(G, G);
 
         //book-keeping
         std::string word, line;
@@ -403,16 +403,16 @@ void chi_physics::TransportCrossSections::
   auto ReadEmissionSpectra =
       [](const std::string& keyword,
          EmissionSpectra& destination,
-         const unsigned int m, //# of groups
-         const unsigned int n, //# of precursors
+         const unsigned int G, //# of groups
+         const unsigned int J, //# of precursors
          std::ifstream& file,
          std::istringstream& line_stream,
          unsigned int& line_number)
       {
         //init storage
         destination.clear();
-        for (unsigned int i = 0; i < m; ++i)
-          destination.emplace_back(n, 0.0);
+        for (unsigned int i = 0; i < G; ++i)
+          destination.emplace_back(J, 0.0);
 
         //book-keeping
         std::string word, line;

--- a/framework/ChiPhysics/PhysicsMaterial/transportxsections/prop_transportxs_01_readfromchi.cc
+++ b/framework/ChiPhysics/PhysicsMaterial/transportxsections/prop_transportxs_01_readfromchi.cc
@@ -10,7 +10,7 @@
 /**\defgroup ChiXSFile Chi-Tech Cross-section format 1
  *\ingroup LuaPhysics
  *
- * An example Chi-Tech cross-section file is shown below. The bare-bones
+ * An example Chi-Tech cross section file is shown below. The bare-bones
  * format is shown below with more examples below:
 \code
 # This header can be as large as you please. The actual processing
@@ -87,9 +87,9 @@ constants, \f$ \lambda_j \f$ are required.
 ## Keyword definitions
 
 - NUM_GROUPS num_groups Required. Specifies the number of groups for this
-  cross-section. Symbol \f$ G \f$.
+  cross section. Symbol \f$ G \f$.
 - NUM_MOMENTS num_moments Required. The number of transfer matrices to allocate
-  for this cross-section (whether used or not). Typically this number is one
+  for this cross section (whether used or not). Typically this number is one
   greater than the scattering order (i.e., \f$ L+1 \f$)
 - NUM_PRECURSORS num_precursors Optional. Indicates how many precursors are used
   in this cross section. Symbol \f$ J \f$
@@ -241,8 +241,8 @@ CHI_DELAYED_END
  * */
 
 //###################################################################
-/**This method populates a transport cross-section from
- * a Chi cross-section file.*/
+/**This method populates a transport cross section from
+ * a Chi cross section file.*/
 void chi_physics::TransportCrossSections::
   MakeFromChiXSFile(const std::string &file_name)
 {
@@ -254,14 +254,14 @@ void chi_physics::TransportCrossSections::
   //============================================================
 
   chi::log.Log()
-      << "Reading Chi cross-section file \"" << file_name << "\"\n";
+      << "Reading Chi cross section file \"" << file_name << "\"\n";
 
   //opens and checks if open
   std::ifstream file;
   file.open(file_name);
   if (!file.is_open())
     throw std::runtime_error(
-        "Failed to open Chi cross-section file "
+        "Failed to open Chi cross section file "
         "\"" + file_name + "\" in call to " +
         std::string(__FUNCTION__));
 
@@ -274,13 +274,13 @@ void chi_physics::TransportCrossSections::
   auto ReadGroupStructure =
       [](const std::string& keyword,
          std::vector<std::vector<double>>& destination,
-         const unsigned int n,
+         const unsigned int G,  //# of groups
          std::ifstream& file,
          std::istringstream& line_stream,
          unsigned int& line_number)
       {
         //init storage
-        destination.assign(n, std::vector<double>(2, 0.0));
+        destination.assign(G, std::vector<double>(2, 0.0));
 
         //book-keeping
         std::string line;
@@ -299,11 +299,11 @@ void chi_physics::TransportCrossSections::
           line_stream >> group >> high >> low;
           destination.at(group).at(0) = high;
           destination.at(group).at(1) = low;
-          if (count++ >= n)
+          if (count++ >= G)
             throw std::runtime_error(
                 "Too many entries encountered when parsing "
                 "group structure.\nThe expected number of entries "
-                "is " + std::to_string(n) + ".");
+                "is " + std::to_string(G) + ".");
 
           //go to next line
           std::getline(file, line);
@@ -411,7 +411,7 @@ void chi_physics::TransportCrossSections::
       {
         //init storage
         destination.clear();
-        for (unsigned int i = 0; i < G; ++i)
+        for (unsigned int g = 0; g < G; ++g)
           destination.emplace_back(J, 0.0);
 
         //book-keeping
@@ -461,7 +461,7 @@ void chi_physics::TransportCrossSections::
       if (G <= 0)
         throw std::logic_error(
             "The specified number of energy groups "
-            "must be positive.");
+            "must be strictly positive.");
       num_groups = G;
     }
 
@@ -507,9 +507,7 @@ void chi_physics::TransportCrossSections::
 
       if (fw == "INV_VELOCITY_BEGIN")
         Read1DData("INV_VELOCITY", inv_velocity, num_groups, f, ls, ln);
-      if (fw == "VELOCITY_BEGIN" &&
-          std::all_of(inv_velocity.begin(), inv_velocity.end(),
-                      [](double x) { return x == 0.0; }))
+      if (fw == "VELOCITY_BEGIN" && inv_velocity.empty())
       {
         Read1DData("VELOCITY", inv_velocity, num_groups, f, ls, ln);
         for (unsigned int g = 0; g < num_groups; ++g)
@@ -582,7 +580,7 @@ void chi_physics::TransportCrossSections::
     catch (const std::runtime_error& err)
     {
       throw std::runtime_error(
-          "Error reading Chi cross-section file "
+          "Error reading Chi cross section file "
           "\"" + file_name + "\".\n" +
           "Line number " + std::to_string(line_number) +
           "\n" + err.what());
@@ -591,7 +589,7 @@ void chi_physics::TransportCrossSections::
     catch (const std::out_of_range& err)
     {
       throw std::out_of_range(
-          "Error reading Chi cross-section file "
+          "Error reading Chi cross section file "
           "\"" + file_name + "\".\n" +
           "Line number " + std::to_string(line_number) +
           "\n" + err.what());

--- a/framework/ChiPhysics/PhysicsMaterial/transportxsections/prop_transportxs_01_readfromchi.cc
+++ b/framework/ChiPhysics/PhysicsMaterial/transportxsections/prop_transportxs_01_readfromchi.cc
@@ -474,7 +474,7 @@ void chi_physics::TransportCrossSections::
         throw std::logic_error(
             "The specified number of scattering moments "
             "must be non-negative.");
-      scattering_order = std::min(0, M - 1);
+      scattering_order = std::max(0, M - 1);
     }
 
     //parse the number of precursors species

--- a/framework/ChiPhysics/PhysicsMaterial/transportxsections/prop_transportxs_01_readfromchi.cc
+++ b/framework/ChiPhysics/PhysicsMaterial/transportxsections/prop_transportxs_01_readfromchi.cc
@@ -455,19 +455,39 @@ void chi_physics::TransportCrossSections::
 
     //parse number of groups
     if (word == "NUM_GROUPS")
-      line_stream >> num_groups;
+    {
+      int G;
+      line_stream >> G;
+      if (G <= 0)
+        throw std::logic_error(
+            "The specified number of energy groups "
+            "must be positive.");
+      num_groups = G;
+    }
 
     //parse the number of scattering moments
     if (word == "NUM_MOMENTS")
     {
-      unsigned int M;
+      int M;
       line_stream >> M;
-      scattering_order = M - 1;
+      if (M < 0)
+        throw std::logic_error(
+            "The specified number of scattering moments "
+            "must be non-negative.");
+      scattering_order = std::min(0, M - 1);
     }
 
     //parse the number of precursors species
     if (word == "NUM_PRECURSORS")
-      line_stream >> num_precursors;
+    {
+      int J;
+      line_stream >> J;
+      if (J < 0)
+        throw std::logic_error(
+            "The specified number of delayed neutron "
+            "precursors must be non-negative.");
+      num_precursors = J;
+    }
 
     //parse nuclear data
     try

--- a/framework/ChiPhysics/PhysicsMaterial/transportxsections/prop_transportxs_01b_finalize.cc
+++ b/framework/ChiPhysics/PhysicsMaterial/transportxsections/prop_transportxs_01b_finalize.cc
@@ -95,176 +95,189 @@ void chi_physics::TransportCrossSections::Finalize()
           << "Prompt/delayed specification used.\n"
           << "Checking for prompt/delayed fission data...";
 
-      // check nu specification
+      //==================================================
+      // Check fission yield data
+      //==================================================
+
+      if (is_valid(nu_prompt) && is_valid(nu_delayed))
       {
-        if (is_valid(nu_prompt) && is_valid(nu_delayed))
-        {
-          if (!std::all_of(nu_prompt.begin(), nu_prompt.end(),
-                           [](double x) { return x == 0.0 || x > 1.0; }) &&
-              !std::all_of(nu_delayed.begin(), nu_delayed.end(),
-                           [](double x) { return x >= 0.0; }))
-            throw std::logic_error(
-                "Invalid prompt and delayed fission neutron yields "
-                "encountered.\nPrompt fission neutron yields must be either "
-                "zero or greater than one.\nDelayed fission neutron yields "
-                "must be zero or greater.");
-
-          //compute other quantities
-          nu.assign(num_groups, 0.0);
-          beta.assign(num_groups, 0.0);
-          for (unsigned int g = 0; g < num_groups; ++g)
-          {
-            nu[g] = nu_prompt[g] + nu_delayed[g];
-            beta[g] = nu_delayed[g] / nu[g];
-          }
-        }//if prompt/delayed specified
-
-        else if (is_valid(nu) && is_valid(beta))
-        {
-          if (!std::all_of(nu.begin(), nu.end(),
-                           [](double x) { return x == 0.0 || x > 1.0; }))
-            throw std::logic_error(
-                "Invalid fission neutron yield data encountered.\n"
-                "All values must be either zero or greater than one.");
-          if (!std::all_of(beta.begin(), beta.end(),
-                           [](double x) { return x >= 0.0 && x <= 1.0; }))
-            throw std::logic_error(
-                "Invalid delayed neutron fraction data encountered.\n"
-                "All values must be in the range [0.0, 1.0].");
-
-          //compute other quantities
-          nu_prompt.assign(num_groups, 0.0);
-          nu_delayed.assign(num_groups, 0.0);
-          for (unsigned int g = 0; g < num_groups; ++g)
-          {
-            nu_prompt[g] = (1.0 - beta[g]) * nu[g];
-            nu_delayed[g] = beta[g] * nu[g];
-          }
-        } //if delayed fraction specified
-
-        else
+        if (!std::all_of(nu_prompt.begin(), nu_prompt.end(),
+                         [](double x) { return x == 0.0 || x > 1.0; }) &&
+            !std::all_of(nu_delayed.begin(), nu_delayed.end(),
+                         [](double x) { return x >= 0.0; }))
           throw std::logic_error(
-              "Invalid specification of prompt/delayed fission "
-              "neutron yield data encountered.\nEither the prompt and "
-              "delayed fission neutron yields or the total fission neutron"
-              "yield and delayed neutron fraction must be provided.");
-
-        // ensure the fission cross-section is available
-        if (!is_valid(sigma_f))
-        {
-          sigma_f.assign(num_groups, 0.0);
-          for (unsigned int g = 0; g < num_groups; ++g)
-            if (nu[g] != 0.0)
-              sigma_f[g] = nu_sigma_f[g] / nu[g];
-        }
+              "Invalid prompt and delayed fission neutron yields "
+              "encountered.\nPrompt fission neutron yields must be either "
+              "zero or greater than one.\nDelayed fission neutron yields "
+              "must be zero or greater.");
 
         //compute other quantities
-        nu_sigma_f.assign(num_groups, 0.0);
-        nu_prompt_sigma_f.assign(num_groups, 0.0);
-        nu_delayed_sigma_f.assign(num_groups, 0.0);
+        nu.assign(num_groups, 0.0);
+        beta.assign(num_groups, 0.0);
         for (unsigned int g = 0; g < num_groups; ++g)
         {
-          nu_sigma_f[g] = nu[g] * sigma_f[g];
-          nu_prompt_sigma_f[g] = nu_prompt[g] * sigma_f[g];
-          nu_delayed_sigma_f[g] = nu_delayed[g] * sigma_f[g];
+          nu[g] = nu_prompt[g] + nu_delayed[g];
+          beta[g] = nu_delayed[g] / nu[g];
         }
-      }
+      }//if prompt/delayed specified
 
-      //check and normalize prompt fission spectrum
+      else if (is_valid(nu) && is_valid(beta))
       {
-        if (chi_prompt.empty())
-          throw std::logic_error("Prompt fission spectrum not found.");
-        if (std::all_of(chi_prompt.begin(), chi_prompt.end(),
-                        [](double x) { return x == 0.0; }))
+        if (!std::all_of(nu.begin(), nu.end(),
+                         [](double x) { return x == 0.0 || x > 1.0; }))
           throw std::logic_error(
-              "Invalid prompt fission spectrum encountered.\n"
-              "Spectra must have at least one nonzero value.");
-
-        //normalize the spectrum to a unit sum
-        double chi_prompt_sum = std::accumulate(
-            chi_prompt.begin(), chi_prompt.end(), 0.0);
-        for (unsigned int g = 0; g < num_groups; ++g)
-          chi_prompt[g] /= chi_prompt_sum;
-      }
-
-      //check and normalize delayed emission spectra
-      {
-        if (chi_delayed.empty())
-          throw std::logic_error("Delayed emission spectra not found.");
-
-        //create chi_delayed transpose for easier checks
-        EmissionSpectra tmp;
-        tmp.resize(num_precursors, std::vector<double>(num_groups, 0.0));
-        for (unsigned int g = 0; g < num_groups; ++g)
-          for (unsigned int j = 0; j < num_precursors; ++j)
-            tmp[j][g] = chi_delayed[g][j];
-
-        for (unsigned int j = 0; j < num_precursors; ++j)
-        {
-          //throw error if emission spectrum j was not specified
-          if (std::all_of(tmp[j].begin(), tmp[j].end(),
-                          [](double x) { return x == 0.0; }))
-            throw std::logic_error(
-                "Invalid delayed emission spectra encountered for "
-                "precursor species " + std::to_string(j) + ".\n" +
-                "Spectra must have at least one nonzero value.");
-
-          //normalize each emission spectrum
-          double chi_delayed_j_sum =
-              std::accumulate(tmp[j].begin(), tmp[j].end(), 0.0);
-
-          for (unsigned int g = 0; g < num_groups; ++g)
-            chi_delayed[g][j] /= chi_delayed_j_sum;
-        }//for j
-      }
-
-      //check the precursor data
-      {
-        if (precursor_lambda.empty())
-          throw std::logic_error("Precursor decay constants not found.");
-        if (!std::all_of(precursor_lambda.begin(),
-                         precursor_lambda.end(),
-                        [](double x) { return x > 0.0;}))
-          throw std::logic_error(
-              "Invalid precursor decay constant encountered.\n"
-              "Decay constants must be greater than zero.");
-
-        if (precursor_yield.empty())
-          throw std::logic_error("Precursor yield fractions no found.");
-        if (!std::all_of(precursor_yield.begin(),
-                         precursor_yield.end(),
+              "Invalid fission neutron yield data encountered.\n"
+              "All values must be either zero or greater than one.");
+        if (!std::all_of(beta.begin(), beta.end(),
                          [](double x) { return x >= 0.0 && x <= 1.0; }))
           throw std::logic_error(
-              "Invalid delayed neutron precursor yield fraction "
-              "encountered.\n"
-              "Yield fractions must be in the range [0.0, 1.0]");
+              "Invalid delayed neutron fraction data encountered.\n"
+              "All values must be in the range [0.0, 1.0].");
 
-        //normalize the precursor yields
-        double yield_sum = std::accumulate(precursor_yield.begin(),
-                                           precursor_yield.end(), 0.0);
+        //compute other quantities
+        nu_prompt.assign(num_groups, 0.0);
+        nu_delayed.assign(num_groups, 0.0);
+        for (unsigned int g = 0; g < num_groups; ++g)
+        {
+          nu_prompt[g] = (1.0 - beta[g]) * nu[g];
+          nu_delayed[g] = beta[g] * nu[g];
+        }
+      } //if delayed fraction specified
 
-        for (unsigned int j = 0; j < num_precursors; ++j)
-          precursor_yield[j] /= yield_sum;
+      else
+        throw std::logic_error(
+            "Invalid specification of prompt/delayed fission "
+            "neutron yield data encountered.\nEither the prompt and "
+            "delayed fission neutron yields or the total fission neutron"
+            "yield and delayed neutron fraction must be provided.");
+
+      //==================================================
+      // Compute all production cross-sections
+      //==================================================
+
+      //ensure the fission cross-section is available
+      if (!is_valid(sigma_f))
+      {
+        sigma_f.assign(num_groups, 0.0);
+        for (unsigned int g = 0; g < num_groups; ++g)
+          if (nu[g] != 0.0)
+            sigma_f[g] = nu_sigma_f[g] / nu[g];
       }
 
-      // Compute the beta-weighted steady-state fission spectrum.
+      //compute other quantities
+      nu_sigma_f.assign(num_groups, 0.0);
+      nu_prompt_sigma_f.assign(num_groups, 0.0);
+      nu_delayed_sigma_f.assign(num_groups, 0.0);
+      for (unsigned int g = 0; g < num_groups; ++g)
+      {
+        nu_sigma_f[g] = nu[g] * sigma_f[g];
+        nu_prompt_sigma_f[g] = nu_prompt[g] * sigma_f[g];
+        nu_delayed_sigma_f[g] = nu_delayed[g] * sigma_f[g];
+      }
+
+      //==================================================
+      // Check prompt fission spectrum
+      //==================================================
+
+      if (chi_prompt.empty())
+        throw std::logic_error("Prompt fission spectrum not found.");
+      if (std::all_of(chi_prompt.begin(), chi_prompt.end(),
+                      [](double x) { return x == 0.0; }))
+        throw std::logic_error(
+            "Invalid prompt fission spectrum encountered.\n"
+            "Spectra must have at least one nonzero value.");
+
+      //normalize the spectrum to a unit sum
+      double chi_prompt_sum = std::accumulate(
+          chi_prompt.begin(), chi_prompt.end(), 0.0);
+      for (unsigned int g = 0; g < num_groups; ++g)
+        chi_prompt[g] /= chi_prompt_sum;
+
+      //==================================================
+      // Check delayed emission spectra
+      //==================================================
+
+      if (chi_delayed.empty())
+        throw std::logic_error("Delayed emission spectra not found.");
+
+      //create chi_delayed transpose for easier checks
+      EmissionSpectra tmp;
+      tmp.resize(num_precursors, std::vector<double>(num_groups, 0.0));
+      for (unsigned int g = 0; g < num_groups; ++g)
+        for (unsigned int j = 0; j < num_precursors; ++j)
+          tmp[j][g] = chi_delayed[g][j];
+
+      for (unsigned int j = 0; j < num_precursors; ++j)
+      {
+        //throw error if emission spectrum j was not specified
+        if (std::all_of(tmp[j].begin(), tmp[j].end(),
+                        [](double x) { return x == 0.0; }))
+          throw std::logic_error(
+              "Invalid delayed emission spectra encountered for "
+              "precursor species " + std::to_string(j) + ".\n" +
+              "Spectra must have at least one nonzero value.");
+
+        //normalize each emission spectrum
+        double chi_delayed_j_sum =
+            std::accumulate(tmp[j].begin(), tmp[j].end(), 0.0);
+
+        for (unsigned int g = 0; g < num_groups; ++g)
+          chi_delayed[g][j] /= chi_delayed_j_sum;
+      }//for j
+
+      //==================================================
+      // Check the precursor data
+      //==================================================
+
+      if (precursor_lambda.empty())
+        throw std::logic_error("Precursor decay constants not found.");
+      if (!std::all_of(precursor_lambda.begin(),
+                       precursor_lambda.end(),
+                      [](double x) { return x > 0.0;}))
+        throw std::logic_error(
+            "Invalid precursor decay constant encountered.\n"
+            "Decay constants must be greater than zero.");
+
+      if (precursor_yield.empty())
+        throw std::logic_error("Precursor yield fractions no found.");
+      if (!std::all_of(precursor_yield.begin(),
+                       precursor_yield.end(),
+                       [](double x) { return x >= 0.0 && x <= 1.0; }))
+        throw std::logic_error(
+            "Invalid delayed neutron precursor yield fraction "
+            "encountered.\n"
+            "Yield fractions must be in the range [0.0, 1.0]");
+
+      //normalize the precursor yields
+      double yield_sum = std::accumulate(precursor_yield.begin(),
+                                         precursor_yield.end(), 0.0);
+
+      for (unsigned int j = 0; j < num_precursors; ++j)
+        precursor_yield[j] /= yield_sum;
+
+
+      //==================================================
+      // Compute the steady-state fission spectrum
+      //==================================================
+
+      // This is computed via a beta-weighting
       // NOTE: Generally, the computation of this quantity requires
       //       a weight function. This estimate uses a unit weight
       //       function and may not be completely accurate.
-      {
-        for (unsigned int g = 0; g < num_groups; ++g)
-        {
-          //compute beta-averaged total fission spectrum
-          chi[g] = (1.0 - beta[g]) * chi_prompt[g];
-          for (unsigned int j = 0; j < num_precursors; ++j)
-            chi[g] += beta[g] * precursor_yield[j] * chi_delayed[g][j];
-        }
 
-        //normalize total chi just in case
-        double chi_sum = std::accumulate(chi.begin(), chi.end(), 0.0);
-        for (unsigned int g = 0; g < num_groups; ++g)
-          chi[g] /= chi_sum;
+      chi.assign(num_groups, 0.0);
+      for (unsigned int g = 0; g < num_groups; ++g)
+      {
+        //compute beta-averaged total fission spectrum
+        chi[g] = (1.0 - beta[g]) * chi_prompt[g];
+        for (unsigned int j = 0; j < num_precursors; ++j)
+          chi[g] += beta[g] * precursor_yield[j] * chi_delayed[g][j];
       }
+
+      //normalize total chi just in case
+      double chi_sum = std::accumulate(chi.begin(), chi.end(), 0.0);
+      for (unsigned int g = 0; g < num_groups; ++g)
+        chi[g] /= chi_sum;
     }//if prompt/delayed
 
     //==================================================

--- a/framework/ChiPhysics/PhysicsMaterial/transportxsections/prop_transportxs_01b_finalize.cc
+++ b/framework/ChiPhysics/PhysicsMaterial/transportxsections/prop_transportxs_01b_finalize.cc
@@ -15,47 +15,59 @@ void chi_physics::TransportCrossSections::Finalize()
   // Set the absorption cross-section, if unset
   //============================================================
 
-  if (std::all_of(sigma_a.begin(), sigma_a.end(),
-                  [](double x) { return x == 0.0; }))
+  // The logic here is that if absorption is empty, it was not
+  // specified, therefore, it should be computed. If a uniformly
+  // zero absorption cross-section was provided, assume that
+  // was intentional.
+
+  if (sigma_a.empty())
     ComputeAbsorption();
 
   //============================================================
   // Define utility functions
   //============================================================
 
-  auto was_specified =
-      [](const std::vector<double>& vec)
-      {
-        return std::any_of(vec.begin(), vec.end(),
-                           [](double x) { return x > 0.0; });
-      };
+
+  auto is_valid = [](const std::vector<double>& vec)
+  {
+    return !vec.empty() &&
+            std::all_of(vec.begin(), vec.end(),
+                       [](double x) { return x >= 0.0; });
+  };
 
   //============================================================
   // Determine if fissionable or not
   //============================================================
 
-  is_fissionable = was_specified(sigma_f) ||
-                   was_specified(nu_sigma_f);
+  is_fissionable = is_valid(sigma_f) || is_valid(nu_sigma_f);
 
   //============================================================
   // Zero fission data if not fissionable
   //============================================================
 
+  // Use a little bit of overkill and clear all fission-related
+  // properties if the fission cross-section was not specified.
+
   if (!is_fissionable)
   {
+    chi::log.Log0Verbose1()
+        << "No fission cross-sections specified... "
+        << "Clearing all fission properties.";
+
+
     num_precursors = 0;
+    sigma_f.clear();
+    nu_sigma_f.clear();
+    nu_prompt_sigma_f.clear();
+    nu_delayed_sigma_f.clear();
 
-    sigma_f.assign(num_groups, 0.0);
-    nu_sigma_f.assign(num_groups, 0.0);
-    nu_prompt_sigma_f.assign(num_groups, 0.0);
-    nu_delayed_sigma_f.assign(num_groups, 0.0);
+    nu.clear();
+    nu_prompt.clear();
+    nu_delayed.clear();
+    beta.clear();
 
-    nu.assign(num_groups, 0.0);
-    nu_prompt.assign(num_groups, 0.0);
-    nu_delayed.assign(num_groups, 0.0);
-
-    chi.assign(num_groups, 0.0);
-    chi_prompt.assign(num_groups, 0.0);
+    chi.clear();
+    chi_prompt.clear();
     chi_delayed.clear();
 
     precursor_lambda.clear();
@@ -68,63 +80,88 @@ void chi_physics::TransportCrossSections::Finalize()
 
   else
   {
+
+    chi::log.Log0Verbose1()
+        << "Fission cross-sections found.\n"
+        << "Checking fission data specification...";
+
     //==================================================
     // Check prompt/delayed specification
     //==================================================
 
     if (num_precursors > 0)
     {
+      chi::log.Log0Verbose1()
+          << "Prompt/delayed specification used.\n"
+          << "Checking for prompt/delayed fission data...";
+
       // check nu specification
       {
-        if (was_specified(nu_prompt) &&
-            was_specified(nu_delayed))
+        if (is_valid(nu_prompt) && is_valid(nu_delayed))
         {
           if (!std::all_of(nu_prompt.begin(), nu_prompt.end(),
                            [](double x) { return x == 0.0 || x > 1.0; }) &&
               !std::all_of(nu_delayed.begin(), nu_delayed.end(),
                            [](double x) { return x >= 0.0; }))
             throw std::logic_error(
-                "Prompt and delayed fission neutron yields must be zero "
-                "or positive. Zero values must be accounted allowed "
-                "for photo-fission, which is a threshold reaction. Prompt "
-                "fission neutron yields must be greater than 1 or 0.");
+                "Invalid prompt and delayed fission neutron yields "
+                "encountered.\nPrompt fission neutron yields must be either "
+                "zero or greater than one.\nDelayed fission neutron yields "
+                "must be zero or greater.");
 
           //compute other quantities
+          nu.assign(num_groups, 0.0);
+          beta.assign(num_groups, 0.0);
           for (unsigned int g = 0; g < num_groups; ++g)
           {
             nu[g] = nu_prompt[g] + nu_delayed[g];
             beta[g] = nu_delayed[g] / nu[g];
           }
-        }//if nu_prompt and nu_delayed specified
-        else if (was_specified(nu) &&
-                 was_specified(beta))
+        }//if prompt/delayed specified
+
+        else if (is_valid(nu) && is_valid(beta))
         {
           if (!std::all_of(nu.begin(), nu.end(),
                            [](double x) { return x == 0.0 || x > 1.0; }))
             throw std::logic_error(
-                "Fission neutron yield must be greater than 1 or 0.");
+                "Invalid fission neutron yield data encountered.\n"
+                "All values must be either zero or greater than one.");
           if (!std::all_of(beta.begin(), beta.end(),
                            [](double x) { return x >= 0.0 && x <= 1.0; }))
             throw std::logic_error(
-                "Delayed neutron fractions must be in the range [0.0, 1.0].");
+                "Invalid delayed neutron fraction data encountered.\n"
+                "All values must be in the range [0.0, 1.0].");
 
           //compute other quantities
+          nu_prompt.assign(num_groups, 0.0);
+          nu_delayed.assign(num_groups, 0.0);
           for (unsigned int g = 0; g < num_groups; ++g)
           {
             nu_prompt[g] = (1.0 - beta[g]) * nu[g];
             nu_delayed[g] = beta[g] * nu[g];
           }
+        } //if delayed fraction specified
 
-          if (was_specified(nu_sigma_f))
-            for (unsigned int g = 0; g < num_groups; ++g)
-              if (nu[g] != 0.0)
-                sigma_f[g] = nu_sigma_f[g] / nu[g];
-        } //if nu and beta specified
         else
           throw std::logic_error(
-              "Invalid specification of fission neutron yield data.");
+              "Invalid specification of prompt/delayed fission "
+              "neutron yield data encountered.\nEither the prompt and "
+              "delayed fission neutron yields or the total fission neutron"
+              "yield and delayed neutron fraction must be provided.");
+
+        // ensure the fission cross-section is available
+        if (!is_valid(sigma_f))
+        {
+          sigma_f.assign(num_groups, 0.0);
+          for (unsigned int g = 0; g < num_groups; ++g)
+            if (nu[g] != 0.0)
+              sigma_f[g] = nu_sigma_f[g] / nu[g];
+        }
 
         //compute other quantities
+        nu_sigma_f.assign(num_groups, 0.0);
+        nu_prompt_sigma_f.assign(num_groups, 0.0);
+        nu_delayed_sigma_f.assign(num_groups, 0.0);
         for (unsigned int g = 0; g < num_groups; ++g)
         {
           nu_sigma_f[g] = nu[g] * sigma_f[g];
@@ -135,20 +172,26 @@ void chi_physics::TransportCrossSections::Finalize()
 
       //check and normalize prompt fission spectrum
       {
-        //throw error if not specified
-        if (!was_specified(chi_prompt))
+        if (chi_prompt.empty())
+          throw std::logic_error("Prompt fission spectrum not found.");
+        if (std::all_of(chi_prompt.begin(), chi_prompt.end(),
+                        [](double x) { return x == 0.0; }))
           throw std::logic_error(
-              "The prompt fission spectrum was not provided.");
+              "Invalid prompt fission spectrum encountered.\n"
+              "Spectra must have at least one nonzero value.");
 
-        //normalize the prompt fission spectrum
-        double chip_sum = std::accumulate(chi_prompt.begin(),
-                                          chi_prompt.end(), 0.0);
+        //normalize the spectrum to a unit sum
+        double chi_prompt_sum = std::accumulate(
+            chi_prompt.begin(), chi_prompt.end(), 0.0);
         for (unsigned int g = 0; g < num_groups; ++g)
-          chi_prompt[g] /= chip_sum;
+          chi_prompt[g] /= chi_prompt_sum;
       }
 
       //check and normalize delayed emission spectra
       {
+        if (chi_delayed.empty())
+          throw std::logic_error("Delayed emission spectra not found.");
+
         //create chi_delayed transpose for easier checks
         EmissionSpectra tmp;
         tmp.resize(num_precursors, std::vector<double>(num_groups, 0.0));
@@ -159,52 +202,69 @@ void chi_physics::TransportCrossSections::Finalize()
         for (unsigned int j = 0; j < num_precursors; ++j)
         {
           //throw error if emission spectrum j was not specified
-          if (!was_specified(tmp[j]))
+          if (std::all_of(tmp[j].begin(), tmp[j].end(),
+                          [](double x) { return x == 0.0; }))
             throw std::logic_error(
-                "The delayed emission spectrum for precursor "
-                "species " + std::to_string(j) + " was not provided.");
+                "Invalid delayed emission spectra encountered for "
+                "precursor species " + std::to_string(j) + ".\n" +
+                "Spectra must have at least one nonzero value.");
 
           //normalize each emission spectrum
-          double chidj_sum = std::accumulate(tmp[j].begin(),
-                                             tmp[j].end(), 0.0);
+          double chi_delayed_j_sum =
+              std::accumulate(tmp[j].begin(), tmp[j].end(), 0.0);
+
           for (unsigned int g = 0; g < num_groups; ++g)
-            chi_delayed[g][j] /= chidj_sum;
+            chi_delayed[g][j] /= chi_delayed_j_sum;
         }//for j
       }
 
       //check the precursor data
       {
-        //throw error if decay constants were not specified
-        if (!was_specified(precursor_lambda))
+        if (precursor_lambda.empty())
+          throw std::logic_error("Precursor decay constants not found.");
+        if (!std::all_of(precursor_lambda.begin(),
+                         precursor_lambda.end(),
+                        [](double x) { return x > 0.0;}))
           throw std::logic_error(
-              "The delayed neutron precursor decay constants "
-              "was not provided.");
+              "Invalid precursor decay constant encountered.\n"
+              "Decay constants must be greater than zero.");
 
-        //throw error if not specified
-        if (!was_specified(precursor_yield))
+        if (precursor_yield.empty())
+          throw std::logic_error("Precursor yield fractions no found.");
+        if (!std::all_of(precursor_yield.begin(),
+                         precursor_yield.end(),
+                         [](double x) { return x >= 0.0 && x <= 1.0; }))
           throw std::logic_error(
-              "The delayed neutron precursor yields was not provided.");
+              "Invalid delayed neutron precursor yield fraction "
+              "encountered.\n"
+              "Yield fractions must be in the range [0.0, 1.0]");
 
         //normalize the precursor yields
         double yield_sum = std::accumulate(precursor_yield.begin(),
                                            precursor_yield.end(), 0.0);
+
         for (unsigned int j = 0; j < num_precursors; ++j)
           precursor_yield[j] /= yield_sum;
       }
 
-      //compute beta-weighted total fission spectrum
-      for (unsigned int g = 0; g < num_groups; ++g)
+      // Compute the beta-weighted steady-state fission spectrum.
+      // NOTE: Generally, the computation of this quantity requires
+      //       a weight function. This estimate uses a unit weight
+      //       function and may not be completely accurate.
       {
-        //compute beta-averaged total fission spectrum
-        chi[g] = (1.0 - beta[g]) * chi_prompt[g];
-        for (unsigned int j = 0; j < num_precursors; ++j)
-          chi[g] += beta[g] * precursor_yield[j] * chi_delayed[g][j];
-      }
+        for (unsigned int g = 0; g < num_groups; ++g)
+        {
+          //compute beta-averaged total fission spectrum
+          chi[g] = (1.0 - beta[g]) * chi_prompt[g];
+          for (unsigned int j = 0; j < num_precursors; ++j)
+            chi[g] += beta[g] * precursor_yield[j] * chi_delayed[g][j];
+        }
 
-      //normalize total chi just in case
-      double chi_sum = std::accumulate(chi.begin(), chi.end(), 0.0);
-      for (unsigned int g = 0; g < num_groups; ++g)
-        chi[g] /= chi_sum;
+        //normalize total chi just in case
+        double chi_sum = std::accumulate(chi.begin(), chi.end(), 0.0);
+        for (unsigned int g = 0; g < num_groups; ++g)
+          chi[g] /= chi_sum;
+      }
     }//if prompt/delayed
 
     //==================================================
@@ -213,43 +273,55 @@ void chi_physics::TransportCrossSections::Finalize()
 
     else
     {
-      //check that nu was specified correctly
-      if (!was_specified(nu))
-        throw std::logic_error(
-            "Total neutrons per fission was not provided.");
-      if (!std::all_of(nu.begin(), nu.end(),
-                       [](double x) { return x == 0.0 || x > 1.0; }))
-        throw std::logic_error(
-            "Total fission yield must be greater than unity.");
+      chi::log.Log0Verbose1()
+          << "Total/steady-state specification used.\n"
+          << "Checking total/steady-state fission data...";
 
-      //compute other quantities
-      if (was_specified(nu_sigma_f))
+      //check total nu
       {
+        if (nu.empty())
+          throw std::logic_error("Total neutrons per fission not found.");
+        if (!std::all_of(nu.begin(), nu.end(),
+                         [](double x) { return x == 0.0 || x > 1.0; }))
+          throw std::logic_error(
+              "Invalid total fission neutron yield encountered.\n"
+              "All values must be either zero or greater than one.");
+
+        //compute other quantities
+        if (sigma_f.empty())
+        {
+          sigma_f.assign(num_groups, 0.0);
+          for (unsigned int g = 0; g < num_groups; ++g)
+            if (nu[g] != 0.0)
+              sigma_f[g] = nu_sigma_f[g] / nu[g];
+        }
+
+        //compute the production cross-section
+        nu_sigma_f.assign(num_groups, 0.0);
         for (unsigned int g = 0; g < num_groups; ++g)
-          sigma_f[g] = nu[g] * sigma_f[g];
+          nu_sigma_f[g] = nu[g] * sigma_f[g];
       }
-      else if (was_specified(nu_sigma_f))
+
+      //check and normalize total fission spectrum
       {
+        if (chi.empty())
+          throw std::logic_error("Total fission spectrum not found.");
+        if (!std::all_of(chi.begin(), chi.end(),
+                         [](double x) { return x == 0.0; }))
+          throw std::logic_error(
+              "Invalid total fission spectrum encountered.\n"
+              "Spectra must have at least one non-zero value.");
+
+        //normalize the total fission spectrum
+        double chi_sum = std::accumulate(chi.begin(), chi.end(), 0.0);
         for (unsigned int g = 0; g < num_groups; ++g)
-          if (nu[g] != 0.0)
-            sigma_f[g] = nu_sigma_f[g] / nu[g];
+          chi[g] /= chi_sum;
       }
-      else
-        throw std::logic_error(
-            "Neither the fission cross-section nor the "
-            "fission multiplicity cross-section was specified.");
+    }//if total
 
-      //check that chi was specified
-      if (!was_specified(chi))
-        throw std::logic_error(
-            "Total fission spectrum was not provided.");
+    chi::log.Log0Verbose1() << "Fission data checks completed.";
 
-      //normalize the total fission spectrum
-      double chi_sum = std::accumulate(chi.begin(), chi.end(), 0.0);
-      for (unsigned int g = 0; g < num_groups; ++g)
-        chi[g] /= chi_sum;
-    }
-    }
+  }//if fissionable
 
   //============================================================
   // Compute diffusion parameters

--- a/framework/ChiPhysics/PhysicsMaterial/transportxsections/prop_transportxs_01b_finalize.cc
+++ b/framework/ChiPhysics/PhysicsMaterial/transportxsections/prop_transportxs_01b_finalize.cc
@@ -12,12 +12,12 @@ void chi_physics::TransportCrossSections::Finalize()
 {
 
   //============================================================
-  // Set the absorption cross-section, if unset
+  // Set the absorption cross section, if unset
   //============================================================
 
   // The logic here is that if absorption is empty, it was not
   // specified, therefore, it should be computed. If a uniformly
-  // zero absorption cross-section was provided, assume that
+  // zero absorption cross section was provided, assume that
   // was intentional.
 
   if (sigma_a.empty())
@@ -46,12 +46,12 @@ void chi_physics::TransportCrossSections::Finalize()
   //============================================================
 
   // Use a little bit of overkill and clear all fission-related
-  // properties if the fission cross-section was not specified.
+  // properties if the fission cross section was not specified.
 
   if (!is_fissionable)
   {
     chi::log.Log0Verbose1()
-        << "No fission cross-sections specified... "
+        << "No fission cross sections specified... "
         << "Clearing all fission properties.";
 
 
@@ -82,7 +82,7 @@ void chi_physics::TransportCrossSections::Finalize()
   {
 
     chi::log.Log0Verbose1()
-        << "Fission cross-sections found.\n"
+        << "Fission cross sections found.\n"
         << "Checking fission data specification...";
 
     //==================================================
@@ -152,10 +152,10 @@ void chi_physics::TransportCrossSections::Finalize()
             "yield and delayed neutron fraction must be provided.");
 
       //==================================================
-      // Compute all production cross-sections
+      // Compute all production cross sections
       //==================================================
 
-      //ensure the fission cross-section is available
+      //ensure the fission cross section is available
       if (!is_valid(sigma_f))
       {
         sigma_f.assign(num_groups, 0.0);
@@ -309,7 +309,7 @@ void chi_physics::TransportCrossSections::Finalize()
               sigma_f[g] = nu_sigma_f[g] / nu[g];
         }
 
-        //compute the production cross-section
+        //compute the production cross section
         nu_sigma_f.assign(num_groups, 0.0);
         for (unsigned int g = 0; g < num_groups; ++g)
           nu_sigma_f[g] = nu[g] * sigma_f[g];

--- a/framework/ChiPhysics/PhysicsMaterial/transportxsections/prop_transportxs_01b_finalize.cc
+++ b/framework/ChiPhysics/PhysicsMaterial/transportxsections/prop_transportxs_01b_finalize.cc
@@ -260,10 +260,15 @@ void chi_physics::TransportCrossSections::Finalize()
       // Compute the steady-state fission spectrum
       //==================================================
 
-      // This is computed via a beta-weighting
-      // NOTE: Generally, the computation of this quantity requires
-      //       a weight function. This estimate uses a unit weight
-      //       function and may not be completely accurate.
+      // NOTE: This is only exact when beta is energy-independent.
+      //       When it is not, this estimation may be incorrect.
+      //       The true definition of steady-state fission spectrum
+      //       is the rate at which prompt and delayed fission
+      //       yield neutrons within group `g` divided by the
+      //       total fission rate. When beta is energy-independent,
+      //       the fission rate can be eliminated . When it is not,
+      //       it requires the computation of the fission rate, which
+      //       requires a weight spectrum.
 
       chi.assign(num_groups, 0.0);
       for (unsigned int g = 0; g < num_groups; ++g)

--- a/framework/ChiPhysics/PhysicsMaterial/transportxsections/prop_transportxs_02_diffparams.cc
+++ b/framework/ChiPhysics/PhysicsMaterial/transportxsections/prop_transportxs_02_diffparams.cc
@@ -46,7 +46,7 @@ ComputeDiffusionParameters()
     if (sig_1 >= sigma_t[g])
     {
       sig_1 = 0.0;
-      chi::log.LogAllWarning()
+      chi::log.Log0Warning()
           << "Transport corrected diffusion coefficient failed for group "
           << g << " in call to " << __FUNCTION__ << ". "
           << "sigma_t=" << sigma_t[g] << " sigs_g_(m=1)=" << sig_1

--- a/framework/ChiPhysics/PhysicsMaterial/transportxsections/prop_transportxs_02_diffparams.cc
+++ b/framework/ChiPhysics/PhysicsMaterial/transportxsections/prop_transportxs_02_diffparams.cc
@@ -75,7 +75,7 @@ ComputeDiffusionParameters()
     }
 
     //============================================================
-    // Compute removal cross-section
+    // Compute removal cross section
     //============================================================
 
     sigma_removal[g] = std::max(0.0, sigma_t[g] - sigma_s_gtog[g]);

--- a/framework/ChiPhysics/PhysicsMaterial/transportxsections/prop_transportxs_06_export.cc
+++ b/framework/ChiPhysics/PhysicsMaterial/transportxsections/prop_transportxs_06_export.cc
@@ -130,6 +130,6 @@ void chi_physics::TransportCrossSections::
 
   ofile.close();
 
-  chi::log.LogAllVerbose1() << "Done exporting transport "
-                                 "cross section to file: " << file_name;
+  chi::log.Log0Verbose1() << "Done exporting transport "
+                             "cross section to file: " << file_name;
 }

--- a/framework/ChiPhysics/PhysicsMaterial/transportxsections/prop_transportxs_06_export.cc
+++ b/framework/ChiPhysics/PhysicsMaterial/transportxsections/prop_transportxs_06_export.cc
@@ -7,7 +7,7 @@
 #include <iostream>
 
 //###################################################################
-/**Exports the cross-section information to ChiTech format.*/
+/**Exports the cross section information to ChiTech format.*/
 void chi_physics::TransportCrossSections::
   ExportToChiXSFile(const std::string &file_name)
 {

--- a/modules/LBSAdjointSolver/IterativeOperations/lbsadj_setsource.cc
+++ b/modules/LBSAdjointSolver/IterativeOperations/lbsadj_setsource.cc
@@ -14,7 +14,7 @@ void lbs_adjoint::AdjointSolver::
   chi::log.LogEvent(source_event_tag, chi_objects::ChiLog::EventType::EVENT_BEGIN);
 
   using Flag = lbs::SourceFlags;
-  const bool apply_mat_src         = (source_flags & Flag::APPLY_FIXED_SOURCES);
+  const bool apply_fixed_src       = (source_flags & Flag::APPLY_FIXED_SOURCES);
   const bool apply_wgs_scatter_src = (source_flags & Flag::APPLY_WGS_SCATTER_SOURCES);
   const bool apply_ags_scatter_src = (source_flags & Flag::APPLY_AGS_SCATTER_SOURCES);
   const bool apply_wgs_fission_src = (source_flags & Flag::APPLY_WGS_FISSION_SOURCES);
@@ -152,7 +152,7 @@ void lbs_adjoint::AdjointSolver::
   }//for cell
 
   //================================================== Apply reference QOI
-  if (apply_mat_src)
+  if (apply_fixed_src)
   {
     for (const auto& qoi_data : response_functions)
     {

--- a/modules/LBSTransientSolver/IterativeOperations/lbts_settransientsource.cc
+++ b/modules/LBSTransientSolver/IterativeOperations/lbts_settransientsource.cc
@@ -33,7 +33,7 @@ void lbs::TransientSolver::
 
   const double eff_dt = theta*dt;
 
-  const bool apply_mat_src         = (source_flags & APPLY_FIXED_SOURCES);
+  const bool apply_fixed_src       = (source_flags & APPLY_FIXED_SOURCES);
   const bool apply_wgs_scatter_src = (source_flags & APPLY_WGS_SCATTER_SOURCES);
   const bool apply_ags_scatter_src = (source_flags & APPLY_AGS_SCATTER_SOURCES);
   const bool apply_wgs_fission_src = (source_flags & APPLY_WGS_FISSION_SOURCES);
@@ -67,7 +67,7 @@ void lbs::TransientSolver::
 
     //==================== Obtain src
     double* src = default_zero_src.data();
-    if (P0_src and apply_mat_src)
+    if (P0_src and apply_fixed_src)
       src = P0_src->source_value_g.data();
 
     //=========================================== Loop over nodes
@@ -86,10 +86,10 @@ void lbs::TransientSolver::
         {
           if (not options.use_src_moments) //using regular material src
           {
-            if (apply_mat_src and ell == 0)
+            if (apply_fixed_src and ell == 0)
               destination_q[uk_map + g] += src[g];
           }
-          else if (apply_mat_src)  //using ext_src_moments
+          else if (apply_fixed_src)  //using ext_src_moments
             destination_q[uk_map + g] += ext_src_moments_local[uk_map + g];
 
           double inscatter_g = 0.0;
@@ -183,7 +183,7 @@ void lbs::TransientSolver::
           }//if fission_avail and apply_wgs_fission_src
 
           //====================== Apply precursors
-          if (fission_avail and apply_mat_src and options.use_precursors)
+          if (fission_avail and apply_fixed_src and options.use_precursors)
           {
             const auto& J = max_precursors_per_material;
             for (size_t j = 0; j < xs.num_precursors; ++j)
@@ -204,7 +204,7 @@ void lbs::TransientSolver::
   }//for cell
 
   //================================================== Apply point sources
-  if ((not options.use_src_moments) and apply_mat_src)
+  if ((not options.use_src_moments) and apply_fixed_src)
   {
     for (const auto& point_source : point_sources)
     {

--- a/modules/LinearBoltzmannSolver/IterativeOperations/lbs_setsource.cc
+++ b/modules/LinearBoltzmannSolver/IterativeOperations/lbs_setsource.cc
@@ -23,7 +23,7 @@ void lbs::SteadySolver::
 {
   chi::log.LogEvent(source_event_tag, chi_objects::ChiLog::EventType::EVENT_BEGIN);
 
-  const bool apply_mat_src         = (source_flags & APPLY_FIXED_SOURCES);
+  const bool apply_fixed_src       = (source_flags & APPLY_FIXED_SOURCES);
   const bool apply_wgs_scatter_src = (source_flags & APPLY_WGS_SCATTER_SOURCES);
   const bool apply_ags_scatter_src = (source_flags & APPLY_AGS_SCATTER_SOURCES);
   const bool apply_wgs_fission_src = (source_flags & APPLY_WGS_FISSION_SOURCES);
@@ -55,7 +55,7 @@ void lbs::SteadySolver::
 
     //==================== Obtain src
     double* src = default_zero_src.data();
-    if (P0_src and apply_mat_src)
+    if (P0_src and apply_fixed_src)
       src = P0_src->source_value_g.data();
 
     //=========================================== Loop over nodes
@@ -74,10 +74,10 @@ void lbs::SteadySolver::
         {
           if (not options.use_src_moments) //using regular material src
           {
-            if (apply_mat_src and ell == 0)
+            if (apply_fixed_src and ell == 0)
               destination_q[uk_map + g] += src[g];
           }
-          else if (apply_mat_src)  //using ext_src_moments
+          else if (apply_fixed_src)  //using ext_src_moments
             destination_q[uk_map + g] += ext_src_moments_local[uk_map + g];
 
           double inscatter_g = 0.0;
@@ -167,7 +167,7 @@ void lbs::SteadySolver::
   }//for cell
 
   //================================================== Apply point sources
-  if ((not options.use_src_moments) and apply_mat_src)
+  if ((not options.use_src_moments) and apply_fixed_src)
   {
     for (const auto& point_source : point_sources)
     {

--- a/tests/KEigenvalueTransport1D_1G.lua
+++ b/tests/KEigenvalueTransport1D_1G.lua
@@ -1,6 +1,6 @@
 -- 1D 1G KEigenvalue::Solver test with Vacuum BC.
 -- SDM: PWLD
--- Test: Final k-eigenvalue: 0.997501
+-- Test: Final k-eigenvalue: 0.999541
 num_procs = 4
 
 -- NOTE: For command line inputs, specify as:


### PR DESCRIPTION
This PR addresses #271 , tackles an issue @Naktakala and I discussed a few days ago (initializing data that may never be used), and makes a small change to a variable name to reflect a previous change.

## Summary

- Initialize data within the read routine according to the specified sizes. 
- When combining cross-sections, we know the rules about when something is initialized. Using said rules, use checks to see if something *needs* to be combined. 
- Changed `apply_mat_src` to `apply_fixed_src` to reflect the previous name change from `APPLY_MATERIAL_SOURCES` to `APPLY_FIXED_SOURCES`.

## Notes

This should be my last PR on cross-sections before moving to the fission matrix formulation.