### PR TITLE
Extrusion upgrades

### DIFF
--- a/framework/ChiMesh/LogicalVolume/lua/logicvolume_lua.cc
+++ b/framework/ChiMesh/LogicalVolume/lua/logicvolume_lua.cc
@@ -1,5 +1,4 @@
 #include"chi_lua.h"
-#include <iostream>
 
 #include "../chi_mesh_logicalvolume.h"
 
@@ -26,7 +25,38 @@ SURFACE= Logical volume determined from a surface mesh. [Requires: a handle
 BOOLEAN= Boolean combination of other volumes.
  [Requires pairs of values: bool,volumeHandle]\n
 
+### Examples
+Example usage:
+\code
+-- Sphere at origin radius 1.0
+lv1 = chiLogicalVolumeCreate(SPHERE_ORIGIN, 1.0)
 
+-- Sphere centered at (0.1,0.2,0.3) with radius 1.0
+lv2 = chiLogicalVolumeCreate(SPHERE, 0.1, 0.2, 0.3, 1.0)
+
+-- Rectangular parallelepiped
+xmin = -1.0; xmax = 1.0
+ymin = -2.0; ymax = 1.0
+zmin = -1000.0, zmax = 1000.0
+lv3 = chiLogicalVolumeCreate(RPP, xmin, xmax, ymin, ymax, zmin, zmax)
+
+-- Right Circular Cylinder
+basex = 1.0; basey = 0.0; basez = 0.5
+upvecx = 0.0; upvecy = 0.0; upvecz = 1.0
+R = 1.0
+lv4 = chiLogicalVolumeCreate(RPP, basex, basey, basez, upvecx, upvecy, upvecz, R)
+
+-- Surface mesh
+lv_surfmesh = chiSurfaceMeshCreate()
+chiSurfaceMeshImportFromOBJFile(lv_surfmesh, "MeshFile3D.obj", false)
+
+lv5 = chiLogicalVolumeCreate(SURFACE, lv_surfmesh)
+
+-- Boolean combination
+lv6 = chiLogicalVolumeCreate(BOOLEAN, {{true , lv5},  -- inside logical volume 5
+                                       {false, lv1},  -- outside logical volume 1
+                                       {false, lv2}}) -- outside logical volume 2
+\endcode
 
 \return Handle int Handle to the created logical volume.
 \ingroup LuaLogicVolumes
@@ -209,6 +239,40 @@ int chiLogicalVolumeCreate(lua_State *L)
    chi::Exit(EXIT_FAILURE);
   }
 
+
+  return 1;
+}
+
+
+//###################################################################
+/**Evaluates whether a point is within the logical volume.
+\param LVHandle int Handle to the logical volume.
+\param Point_x double X-coordinate of the point.
+\param Point_y double Y-coordinate of the point.
+\param Point_z double Z-coordinate of the point.
+
+\return Sense true if inside the logical volume and false if outside.
+*/
+int chiLogicalVolumePointSense(lua_State* L)
+{
+  const std::string fname = "chiLogicalVolumePointSense";
+  const int num_args = lua_gettop(L);
+  if (num_args != 4)
+    LuaPostArgAmountError(fname, 4, num_args);
+
+  LuaCheckNilValue(fname, L, 1);
+
+  const int lv_handle = lua_tointeger(L, 1);
+
+  const auto& lv = chi::GetStackItem<chi_mesh::LogicalVolume>(
+    chi::logicvolume_stack, lv_handle, fname);
+
+  const chi_mesh::Vector3 point(lua_tonumber(L,2),
+                                lua_tonumber(L,3),
+                                lua_tonumber(L,4));
+
+  if (lv.Inside(point)) lua_pushboolean(L, true);
+  else                  lua_pushboolean(L, false);
 
   return 1;
 }

--- a/framework/ChiMesh/LogicalVolume/lua/logicvolume_lua.h
+++ b/framework/ChiMesh/LogicalVolume/lua/logicvolume_lua.h
@@ -2,5 +2,6 @@
 #define CHITECH_LOGICVOLUME_LUA_H
 
 int chiLogicalVolumeCreate(lua_State *L);
+int chiLogicalVolumePointSense(lua_State* L);
 
 #endif //CHITECH_LOGICVOLUME_LUA_H

--- a/framework/ChiMesh/MeshContinuum/chi_meshcontinuum.h
+++ b/framework/ChiMesh/MeshContinuum/chi_meshcontinuum.h
@@ -87,7 +87,7 @@ public:
   void ExportCellsToObj(const char* fileName,
                            bool per_material=false,
                            int options = 0) const;
-  void ExportCellsToVTK(const char* baseName) const;
+  void ExportCellsToVTK(const std::string& baseName) const;
 
   void BuildFaceHistogramInfo(double master_tolerance=100.0, double slave_tolerance=1.1);
   size_t NumberOfFaceHistogramBins();

--- a/framework/ChiMesh/MeshContinuum/chi_meshcontinuum_exportvtk.cc
+++ b/framework/ChiMesh/MeshContinuum/chi_meshcontinuum_exportvtk.cc
@@ -7,10 +7,6 @@
 
 #include "chi_runtime.h"
 #include "chi_log.h"
-;
-
-#include "chi_mpi.h"
-
 
 #include <vtkCellType.h>
 #include <vtkUnstructuredGrid.h>
@@ -26,9 +22,9 @@
 
 //###################################################################
 /**Exports just the mesh to VTK format.*/
-void chi_mesh::MeshContinuum::ExportCellsToVTK(const char* baseName) const
+void chi_mesh::MeshContinuum::ExportCellsToVTK(const std::string& baseName) const
 {
-  chi::log.Log() << "Exporting mesh to VTK. " << local_cells.size();
+  chi::log.Log() << "Exporting mesh to VTK files with base " << baseName;
   std::vector<std::vector<double>> d_nodes;
 
   auto points = vtkSmartPointer<vtkPoints>::New();

--- a/framework/ChiMesh/MeshHandler/lua/meshhandler_exportmesh.cc
+++ b/framework/ChiMesh/MeshHandler/lua/meshhandler_exportmesh.cc
@@ -37,7 +37,7 @@ int chiMeshHandlerExportMeshToObj(lua_State* L)
 
 
 //###################################################################
-/**Exports the mesh to a wavefront.obj format.
+/**Exports the mesh to vtu format.
 \param FileName char Name of the file to be used.
 \ingroup LuaMeshHandler
 */

--- a/framework/ChiMesh/SurfaceMesh/lua/surfacemesh_create.cc
+++ b/framework/ChiMesh/SurfaceMesh/lua/surfacemesh_create.cc
@@ -1,13 +1,11 @@
-#include"../../../ChiLua/chi_lua.h"
-#include<iostream>
+#include "ChiLua/chi_lua.h"
+
 #include "../chi_surfacemesh.h"
-#include "../../MeshHandler/chi_meshhandler.h"
+#include "ChiMesh/MeshHandler/chi_meshhandler.h"
 
 #include "chi_runtime.h"
 
-#include <chi_log.h>
-
-;
+#include "chi_log.h"
 
 /** \defgroup LuaSurfaceMesh Surface Meshes
  * \ingroup LuaMesh
@@ -15,6 +13,12 @@
 
 //#############################################################################
 /** Creates a new empty surface mesh.
+
+### Example
+Example usage:
+\code
+surfmesh = chiSurfaceMeshCreate()
+\endcode
 
 \return Handle int Handle to the created surface mesh.
 \ingroup LuaSurfaceMesh
@@ -31,89 +35,6 @@ int chiSurfaceMeshCreate(lua_State *L)
   chi::log.LogAllVerbose2() << "chiSurfaceMeshCreate: "
                                          "Empty SurfaceMesh object, "
                                       << index << ", created" << std::endl;
-
-  return 1;
-}
-
-//#############################################################################
-/** Creates a new surface mesh from a set of vertex arrays.
-
-\param vertices_x array Array of vertices along x.
-\param vertices_y array Array of vertices along y.
-
-
-##_
-Example:
-\code
-xmesh = {0.0,0.1,0.2,0.3,0.5}
-ymesh = {0.0,0.1,0.2,0.3,0.5}
-surf_mesh = chiSurfaceMeshCreateFromArrays(xmesh,ymesh)
-\endcode
-
-\return Handle int Handle to the created surface mesh.
-\ingroup LuaSurfaceMesh
-\author Jan*/
-int chiSurfaceMeshCreateFromArrays(lua_State *L)
-{
-  int num_args = lua_gettop(L);
-  if (num_args != 2)
-    LuaPostArgAmountError("chiSurfaceMeshCreateFromArrays",2,num_args);
-
-  if (not lua_istable(L,1))
-  {
-    chi::log.LogAllError()
-      << "In call to chiSurfaceMeshCreateFromArrays: "
-      << "The first argument was detected not to be a lua table.";
-   chi::Exit(EXIT_FAILURE);
-  }
-  if (not lua_istable(L,2))
-  {
-    chi::log.LogAllError()
-      << "In call to chiSurfaceMeshCreateFromArrays: "
-      << "The second argument was detected not to be a lua table.";
-   chi::Exit(EXIT_FAILURE);
-  }
-
-  //============================================= Extract x-array
-  size_t xtable_len = lua_rawlen(L,1);
-  std::vector<double> values_x(xtable_len,0.0);
-
-  for (int g=0; g<xtable_len; g++)
-  {
-    lua_pushnumber(L,g+1);
-    lua_gettable(L,1);
-
-    values_x[g] = lua_tonumber(L,-1);
-    lua_pop(L,1);
-  }
-
-  //============================================= Extract y-array
-  size_t ytable_len = lua_rawlen(L,2);
-  std::vector<double> values_y(ytable_len,0.0);
-
-  for (int g=0; g<ytable_len; g++)
-  {
-    lua_pushnumber(L,g+1);
-    lua_gettable(L,1);
-
-    values_y[g] = lua_tonumber(L,-1);
-    lua_pop(L,1);
-  }
-
-  //============================================= Create surface mesh
-  auto surface_mesh =
-    chi_mesh::SurfaceMesh::CreateFromDivisions(values_x,values_y);
-
-  //============================================= Push to stack
-  chi::surface_mesh_stack.emplace_back(surface_mesh);
-
-  size_t index = chi::surface_mesh_stack.size()-1;
-  lua_pushnumber(L,static_cast<lua_Number>(index));
-
-  chi::log.LogAllVerbose2()
-    << "chiSurfaceMeshCreateFromArrays: Created surface mesh "
-    << index << std::endl;
-
 
   return 1;
 }

--- a/framework/ChiMesh/SurfaceMesh/lua/surfacemesh_load.cc
+++ b/framework/ChiMesh/SurfaceMesh/lua/surfacemesh_load.cc
@@ -1,24 +1,47 @@
 #include "ChiLua/chi_lua.h"
 
-#include <iostream>
 #include "ChiMesh/SurfaceMesh/chi_surfacemesh.h"
-#include "../../MeshHandler/chi_meshhandler.h"
+#include "ChiMesh/MeshHandler/chi_meshhandler.h"
 
 #include "chi_runtime.h"
-
 #include "chi_log.h"
-;
-
 
 //############################################################################# Create Window
 /** Loads mesh data from a wavefront object.
  *
 \param SurfaceHandle int Handle to the surface on which the operation is to be performed.
-\param FileName char* Path to the file to be imported.
+\param FileName string Path to the file to be imported.
 \param polyflag bool (Optional)Flag indicating whether triangles
-                               are to be read as polygons. [Default: true].
+                               are to be read as polygons. [Default: true (read
+                               as polygons)].
 \param transform table3 (Optional) Translation vector to move all the vertices.
                                    [Default: none].
+
+### Note:
+If the intent of a surface mesh is to serve as a 3D logical volume then
+the `polyFlag` parameter should be set to false.
+
+### Example
+Example usage:
+\code
+-- Basic example
+surfmesh1 = chiSurfaceMeshCreate()
+chiSurfaceMeshImportFromOBJFile(surfmesh1, "MeshFile1.obj")
+
+-- Surface mesh used as Logical volume
+lv_surfmesh1 = chiSurfaceMeshCreate()
+chiSurfaceMeshImportFromOBJFile(lv_surfmesh1, "MeshFile3D.obj", false)
+
+lv1 = chiLogicalVolumeCreate(SURFACE, lv_surfmesh1)
+
+-- Surface mesh with transform
+dx = 1.5
+dy = -2.5
+lv_surfmesh2 = chiSurfaceMeshCreate()
+chiSurfaceMeshImportFromOBJFile(lv_surfmesh2, "MeshFile3D.obj", false, {dx,dy,0.0})
+
+lv2 = chiLogicalVolumeCreate(SURFACE, lv_surfmesh2)
+\endcode
 
 \return success bool Return true if file was successfully loaded and false
  otherwise.

--- a/framework/ChiMesh/VolumeMesher/Extruder/volmesher_extruder.h
+++ b/framework/ChiMesh/VolumeMesher/Extruder/volmesher_extruder.h
@@ -36,11 +36,13 @@ public:
 public:
   explicit
   VolumeMesherExtruder(std::shared_ptr<chi_mesh::SurfaceMesh> in_surface_mesh) :
+    VolumeMesher(VolumeMesherType::EXTRUDER),
     template_type(TemplateType::SURFACE_MESH),
     template_surface_mesh(std::move(in_surface_mesh))
   {}
   explicit
   VolumeMesherExtruder(std::shared_ptr<chi_mesh::UnpartitionedMesh> in_unpartitioned_mesh) :
+    VolumeMesher(VolumeMesherType::EXTRUDER),
     template_type(TemplateType::UNPARTITIONED_MESH),
     template_unpartitioned_mesh(std::move(in_unpartitioned_mesh))
   {}

--- a/framework/ChiMesh/VolumeMesher/Extruder/volmesher_extruder_extrudecells.cc
+++ b/framework/ChiMesh/VolumeMesher/Extruder/volmesher_extruder_extrudecells.cc
@@ -54,6 +54,8 @@ void chi_mesh::VolumeMesherExtruder::
 
         cell->material_id = template_cell.material_id;
 
+        cell->material_id = template_cell.material_id;
+
         grid.cells.push_back(std::move(cell));
       }
       ++num_global_cells;

--- a/framework/ChiMesh/VolumeMesher/PredefinedUnpartitioned/volmesher_predefunpart.h
+++ b/framework/ChiMesh/VolumeMesher/PredefinedUnpartitioned/volmesher_predefunpart.h
@@ -16,6 +16,7 @@ public:
   explicit
   VolumeMesherPredefinedUnpartitioned(
     std::shared_ptr<chi_mesh::UnpartitionedMesh> in_umesh) :
+    VolumeMesher(VolumeMesherType::UNPARTITIONED),
     m_umesh(std::move(in_umesh)) {}
 
   void Execute() override;

--- a/framework/ChiMesh/VolumeMesher/chi_volumemesher.h
+++ b/framework/ChiMesh/VolumeMesher/chi_volumemesher.h
@@ -11,25 +11,27 @@
 
 namespace chi_mesh
 {
-  enum VolumeMesherType
+  enum class VolumeMesherType
   {
     EXTRUDER      = 4,
     UNPARTITIONED = 6
   };
   enum VolumeMesherProperty
   {
-    FORCE_POLYGONS      = 1,
-    MESH_GLOBAL         = 2,
-    PARTITION_Z         = 3,
-    PARTITION_Y         = 4,
-    PARTITION_X         = 5,
-    CUTS_Z              = 6,
-    CUTS_Y              = 7,
-    CUTS_X              = 8,
-    PARTITION_TYPE      = 9,
-    EXTRUSION_LAYER     = 10,
-    MATID_FROMLOGICAL   = 11,
-    BNDRYID_FROMLOGICAL = 12
+    FORCE_POLYGONS            = 1,
+    MESH_GLOBAL               = 2,
+    PARTITION_Z               = 3,
+    PARTITION_Y               = 4,
+    PARTITION_X               = 5,
+    CUTS_Z                    = 6,
+    CUTS_Y                    = 7,
+    CUTS_X                    = 8,
+    PARTITION_TYPE            = 9,
+    EXTRUSION_LAYER           = 10,
+    MATID_FROMLOGICAL         = 11,
+    BNDRYID_FROMLOGICAL       = 12,
+    MATID_FROM_LUA_FUNCTION   = 13,
+    BNDRYID_FROM_LUA_FUNCTION = 14
   };
 }
 
@@ -39,6 +41,7 @@ class chi_mesh::VolumeMesher
 {
 private:
   chi_mesh::MeshContinuumPtr m_grid;
+  const VolumeMesherType     m_type;
 public:
   enum PartitionType
   {
@@ -60,20 +63,26 @@ public:
   };
   VOLUME_MESHER_OPTIONS options;
 public:
+  explicit
   //01 Utils
-//  static
-//  void AddContinuumToRegion(MeshContinuumPtr& grid, Region& region);
+  VolumeMesher(VolumeMesherType type);
   void SetContinuum(MeshContinuumPtr& grid);
   MeshContinuumPtr& GetContinuum();
+  void SetGridAttributes(MeshAttributes new_attribs,
+                         std::array<size_t,3> ortho_Nis={0,0,0});
+  VolumeMesherType Type() const;
 
-  static
-  void CreatePolygonCells(const chi_mesh::UnpartitionedMesh& umesh,
-                          chi_mesh::MeshContinuumPtr& grid);
+  //01a
   static
   std::pair<int,int>  GetCellXYPartitionID(chi_mesh::Cell *cell);
   static
   std::tuple<int,int,int>
                       GetCellXYZPartitionID(chi_mesh::Cell *cell);
+  //01b
+  static
+  void CreatePolygonCells(const chi_mesh::UnpartitionedMesh& umesh,
+                          chi_mesh::MeshContinuumPtr& grid);
+  //01c
   static
   void                SetMatIDFromLogical(const chi_mesh::LogicalVolume& log_vol,
                                           bool sense, int mat_id);
@@ -82,14 +91,19 @@ public:
                                           bool sense, int bndry_id);
   static
   void                SetMatIDToAll(int mat_id);
+
+  static
+  void                SetMatIDFromLuaFunction(const std::string& lua_fname);
+  static
+  void                SetBndryIDFromLuaFunction(const std::string& lua_fname);
+  //01d
   static
   void                SetupOrthogonalBoundaries();
   //02
   virtual void Execute();
 
-  //
-  void SetGridAttributes(MeshAttributes new_attribs,
-                         std::array<size_t,3> ortho_Nis={0,0,0});
+
+
 
 };
 

--- a/framework/ChiMesh/VolumeMesher/chi_volumemesher_01_utils.cc
+++ b/framework/ChiMesh/VolumeMesher/chi_volumemesher_01_utils.cc
@@ -4,9 +4,7 @@
 //###################################################################
 chi_mesh::VolumeMesher::VolumeMesher(VolumeMesherType type) :
  m_type(type)
-{
-
-}
+{}
 
 //###################################################################
 /** Sets the grid member of the volume mesher.*/

--- a/framework/ChiMesh/VolumeMesher/chi_volumemesher_01_utils.cc
+++ b/framework/ChiMesh/VolumeMesher/chi_volumemesher_01_utils.cc
@@ -2,6 +2,13 @@
 #include "ChiMesh/MeshContinuum/chi_meshcontinuum.h"
 
 //###################################################################
+chi_mesh::VolumeMesher::VolumeMesher(VolumeMesherType type) :
+ m_type(type)
+{
+
+}
+
+//###################################################################
 /** Sets the grid member of the volume mesher.*/
 void chi_mesh::VolumeMesher::SetContinuum(MeshContinuumPtr &grid)
 {
@@ -24,3 +31,12 @@ void chi_mesh::VolumeMesher::
 {
   m_grid->SetAttributes(new_attribs, ortho_Nis);
 }
+
+
+//###################################################################
+/**Gets the volume mesher's type.*/
+chi_mesh::VolumeMesherType chi_mesh::VolumeMesher::Type() const
+{
+  return m_type;
+}
+

--- a/framework/ChiMesh/VolumeMesher/lua/volumemesher_create.cc
+++ b/framework/ChiMesh/VolumeMesher/lua/volumemesher_create.cc
@@ -8,9 +8,7 @@
 #include <iostream>
 
 #include "chi_runtime.h"
-
 #include "chi_log.h"
-;
 
 
 //#############################################################################
@@ -55,7 +53,8 @@ int chiVolumeMesherCreate(lua_State *L)
   LuaCheckNilValue(fname, L, 1);
 
   //============================================= Mesher type
-  const int mesher_type = lua_tonumber(L, 1);
+  const auto mesher_type =
+    static_cast<chi_mesh::VolumeMesherType>(lua_tointeger(L, 1));
 
   std::shared_ptr<chi_mesh::VolumeMesher> new_mesher = nullptr;
 

--- a/framework/ChiMesh/VolumeMesher/lua/volumemesher_setproperty.cc
+++ b/framework/ChiMesh/VolumeMesher/lua/volumemesher_setproperty.cc
@@ -69,16 +69,17 @@ Can be any of the following:
 \author Jan*/
 int chiVolumeMesherSetProperty(lua_State *L)
 {
+  const std::string fname = "chiVolumeMesherSetProperty";
   //============================================= Get current mesh handler
   auto& cur_hndlr = chi_mesh::GetCurrentHandler();
 
   //============================================= Get property index
-  int num_args = lua_gettop(L);
+  const int num_args = lua_gettop(L);
   if (num_args < 1)
-    LuaPostArgAmountError(__FUNCTION__,1,num_args);
+    LuaPostArgAmountError(fname,1,num_args);
 
-  LuaCheckNilValue(__FUNCTION__,L,1);
-  LuaCheckNilValue(__FUNCTION__,L,2);
+  LuaCheckNilValue(fname,L,1);
+  LuaCheckNilValue(fname,L,2);
 
   int property_index = lua_tonumber(L,1);
 
@@ -146,7 +147,7 @@ int chiVolumeMesherSetProperty(lua_State *L)
     {
       chi::log.LogAllError()
         << "Unsupported partition type used in call to "
-        << __FUNCTION__ << ".";
+        << fname << ".";
      chi::Exit(EXIT_FAILURE);
     }
   }
@@ -154,6 +155,7 @@ int chiVolumeMesherSetProperty(lua_State *L)
   else if (property_index == VMP::EXTRUSION_LAYER)
   {
     if (typeid(*cur_hndlr.volume_mesher) == typeid(chi_mesh::VolumeMesherExtruder))
+    if (cur_hndlr.volume_mesher->ty)
     {
       auto& mesher = (chi_mesh::VolumeMesherExtruder&)*cur_hndlr.volume_mesher;
 
@@ -197,7 +199,7 @@ int chiVolumeMesherSetProperty(lua_State *L)
     if (num_args==4) sense = lua_toboolean(L,4);
 
     const auto& log_vol = chi::GetStackItem<chi_mesh::LogicalVolume>(
-      chi::logicvolume_stack, volume_hndl, __FUNCTION__);
+      chi::logicvolume_stack, volume_hndl, fname);
 
     chi_mesh::VolumeMesher::SetMatIDFromLogical(log_vol,sense,mat_id);
   }
@@ -217,7 +219,7 @@ int chiVolumeMesherSetProperty(lua_State *L)
     if (num_args==4) sense = lua_toboolean(L,4);
 
     const auto& log_vol = chi::GetStackItem<chi_mesh::LogicalVolume>(
-      chi::logicvolume_stack, volume_hndl, __FUNCTION__);
+      chi::logicvolume_stack, volume_hndl, fname);
 
     chi_mesh::VolumeMesher::SetBndryIDFromLogical(log_vol,sense,bndry_id);
   }

--- a/framework/ChiMesh/lua/chi_mesh_lua.cc
+++ b/framework/ChiMesh/lua/chi_mesh_lua.cc
@@ -54,6 +54,7 @@ void chi_mesh::lua_utils::RegisterLuaEntities(lua_State *L)
     LUA_CMACRO1(RCC          , 4);
     LUA_CMACRO1(SURFACE      , 9);
     LUA_CMACRO1(BOOLEAN      , 10);
+  LUA_FMACRO1(chiLogicalVolumePointSense);
 
   //=================================== Mesh handler
   LUA_FMACRO1(chiMeshHandlerCreate);

--- a/framework/ChiMesh/lua/chi_mesh_lua.cc
+++ b/framework/ChiMesh/lua/chi_mesh_lua.cc
@@ -93,6 +93,8 @@ void chi_mesh::lua_utils::RegisterLuaEntities(lua_State *L)
     LUA_CMACRO1(EXTRUSION_LAYER    , 10);
     LUA_CMACRO1(MATID_FROMLOGICAL  , 11);
     LUA_CMACRO1(BNDRYID_FROMLOGICAL, 12);
+    LUA_CMACRO1(MATID_FROM_LUA_FUNCTION  , 13);
+    LUA_CMACRO1(BNDRYID_FROM_LUA_FUNCTION, 14);
 
   LUA_FMACRO1(chiVolumeMesherSetKBAPartitioningPxPyPz);
   LUA_FMACRO1(chiVolumeMesherSetKBACutsX);

--- a/tutorials/MeshingExamples/MatIDsBndryIDFromLua.lua
+++ b/tutorials/MeshingExamples/MatIDsBndryIDFromLua.lua
@@ -1,0 +1,68 @@
+--############################################### Setup mesh
+chiMeshHandlerCreate()
+
+mesh={}
+N=10
+L=5
+xmin = -L/2
+dx = L/N
+for i=1,(N+1) do
+    k=i-1
+    mesh[i] = xmin + k*dx
+end
+
+chiMeshCreateUnpartitioned3DOrthoMesh(mesh,mesh,mesh)
+
+chiVolumeMesherExecute();
+
+chiMeshHandlerExportMeshToVTK("ZMeshPhase1")
+
+chiVolumeMesherSetMatIDToAll(0)
+
+--Sets a middle square to material 1
+function MatIDFunction1(x,y,z,cur_id)
+
+    if (math.abs(x)<L/10 and math.abs(y)<L/10) then
+        return 1
+    end
+
+    return cur_id
+end
+
+chiVolumeMesherSetProperty(MATID_FROM_LUA_FUNCTION, "MatIDFunction1")
+
+chiMeshHandlerExportMeshToVTK("ZMeshPhase2")
+
+--Setting left, right, top and bottom boundaries
+-- left = 0
+-- right = 1
+-- bottom = 2
+-- top = 3
+function dot_product(v1,v2)
+    result = v1[1]*v2[1] +
+             v1[2]*v2[2] +
+             v1[3]*v2[3]
+    return result
+end
+function BndryIDFunction1(x,y,z,nx,ny,nz,cur_bid)
+    epsilon = 1.0e-6
+    n = {nx,ny,nz}
+    if (dot_product(n,{-1.0,0.0,0.0}) > (1.0-epsilon)) then
+        return 0
+    end
+    if (dot_product(n,{1.0,0.0,0.0}) > (1.0-epsilon)) then
+        return 1
+    end
+    if (dot_product(n,{0.0,-1.0,0.0}) > (1.0-epsilon)) then
+        return 2
+    end
+    if (dot_product(n,{0.0,1.0,0.0}) > (1.0-epsilon)) then
+        return 3
+    end
+
+    return cur_bid
+end
+
+chiVolumeMesherSetProperty(BNDRYID_FROM_LUA_FUNCTION, "BndryIDFunction1")
+
+chiMeshHandlerExportMeshToVTK("ZMeshPhase3")


### PR DESCRIPTION
## Highlights
- Added two new options for setting material- and boundary-ids:
  - `chiVolumeMesherSetProperty(MATID_FROM_LUA_FUNCTION,...`
  - `chiVolumeMesherSetProperty(BNDRYID_FROM_LUA_FUNCTION,...`
- The material-id function gets called for each cell and is passed the cell's centroid and current mat-id
- The boundary-id function gets called for each boundary face and is passed the face's centroid, face's normal and
current boundary id

- Also modified the extruded to always copy (by default) the 2D template's mat-ids.
- Various small cosmetic changes.