### PR TITLE
Changes 2023 10 week1

### DIFF
--- a/framework/math/Quadratures/point_quadrature.cc
+++ b/framework/math/Quadratures/point_quadrature.cc
@@ -1,0 +1,12 @@
+#include "point_quadrature.h"
+
+namespace chi_math
+{
+
+PointQuadrature::PointQuadrature() : Quadrature(QuadratureOrder::CONSTANT)
+{
+  qpoints_ = {{0.0, 0.0, 0.0}};
+  weights_ = {1.0};
+}
+
+} // namespace chi_math

--- a/framework/math/Quadratures/point_quadrature.h
+++ b/framework/math/Quadratures/point_quadrature.h
@@ -1,0 +1,19 @@
+#ifndef CHITECH_POINT_QUADRATURE_H
+#define CHITECH_POINT_QUADRATURE_H
+
+#include "quadrature.h"
+
+namespace chi_math
+{
+
+/**Quadrate for a single point. Helps generalize quadrature based integration
+* on 1D cell faces.*/
+class PointQuadrature : public Quadrature
+{
+public:
+  PointQuadrature();
+};
+
+}
+
+#endif // CHITECH_POINT_QUADRATURE_H

--- a/framework/math/Quadratures/quadrature_hexahedron.cc
+++ b/framework/math/Quadratures/quadrature_hexahedron.cc
@@ -10,6 +10,8 @@ chi_math::QuadratureHexahedron::QuadratureHexahedron(QuadratureOrder order) :
 {
   QuadratureGaussLegendre legendre(order);
 
+  legendre.SetRange({-1.0,1.0});
+
   size_t N = legendre.qpoints_.size();
 
   qpoints_.resize(N * N * N);

--- a/framework/math/Quadratures/quadrature_quadrilateral.cc
+++ b/framework/math/Quadratures/quadrature_quadrilateral.cc
@@ -10,6 +10,8 @@ chi_math::QuadratureQuadrilateral::QuadratureQuadrilateral(QuadratureOrder order
 {
   QuadratureGaussLegendre legendre(order);
 
+  legendre.SetRange({-1.0, 1.0});
+
   size_t N = legendre.qpoints_.size();
 
   qpoints_.resize(N * N);

--- a/framework/math/Quadratures/quadrature_wedge.cc
+++ b/framework/math/Quadratures/quadrature_wedge.cc
@@ -1,0 +1,36 @@
+#include "quadrature_wedge.h"
+
+#include "quadrature_gausslegendre.h"
+#include "quadrature_triangle.h"
+
+namespace chi_math
+{
+
+QuadratureWedge::QuadratureWedge(QuadratureOrder order) : Quadrature(order)
+{
+  QuadratureGaussLegendre legendre(order);
+  legendre.SetRange({-1.0, 1.0});
+  QuadratureTriangle triangle(order);
+
+  const size_t NL = legendre.qpoints_.size();
+  const size_t NT = triangle.qpoints_.size();
+
+  qpoints_.resize(NL * NT);
+  weights_.resize(NL * NT);
+
+  size_t q = 0;
+  for (size_t i=0; i<NL; ++i)
+    for (size_t j=0; j<NT; ++j)
+    {
+      qpoints_[q](0) = triangle.qpoints_[j][0];
+      qpoints_[q](1) = triangle.qpoints_[j][1];
+      qpoints_[q](2) = legendre.qpoints_[i][0];
+
+      weights_[q] = legendre.weights_[i] * triangle.weights_[j];
+
+      ++q;
+    }
+
+}
+
+} // namespace chi_math

--- a/framework/math/Quadratures/quadrature_wedge.h
+++ b/framework/math/Quadratures/quadrature_wedge.h
@@ -1,0 +1,20 @@
+#ifndef CHITECH_QUADRATURE_WEDGE_H
+#define CHITECH_QUADRATURE_WEDGE_H
+
+#include "quadrature.h"
+
+namespace chi_math
+{
+
+/**Quadrature for a wedge (extruded triangle). This is a simple product
+* of a triangle quadrature and Gauss-Legendre line quadrature.*/
+class QuadratureWedge : public Quadrature
+{
+public:
+  // Constructor
+  explicit QuadratureWedge(QuadratureOrder order);
+};
+
+} // namespace chi_math
+
+#endif // CHITECH_QUADRATURE_WEDGE_H

--- a/framework/mesh/MeshGenerator/ExtruderMeshGenerator.cc
+++ b/framework/mesh/MeshGenerator/ExtruderMeshGenerator.cc
@@ -234,19 +234,6 @@ ExtruderMeshGenerator::GenerateUnpartitionedMesh(
         } // for tc face
 
         //================================== Create top and bottom faces
-        // Bottom face
-        {
-          UnpartitionedMesh::LightWeightFace new_face;
-
-          new_face.vertex_ids.reserve(template_cell->vertex_ids.size());
-          auto& vs = template_cell->vertex_ids;
-          for (auto vid = vs.rbegin(); vid != vs.rend(); ++vid)
-            new_face.vertex_ids.push_back((*vid) + k * num_template_vertices);
-
-          if (k == 0) new_face.neighbor = zmin_bndry_id;
-
-          new_cell.faces.push_back(std::move(new_face));
-        }
         // Top face
         {
           UnpartitionedMesh::LightWeightFace new_face;
@@ -257,6 +244,19 @@ ExtruderMeshGenerator::GenerateUnpartitionedMesh(
                                           (k + 1) * num_template_vertices);
 
           if ((k + 1) == z_levels.size()) new_face.neighbor = zmax_bndry_id;
+
+          new_cell.faces.push_back(std::move(new_face));
+        }
+        // Bottom face
+        {
+          UnpartitionedMesh::LightWeightFace new_face;
+
+          new_face.vertex_ids.reserve(template_cell->vertex_ids.size());
+          auto& vs = template_cell->vertex_ids;
+          for (auto vid = vs.rbegin(); vid != vs.rend(); ++vid)
+            new_face.vertex_ids.push_back((*vid) + k * num_template_vertices);
+
+          if (k == 0) new_face.neighbor = zmin_bndry_id;
 
           new_cell.faces.push_back(std::move(new_face));
         }

--- a/framework/mesh/MeshGenerator/ExtruderMeshGenerator.cc
+++ b/framework/mesh/MeshGenerator/ExtruderMeshGenerator.cc
@@ -206,6 +206,8 @@ ExtruderMeshGenerator::GenerateUnpartitionedMesh(
           CellType::POLYHEDRON, extruded_subtype);
         auto& new_cell = *new_cell_ptr;
 
+        new_cell.material_id = template_cell->material_id;
+
         //================================== Build vertices
         const size_t tc_num_verts = template_cell->vertex_ids.size();
         new_cell.vertex_ids.reserve(2 * tc_num_verts);

--- a/framework/mesh/UnpartitionedMesh/chi_unpartitioned_mesh.h
+++ b/framework/mesh/UnpartitionedMesh/chi_unpartitioned_mesh.h
@@ -83,7 +83,9 @@ protected:
 
   typedef vtkSmartPointer<vtkUnstructuredGrid> vtkUGridPtr;
   typedef std::pair<vtkUGridPtr, std::string> vtkUGridPtrAndName;
-  void CopyUGridCellsAndPoints(vtkUnstructuredGrid& ugrid, double scale);
+  void CopyUGridCellsAndPoints(vtkUnstructuredGrid& ugrid,
+                               double scale,
+                               int dimension_to_copy);
 
   void SetMaterialIDsFromList(const std::vector<int>& material_ids);
 
@@ -106,10 +108,7 @@ public:
 
   void AddCell(LightWeightCell*& cell) { raw_cells_.push_back(cell); }
   size_t GetNumberOfCells() const { return raw_cells_.size(); }
-  std::vector<LightWeightCell*>& GetRawCells()
-  {
-    return raw_cells_;
-  }
+  std::vector<LightWeightCell*>& GetRawCells() { return raw_cells_; }
   const std::vector<LightWeightCell*>& GetRawCells() const
   {
     return raw_cells_;

--- a/framework/mesh/UnpartitionedMesh/unpartmesh_00c_vtk_cellsvtk2chi.cc
+++ b/framework/mesh/UnpartitionedMesh/unpartmesh_00c_vtk_cellsvtk2chi.cc
@@ -1,14 +1,13 @@
 #include "chi_unpartitioned_mesh.h"
 
-#include <vtkPolyhedron.h>
 #include <vtkPolygon.h>
 #include <vtkLine.h>
 #include <vtkVertex.h>
 
-//###################################################################
+// ###################################################################
 /**Creates a raw polyhedron cell from a vtk-polyhedron.*/
-chi_mesh::UnpartitionedMesh::LightWeightCell* chi_mesh::UnpartitionedMesh::
-  CreateCellFromVTKPolyhedron(vtkCell *vtk_cell)
+chi_mesh::UnpartitionedMesh::LightWeightCell*
+chi_mesh::UnpartitionedMesh::CreateCellFromVTKPolyhedron(vtkCell* vtk_cell)
 {
   const std::string fname =
     "chi_mesh::UnpartitionedMesh::CreateCellFromVTKPolyhedron";
@@ -18,53 +17,135 @@ chi_mesh::UnpartitionedMesh::LightWeightCell* chi_mesh::UnpartitionedMesh::
   {
     case VTK_HEXAGONAL_PRISM:
     case VTK_PENTAGONAL_PRISM:
-    case VTK_POLYHEDRON:       sub_type = CellType::POLYHEDRON; break;
-    case VTK_PYRAMID:          sub_type = CellType::PYRAMID; break;
-    case VTK_WEDGE:            sub_type = CellType::WEDGE; break;
+    case VTK_POLYHEDRON:
+      sub_type = CellType::POLYHEDRON;
+      break;
+    case VTK_PYRAMID:
+      sub_type = CellType::PYRAMID;
+      break;
+    case VTK_WEDGE:
+      sub_type = CellType::WEDGE;
+      break;
     case VTK_HEXAHEDRON:
-    case VTK_VOXEL:            sub_type = CellType::HEXAHEDRON; break;
-    case VTK_TETRA:            sub_type = CellType::TETRAHEDRON; break;
+    case VTK_VOXEL:
+      sub_type = CellType::HEXAHEDRON;
+      break;
+    case VTK_TETRA:
+      sub_type = CellType::TETRAHEDRON;
+      break;
     default:
       throw std::logic_error(fname + ": Unsupported 3D cell type encountered.");
   }
-  auto polyh_cell  = new LightWeightCell(CellType::POLYHEDRON, sub_type);
+  auto polyh_cell = new LightWeightCell(CellType::POLYHEDRON, sub_type);
 
-  auto num_cpoints  = vtk_cell->GetNumberOfPoints();
-  auto num_cfaces   = vtk_cell->GetNumberOfFaces();
+  auto num_cpoints = vtk_cell->GetNumberOfPoints();
+  auto num_cfaces = vtk_cell->GetNumberOfFaces();
 
   polyh_cell->vertex_ids.reserve(num_cpoints);
-  auto point_ids   = vtk_cell->GetPointIds();
-  for (int p=0; p<num_cpoints; ++p)
+  auto point_ids = vtk_cell->GetPointIds();
+  for (int p = 0; p < num_cpoints; ++p)
   {
     uint64_t point_id = point_ids->GetId(p);
     polyh_cell->vertex_ids.push_back(point_id);
-  }//for p
+  } // for p
 
-  polyh_cell->faces.reserve(num_cfaces);
-  for (int f=0; f<num_cfaces; ++f)
+  switch (sub_type)
   {
-    LightWeightFace face;
-    auto vtk_face = vtk_cell->GetFace(f);
-    auto num_face_points = vtk_face->GetNumberOfPoints();
+    // The cell vertex ids in VTK is the same as in ChiTech so we don't
+    // need to remap the vertices. We do however need to remap the faces.
+    case CellType::HEXAHEDRON:
+    {
+      std::vector<std::vector<uint64_t>> face_vids = {{1, 2, 6, 5},
+                                                      {3, 0, 4, 7},
+                                                      {2, 3, 7, 6},
+                                                      {0, 1, 5, 4},
+                                                      {4, 5, 6, 7},
+                                                      {3, 2, 1, 0}};
+      for (int f = 0; f < 6; ++f)
+      {
+        LightWeightFace face;
 
-    face.vertex_ids.reserve(num_face_points);
-    auto face_point_ids = vtk_face->GetPointIds();
-    for (int p = 0; p < num_face_points; ++p) {
-      uint64_t point_id = face_point_ids->GetId(p);
-      face.vertex_ids.push_back(point_id);
+        face.vertex_ids.reserve(4);
+        for (int p = 0; p < 4; ++p)
+          face.vertex_ids.push_back(polyh_cell->vertex_ids[face_vids[f][p]]);
+
+        polyh_cell->faces.push_back(face);
+      }
+      break;
     }
+    // For wedges we need to remap cell vertices and faces.
+    case CellType::WEDGE:
+    {
+      std::vector<uint64_t> remapping = {0, 2, 1, 3, 5, 4};
+      std::vector<uint64_t> remapped(6, 0);
+      for (int i = 0; i < 6; ++i)
+        remapped[i] = polyh_cell->vertex_ids[remapping[i]];
+      polyh_cell->vertex_ids = remapped;
 
-    polyh_cell->faces.push_back(face);
-  }
+      std::vector<std::vector<uint64_t>> face_vids = {
+        {0, 1, 4, 3}, {1, 2, 5, 4}, {2, 0, 3, 5}, {3, 4, 5}, {0, 2, 1}};
+      for (int f = 0; f < 6; ++f)
+      {
+        LightWeightFace face;
+
+        face.vertex_ids.reserve(4);
+        for (int p = 0; p < face_vids[f].size(); ++p)
+          face.vertex_ids.push_back(polyh_cell->vertex_ids[face_vids[f][p]]);
+
+        polyh_cell->faces.push_back(face);
+      }
+      break;
+    }
+    // We dont need cell vertex id remapping but we need to impose our own
+    // face orientation
+    case CellType::TETRAHEDRON:
+    {
+      std::vector<std::vector<uint64_t>> face_vids = {{0, 2, 1},
+                                                      {0, 1, 3},
+                                                      {0, 3, 2},
+                                                      {3, 1, 2}};
+      for (int f = 0; f < 4; ++f)
+      {
+        LightWeightFace face;
+
+        face.vertex_ids.reserve(3);
+        for (int p = 0; p < 3; ++p)
+          face.vertex_ids.push_back(polyh_cell->vertex_ids[face_vids[f][p]]);
+
+        polyh_cell->faces.push_back(face);
+      }
+      break;
+    }
+    default:
+    {
+      polyh_cell->faces.reserve(num_cfaces);
+      for (int f = 0; f < num_cfaces; ++f)
+      {
+        LightWeightFace face;
+        auto vtk_face = vtk_cell->GetFace(f);
+        auto num_face_points = vtk_face->GetNumberOfPoints();
+
+        face.vertex_ids.reserve(num_face_points);
+        auto face_point_ids = vtk_face->GetPointIds();
+        for (int p = 0; p < num_face_points; ++p)
+        {
+          uint64_t point_id = face_point_ids->GetId(p);
+          face.vertex_ids.push_back(point_id);
+        }
+
+        polyh_cell->faces.push_back(face);
+      }
+      break;
+    } // default
+  }   // switch on sub_type
 
   return polyh_cell;
 }
 
-
-//###################################################################
+// ###################################################################
 /**Creates a raw polygon cell from a vtk-polygon.*/
-chi_mesh::UnpartitionedMesh::LightWeightCell* chi_mesh::UnpartitionedMesh::
-  CreateCellFromVTKPolygon(vtkCell *vtk_cell)
+chi_mesh::UnpartitionedMesh::LightWeightCell*
+chi_mesh::UnpartitionedMesh::CreateCellFromVTKPolygon(vtkCell* vtk_cell)
 {
   const std::string fname =
     "chi_mesh::UnpartitionedMesh::CreateCellFromVTKPolygon";
@@ -72,35 +153,41 @@ chi_mesh::UnpartitionedMesh::LightWeightCell* chi_mesh::UnpartitionedMesh::
   CellType sub_type;
   switch (vtk_cell->GetCellType())
   {
-    case VTK_POLYGON:          sub_type = CellType::POLYGON; break;
+    case VTK_POLYGON:
+      sub_type = CellType::POLYGON;
+      break;
     case VTK_QUAD:
-    case VTK_PIXEL:            sub_type = CellType::QUADRILATERAL; break;
-    case VTK_TRIANGLE:         sub_type = CellType::TRIANGLE; break;
+    case VTK_PIXEL:
+      sub_type = CellType::QUADRILATERAL;
+      break;
+    case VTK_TRIANGLE:
+      sub_type = CellType::TRIANGLE;
+      break;
     default:
       throw std::logic_error(fname + ": Unsupported 2D cell type encountered.");
   }
 
-  auto poly_cell   = new LightWeightCell(CellType::POLYGON, sub_type);
+  auto poly_cell = new LightWeightCell(CellType::POLYGON, sub_type);
 
   auto num_cpoints = vtk_cell->GetNumberOfPoints();
-  auto num_cfaces  = num_cpoints;
+  auto num_cfaces = num_cpoints;
 
   poly_cell->vertex_ids.reserve(num_cpoints);
-  auto point_ids   = vtk_cell->GetPointIds();
-  for (int p=0; p<num_cpoints; ++p)
+  auto point_ids = vtk_cell->GetPointIds();
+  for (int p = 0; p < num_cpoints; ++p)
   {
     uint64_t point_id = point_ids->GetId(p);
     poly_cell->vertex_ids.push_back(point_id);
-  }//for p
+  } // for p
 
   poly_cell->faces.reserve(num_cfaces);
-  for (int f=0; f<num_cfaces; ++f)
+  for (int f = 0; f < num_cfaces; ++f)
   {
     LightWeightFace face;
 
     auto v0_id = poly_cell->vertex_ids[f];
-    auto v1_id = (f<(num_cfaces-1))? poly_cell->vertex_ids[f+1] :
-                 poly_cell->vertex_ids[0];
+    auto v1_id = (f < (num_cfaces - 1)) ? poly_cell->vertex_ids[f + 1]
+                                        : poly_cell->vertex_ids[0];
 
     face.vertex_ids.reserve(2);
     face.vertex_ids.push_back(v0_id);
@@ -112,11 +199,10 @@ chi_mesh::UnpartitionedMesh::LightWeightCell* chi_mesh::UnpartitionedMesh::
   return poly_cell;
 }
 
-
-//###################################################################
+// ###################################################################
 /**Creates a raw slab cell from a vtk-line.*/
-chi_mesh::UnpartitionedMesh::LightWeightCell* chi_mesh::UnpartitionedMesh::
-  CreateCellFromVTKLine(vtkCell *vtk_cell)
+chi_mesh::UnpartitionedMesh::LightWeightCell*
+chi_mesh::UnpartitionedMesh::CreateCellFromVTKLine(vtkCell* vtk_cell)
 {
   const std::string fname =
     "chi_mesh::UnpartitionedMesh::CreateCellFromVTKPolygon";
@@ -124,27 +210,29 @@ chi_mesh::UnpartitionedMesh::LightWeightCell* chi_mesh::UnpartitionedMesh::
   CellType sub_type;
   switch (vtk_cell->GetCellType())
   {
-    case VTK_LINE:             sub_type = CellType::SLAB; break;
+    case VTK_LINE:
+      sub_type = CellType::SLAB;
+      break;
     default:
       throw std::logic_error(fname + ": Unsupported 1D cell type encountered.");
   }
 
-  auto slab_cell   = new LightWeightCell(CellType::SLAB, sub_type);
+  auto slab_cell = new LightWeightCell(CellType::SLAB, sub_type);
 
-  auto vtk_line    = vtkLine::SafeDownCast(vtk_cell);
+  auto vtk_line = vtkLine::SafeDownCast(vtk_cell);
   auto num_cpoints = vtk_line->GetNumberOfPoints();
-  auto num_cfaces  = num_cpoints;
+  auto num_cfaces = num_cpoints;
 
   slab_cell->vertex_ids.reserve(num_cpoints);
-  auto point_ids   = vtk_line->GetPointIds();
-  for (int p=0; p<num_cpoints; ++p)
+  auto point_ids = vtk_line->GetPointIds();
+  for (int p = 0; p < num_cpoints; ++p)
   {
     uint64_t point_id = point_ids->GetId(p);
     slab_cell->vertex_ids.push_back(point_id);
-  }//for p
+  } // for p
 
   slab_cell->faces.reserve(num_cfaces);
-  for (int f=0; f<num_cfaces; ++f)
+  for (int f = 0; f < num_cfaces; ++f)
   {
     LightWeightFace face;
 
@@ -159,25 +247,23 @@ chi_mesh::UnpartitionedMesh::LightWeightCell* chi_mesh::UnpartitionedMesh::
   return slab_cell;
 }
 
-
-//###################################################################
+// ###################################################################
 /**Creates a raw point cell from a vtk-vertex.*/
-chi_mesh::UnpartitionedMesh::LightWeightCell* chi_mesh::UnpartitionedMesh::
-  CreateCellFromVTKVertex(vtkCell *vtk_cell)
+chi_mesh::UnpartitionedMesh::LightWeightCell*
+chi_mesh::UnpartitionedMesh::CreateCellFromVTKVertex(vtkCell* vtk_cell)
 {
-  auto point_cell  = new LightWeightCell(CellType::GHOST,
-                                         CellType::POINT);
+  auto point_cell = new LightWeightCell(CellType::GHOST, CellType::POINT);
 
-  auto vtk_vertex  = vtkVertex::SafeDownCast(vtk_cell);
+  auto vtk_vertex = vtkVertex::SafeDownCast(vtk_cell);
   auto num_cpoints = vtk_vertex->GetNumberOfPoints();
 
   point_cell->vertex_ids.reserve(num_cpoints);
-  auto point_ids   = vtk_vertex->GetPointIds();
-  for (int p=0; p<num_cpoints; ++p)
+  auto point_ids = vtk_vertex->GetPointIds();
+  for (int p = 0; p < num_cpoints; ++p)
   {
     uint64_t point_id = point_ids->GetId(p);
     point_cell->vertex_ids.push_back(point_id);
-  }//for p
+  } // for p
 
   return point_cell;
 }

--- a/framework/mesh/UnpartitionedMesh/unpartmesh_01a_readfromvtu.cc
+++ b/framework/mesh/UnpartitionedMesh/unpartmesh_01a_readfromvtu.cc
@@ -49,6 +49,7 @@ void chi_mesh::UnpartitionedMesh::ReadFromVTU(
 
   //======================================== Get the main + bndry blocks
   const int max_dimension = chi_mesh::FindHighestDimension(grid_blocks);
+  Chi::log.Log0Verbose1() << "Maximum dimension : " << max_dimension << "\n";
   std::vector<vtkUGridPtrAndName> domain_grid_blocks =
     chi_mesh::GetBlocksOfDesiredDimension(grid_blocks, max_dimension);
   std::vector<vtkUGridPtrAndName> bndry_grid_blocks =
@@ -59,7 +60,7 @@ void chi_mesh::UnpartitionedMesh::ReadFromVTU(
     domain_grid_blocks, mesh_options_.material_id_fieldname);
 
   //======================================== Copy Data
-  CopyUGridCellsAndPoints(*ugrid, options.scale);
+  CopyUGridCellsAndPoints(*ugrid, options.scale, max_dimension);
 
   //======================================== Set material ids
   const auto material_ids = chi_mesh::BuildCellMaterialIDsFromField(

--- a/framework/mesh/UnpartitionedMesh/unpartmesh_01b_readfrompvtu.cc
+++ b/framework/mesh/UnpartitionedMesh/unpartmesh_01b_readfrompvtu.cc
@@ -49,6 +49,7 @@ void chi_mesh::UnpartitionedMesh::
 
   //======================================== Get the main + bndry blocks
   const int max_dimension = chi_mesh::FindHighestDimension(grid_blocks);
+  Chi::log.Log0Verbose1() << "Maximum dimension : " << max_dimension << "\n";
   std::vector<vtkUGridPtrAndName> domain_grid_blocks =
     chi_mesh::GetBlocksOfDesiredDimension(grid_blocks, max_dimension);
   std::vector<vtkUGridPtrAndName> bndry_grid_blocks =
@@ -58,7 +59,7 @@ void chi_mesh::UnpartitionedMesh::
   auto ugrid = chi_mesh::ConsolidateGridBlocks(domain_grid_blocks);
 
   //======================================== Copy Data
-  CopyUGridCellsAndPoints(*ugrid, options.scale);
+  CopyUGridCellsAndPoints(*ugrid, options.scale, max_dimension);
 
   //======================================== Set material ids
   const auto material_ids = chi_mesh::BuildCellMaterialIDsFromField(

--- a/framework/mesh/UnpartitionedMesh/unpartmesh_01c_readfromensight.cc
+++ b/framework/mesh/UnpartitionedMesh/unpartmesh_01c_readfromensight.cc
@@ -72,6 +72,7 @@ void chi_mesh::UnpartitionedMesh::
 
   //======================================== Get the main + bndry blocks
   const int max_dimension = chi_mesh::FindHighestDimension(grid_blocks);
+  Chi::log.Log0Verbose1() << "Maximum dimension : " << max_dimension << "\n";
   std::vector<vtkUGridPtrAndName> domain_grid_blocks =
     chi_mesh::GetBlocksOfDesiredDimension(grid_blocks, max_dimension);
   std::vector<vtkUGridPtrAndName> bndry_grid_blocks =
@@ -85,7 +86,7 @@ void chi_mesh::UnpartitionedMesh::
 
   //======================================== Copy Data
   // Material-IDs will get set form block-id arrays
-  CopyUGridCellsAndPoints(*ugrid, options.scale);
+  CopyUGridCellsAndPoints(*ugrid, options.scale, max_dimension);
 
   //======================================== Always do this
   chi_mesh::MeshAttributes dimension = NONE;

--- a/framework/mesh/UnpartitionedMesh/unpartmesh_01f_readfromexodus.cc
+++ b/framework/mesh/UnpartitionedMesh/unpartmesh_01f_readfromexodus.cc
@@ -97,6 +97,7 @@ void chi_mesh::UnpartitionedMesh::
 
   //======================================== Get the main + bndry blocks
   const int max_dimension = chi_mesh::FindHighestDimension(grid_blocks);
+  Chi::log.Log0Verbose1() << "Maximum dimension : " << max_dimension << "\n";
   std::vector<vtkUGridPtrAndName> domain_grid_blocks =
     chi_mesh::GetBlocksOfDesiredDimension(grid_blocks, max_dimension);
   std::vector<vtkUGridPtrAndName> bndry_grid_blocks =
@@ -108,7 +109,7 @@ void chi_mesh::UnpartitionedMesh::
 
   //======================================== Copy Data
   // Material-IDs will get set form block-id arrays
-  CopyUGridCellsAndPoints(*ugrid, options.scale);
+  CopyUGridCellsAndPoints(*ugrid, options.scale, max_dimension);
 
   //======================================== Always do this
   chi_mesh::MeshAttributes dimension = NONE;


### PR DESCRIPTION
# Highlights

- Addition of a convenient point-quadrature (for the upcoming Lagrange SDM)
- Corrections for the Quadrilateral- and Hexahedron-quadratures (these have been unused thus far)
- Robustness improvements to the VTK reader
  - Properly imposes correct conventions from VTK-cells to Chi-Tech cells (especially the faces)
  - Will now produce a proper message when BlockID is missing from VTK files
  - Now handles mixed type meshes better (GMSH exports mixed meshes)