### PR TITLE
Hot fix for MeshGenerator and LBS

### DIFF
--- a/framework/mesh/MeshContinuum/chi_meshcontinuum.h
+++ b/framework/mesh/MeshContinuum/chi_meshcontinuum.h
@@ -25,6 +25,7 @@ class ChiMPICommunicatorSet;
 namespace chi_mesh
 {
 class GridFaceHistogram;
+class MeshGenerator;
 }
 
 // ######################################################### Class Definition
@@ -162,6 +163,7 @@ public:
 
 private:
   friend class chi_mesh::VolumeMesher;
+  friend class chi_mesh::MeshGenerator;
   void SetAttributes(MeshAttributes new_attribs,
                      std::array<size_t, 3> ortho_Nis = {0, 0, 0})
   {

--- a/framework/mesh/MeshGenerator/MeshGenerator_01_SetupMesh.cc
+++ b/framework/mesh/MeshGenerator/MeshGenerator_01_SetupMesh.cc
@@ -68,6 +68,11 @@ MeshGenerator::SetupMesh(std::unique_ptr<UnpartitionedMesh> input_umesh_ptr)
     ++cell_globl_id;
   } // for raw_cell
 
+  grid_ptr->SetAttributes(input_umesh_ptr->GetMeshAttributes(),
+                          {input_umesh_ptr->GetMeshOptions().ortho_Nx,
+                           input_umesh_ptr->GetMeshOptions().ortho_Ny,
+                           input_umesh_ptr->GetMeshOptions().ortho_Nz});
+
   grid_ptr->SetGlobalVertexCount(input_umesh_ptr->GetVertices().size());
 
   //======================================== Concluding messages

--- a/modules/LinearBoltzmannSolvers/A_LBSSolver/lbs_01a_inputchecks.cc
+++ b/modules/LinearBoltzmannSolvers/A_LBSSolver/lbs_01a_inputchecks.cc
@@ -58,9 +58,12 @@ void lbs::LBSSolver::PerformInputChecks()
   const auto grid_attribs = grid_ptr_->Attributes();
   if (grid_attribs & DIMENSION_1)
     options_.geometry_type = GeometryType::ONED_SLAB;
-  if (grid_attribs & DIMENSION_2)
+  else if (grid_attribs & DIMENSION_2)
     options_.geometry_type = GeometryType::TWOD_CARTESIAN;
-  if (grid_attribs & DIMENSION_3)
+  else if (grid_attribs & DIMENSION_3)
     options_.geometry_type = GeometryType::THREED_CARTESIAN;
+  else
+    ChiLogicalError("Cannot deduce geometry type from mesh.");
+
 
 }


### PR DESCRIPTION
Mesh attributes were not copied from the MeshGenerator to the final grid. I missed this because only the LBS solvers use that info.