### PR TITLE
GitHub Action for regression testing

### DIFF
--- a/.github/workflows/Regression.yaml
+++ b/.github/workflows/Regression.yaml
@@ -1,0 +1,27 @@
+name: Chi-Tech Regression Tests
+
+on:
+  schedule:
+    - cron: "0 0 * * *"
+  workflow_dispatch:
+    
+jobs:
+  test:
+    runs-on: 'self-hosted'
+    steps:
+      - uses: actions/checkout@v2
+      - name: configure
+        shell: bash
+        run: |
+          export MODULEPATH=/scratch-local/software/modulefiles
+          module load chitech/gcc/12.3.0
+          ./configure.sh
+      - name: make
+        shell: bash
+        run: |
+          export MODULEPATH=/scratch-local/software/modulefiles
+          module load chitech/gcc/12.3.0
+          make -j64
+      - name: test
+        shell: bash
+        run: test/run_tests -d test/modules

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![Developer Branch Regression Tests](https://github.com/wdhawkins/chi-tech/actions/workflows/Regression.yaml/badge.svg)
+![Developer Branch Regression Tests](https://github.com/wdhawkins/chi-tech/actions/workflows/Regression.yaml/badge.svg?branch=development)
 
 <p align="center">
   <img src="doc/HTMLimages/CoolPics/banner.png" width="700">

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![GitHub branch checks state](https://img.shields.io/github/checks-status/chi-tech/chi-tech/development?label=Development)
+![Developer Branch Regression Tests](https://github.com/wdhawkins/chi-tech/actions/workflows/Regression.yaml/badge.svg?branch=developer)
 
 <p align="center">
   <img src="doc/HTMLimages/CoolPics/banner.png" width="700">

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![Developer Branch Regression Tests](https://github.com/wdhawkins/chi-tech/actions/workflows/Regression.yaml/badge.svg?branch=developer)
+![Developer Branch Regression Tests](https://github.com/wdhawkins/chi-tech/actions/workflows/Regression.yaml/badge.svg)
 
 <p align="center">
   <img src="doc/HTMLimages/CoolPics/banner.png" width="700">

--- a/test/run_tests
+++ b/test/run_tests
@@ -130,4 +130,5 @@ print("\033[36m[Python error]\033[0m = A python error occurred. Run with -v 1 "
 
 print()
 
-jobmanager.RunTests(tests, argv)
+retval = jobmanager.RunTests(tests, argv)
+sys.exit(retval)

--- a/test/src/jobmanager.py
+++ b/test/src/jobmanager.py
@@ -334,3 +334,7 @@ def RunTests(tests: list, argv):
     print(f"Number of tests run    : {len(test_slots)}")
     print(f"Number of failed tests : {num_tests_failed}")
     print()
+
+    if num_tests_failed > 0:
+      return 1
+    return 0


### PR DESCRIPTION
Initial commit of a GitHub action targeting regression tests for the development branch. The action will run automatically every night at midnight or can be triggered manually. I suspect we'll be fine tuning these changes over the next day or so. As of this commit, 3 regression tests are failing on the runner (probably due to tolerance issues).