### PR TITLE
Addition of SplitFileMeshGenerator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,3 +76,4 @@ scratch/
 #general data files
 *.data
 tests/BigTests/c5g7/Test1/solutions/
+**/*.cmesh

--- a/framework/graphs/PETScGraphPartitioner.cc
+++ b/framework/graphs/PETScGraphPartitioner.cc
@@ -48,90 +48,79 @@ std::vector<int64_t> PETScGraphPartitioner::Partition(
 
   //================================================== Start building indices
   std::vector<int64_t> cell_pids(num_raw_cells, 0);
-  if (Chi::mpi.location_id == 0)
+  if (num_raw_cells > 1)
   {
-    if (num_raw_cells > 1)
+    //======================================== Build indices
+    std::vector<int64_t> i_indices(num_raw_cells + 1, 0);
+    std::vector<int64_t> j_indices;
+    j_indices.reserve(num_raw_cells * avg_num_face_per_cell);
     {
-      //======================================== Build indices
-      std::vector<int64_t> i_indices(num_raw_cells + 1, 0);
-      std::vector<int64_t> j_indices;
-      j_indices.reserve(num_raw_cells * avg_num_face_per_cell);
+      int64_t i = 0;
+      int64_t icount = 0;
+      for (const auto& cell : graph)
       {
-        int64_t i = 0;
-        int64_t icount = 0;
-        for (const auto& cell : graph)
-        {
-          i_indices[i] = icount;
-
-          for (const uint64_t neighbor_id : cell)
-          {
-            j_indices.push_back(static_cast<int64_t>(neighbor_id));
-            ++icount;
-          }
-          ++i;
-        }
         i_indices[i] = icount;
+
+        for (const uint64_t neighbor_id : cell)
+        {
+          j_indices.push_back(static_cast<int64_t>(neighbor_id));
+          ++icount;
+        }
+        ++i;
       }
+      i_indices[i] = icount;
+    }
 
-      Chi::log.Log0Verbose1() << "Done building indices.";
+    Chi::log.Log0Verbose1() << "Done building indices.";
 
-      //======================================== Copy to raw arrays
-      int64_t* i_indices_raw;
-      int64_t* j_indices_raw;
-      PetscMalloc(i_indices.size() * sizeof(int64_t), &i_indices_raw);
-      PetscMalloc(j_indices.size() * sizeof(int64_t), &j_indices_raw);
+    //======================================== Copy to raw arrays
+    int64_t* i_indices_raw;
+    int64_t* j_indices_raw;
+    PetscMalloc(i_indices.size() * sizeof(int64_t), &i_indices_raw);
+    PetscMalloc(j_indices.size() * sizeof(int64_t), &j_indices_raw);
 
-      for (int64_t j = 0; j < static_cast<int64_t>(i_indices.size()); ++j)
-        i_indices_raw[j] = i_indices[j];
+    for (int64_t j = 0; j < static_cast<int64_t>(i_indices.size()); ++j)
+      i_indices_raw[j] = i_indices[j];
 
-      for (int64_t j = 0; j < static_cast<int64_t>(j_indices.size()); ++j)
-        j_indices_raw[j] = j_indices[j];
+    for (int64_t j = 0; j < static_cast<int64_t>(j_indices.size()); ++j)
+      j_indices_raw[j] = j_indices[j];
 
-      Chi::log.Log0Verbose1() << "Done copying to raw indices.";
+    Chi::log.Log0Verbose1() << "Done copying to raw indices.";
 
-      //========================================= Create adjacency matrix
-      Mat Adj; // Adjacency matrix
-      MatCreateMPIAdj(PETSC_COMM_SELF,
-                      (int64_t)num_raw_cells,
-                      (int64_t)num_raw_cells,
-                      i_indices_raw,
-                      j_indices_raw,
-                      nullptr,
-                      &Adj);
+    //========================================= Create adjacency matrix
+    Mat Adj; // Adjacency matrix
+    MatCreateMPIAdj(PETSC_COMM_SELF,
+                    (int64_t)num_raw_cells,
+                    (int64_t)num_raw_cells,
+                    i_indices_raw,
+                    j_indices_raw,
+                    nullptr,
+                    &Adj);
 
-      Chi::log.Log0Verbose1() << "Done creating adjacency matrix.";
+    Chi::log.Log0Verbose1() << "Done creating adjacency matrix.";
 
-      //========================================= Create partitioning
-      MatPartitioning part;
-      IS is, isg;
-      MatPartitioningCreate(MPI_COMM_SELF, &part);
-      MatPartitioningSetAdjacency(part, Adj);
-      MatPartitioningSetType(part, type_.c_str());
-      MatPartitioningSetNParts(part, Chi::mpi.process_count);
-      MatPartitioningApply(part, &is);
-      MatPartitioningDestroy(&part);
-      MatDestroy(&Adj);
-      ISPartitioningToNumbering(is, &isg);
-      Chi::log.Log0Verbose1() << "Done building paritioned index set.";
+    //========================================= Create partitioning
+    MatPartitioning part;
+    IS is, isg;
+    MatPartitioningCreate(MPI_COMM_SELF, &part);
+    MatPartitioningSetAdjacency(part, Adj);
+    MatPartitioningSetType(part, type_.c_str());
+    MatPartitioningSetNParts(part, number_of_parts);
+    MatPartitioningApply(part, &is);
+    MatPartitioningDestroy(&part);
+    MatDestroy(&Adj);
+    ISPartitioningToNumbering(is, &isg);
+    Chi::log.Log0Verbose1() << "Done building paritioned index set.";
 
-      //========================================= Get cell global indices
-      const int64_t* cell_pids_raw;
-      ISGetIndices(is, &cell_pids_raw);
-      for (size_t i = 0; i < num_raw_cells; ++i)
-        cell_pids[i] = cell_pids_raw[i];
-      ISRestoreIndices(is, &cell_pids_raw);
+    //========================================= Get cell global indices
+    const int64_t* cell_pids_raw;
+    ISGetIndices(is, &cell_pids_raw);
+    for (size_t i = 0; i < num_raw_cells; ++i)
+      cell_pids[i] = cell_pids_raw[i];
+    ISRestoreIndices(is, &cell_pids_raw);
 
-      Chi::log.Log0Verbose1() << "Done retrieving cell global indices.";
-    } // if more than 1 cell
-  }   // if home location
-
-  //======================================== Broadcast partitioning to all
-  //                                         locations
-  MPI_Bcast(cell_pids.data(),                // buffer [IN/OUT]
-            static_cast<int>(num_raw_cells), // count
-            MPI_LONG_LONG_INT,               // data type
-            0,                               // root
-            Chi::mpi.comm);                  // communicator
+    Chi::log.Log0Verbose1() << "Done retrieving cell global indices.";
+  } // if more than 1 cell
 
   Chi::log.Log0Verbose1() << "Done partitioning with PETScGraphPartitioner";
   return cell_pids;

--- a/framework/mesh/MeshGenerator/FromFileMeshGenerator.cc
+++ b/framework/mesh/MeshGenerator/FromFileMeshGenerator.cc
@@ -20,7 +20,7 @@ chi::InputParameters FromFileMeshGenerator::GetInputParameters()
 
   params.SetGeneralDescription("Generator for loading an unpartitioned mesh"
                                " from a file.");
-  params.SetDocGroup("MeshGenerator");
+  params.SetDocGroup("doc_MeshGenerators");
 
   params.AddRequiredParameter<std::string>("filename", "Path to the file.");
   params.AddOptionalParameter(

--- a/framework/mesh/MeshGenerator/MeshGenerator.cc
+++ b/framework/mesh/MeshGenerator/MeshGenerator.cc
@@ -104,7 +104,7 @@ void MeshGenerator::Execute()
   if (Chi::mpi.location_id == 0)
     cell_pids = PartitionMesh(*current_umesh, Chi::mpi.process_count);
 
-  BroadCastPIDs(cell_pids, 0, Chi::mpi.comm);
+  BroadcastPIDs(cell_pids, 0, Chi::mpi.comm);
 
   auto grid_ptr = SetupMesh(std::move(current_umesh), cell_pids);
 
@@ -121,15 +121,15 @@ void MeshGenerator::Execute()
   Chi::mpi.Barrier();
 }
 
-void MeshGenerator::SetGridAttributes(chi_mesh::MeshContinuum& grid,
-                                      MeshAttributes new_attribs,
-                                      std::array<size_t, 3> ortho_Nis)
+void MeshGenerator::SetGridAttributes(
+  chi_mesh::MeshContinuum& grid,
+  MeshAttributes new_attribs,
+  std::array<size_t, 3> ortho_cells_per_dimension)
 {
-  grid.SetAttributes(new_attribs, ortho_Nis);
+  grid.SetAttributes(new_attribs, ortho_cells_per_dimension);
 }
 
-void MeshGenerator::ComputeAndPrintStats(
-  const chi_mesh::MeshContinuum& grid)
+void MeshGenerator::ComputeAndPrintStats(const chi_mesh::MeshContinuum& grid)
 {
   const size_t num_local_cells = grid.local_cells.size();
   size_t num_global_cells = 0;

--- a/framework/mesh/MeshGenerator/MeshGenerator.cc
+++ b/framework/mesh/MeshGenerator/MeshGenerator.cc
@@ -3,13 +3,14 @@
 #include "mesh/UnpartitionedMesh/chi_unpartitioned_mesh.h"
 #include "mesh/MeshHandler/chi_meshhandler.h"
 #include "mesh/VolumeMesher/chi_volumemesher.h"
+#include "mesh/MeshContinuum/chi_meshcontinuum.h"
 #include "graphs/GraphPartitioner.h"
 #include "graphs/PETScGraphPartitioner.h"
 
 #include "ChiObjectFactory.h"
 
 #include "chi_runtime.h"
-#include "chi_log.h" // TODO: Remove
+#include "chi_log.h"
 
 namespace chi_mesh
 {
@@ -21,7 +22,7 @@ chi::InputParameters MeshGenerator::GetInputParameters()
   chi::InputParameters params = ChiObject::GetInputParameters();
 
   params.SetGeneralDescription("The base class for all mesh generators");
-  params.SetDocGroup("MeshGenerator");
+  params.SetDocGroup("doc_MeshGenerators");
 
   params.AddOptionalParameter(
     "scale", 1.0, "Uniform scale to apply to the mesh after reading.");
@@ -98,7 +99,14 @@ void MeshGenerator::Execute()
 
   //======================================== Generate final umesh and convert it
   current_umesh = GenerateUnpartitionedMesh(std::move(current_umesh));
-  auto grid_ptr = SetupMesh(std::move(current_umesh));
+
+  std::vector<int64_t> cell_pids;
+  if (Chi::mpi.location_id == 0)
+    cell_pids = PartitionMesh(*current_umesh, Chi::mpi.process_count);
+
+  BroadCastPIDs(cell_pids, 0, Chi::mpi.comm);
+
+  auto grid_ptr = SetupMesh(std::move(current_umesh), cell_pids);
 
   //======================================== Assign the mesh to a VolumeMesher
   auto new_mesher =
@@ -111,6 +119,72 @@ void MeshGenerator::Execute()
   cur_hndlr.SetVolumeMesher(new_mesher);
 
   Chi::mpi.Barrier();
+}
+
+void MeshGenerator::SetGridAttributes(chi_mesh::MeshContinuum& grid,
+                                      MeshAttributes new_attribs,
+                                      std::array<size_t, 3> ortho_Nis)
+{
+  grid.SetAttributes(new_attribs, ortho_Nis);
+}
+
+void MeshGenerator::ComputeAndPrintStats(
+  const chi_mesh::MeshContinuum& grid)
+{
+  const size_t num_local_cells = grid.local_cells.size();
+  size_t num_global_cells = 0;
+
+  MPI_Allreduce(&num_local_cells,       // sendbuf
+                &num_global_cells,      // recvbuf
+                1,                      // count
+                MPI_UNSIGNED_LONG_LONG, // datatype
+                MPI_SUM,                // operation
+                Chi::mpi.comm);         // communicator
+
+  size_t max_num_local_cells;
+  MPI_Allreduce(&num_local_cells,       // sendbuf
+                &max_num_local_cells,   // recvbuf
+                1,                      // count
+                MPI_UNSIGNED_LONG_LONG, // datatype
+                MPI_MAX,                // operation
+                Chi::mpi.comm);         // communicator
+
+  size_t min_num_local_cells;
+  MPI_Allreduce(&num_local_cells,       // sendbuf
+                &min_num_local_cells,   // recvbuf
+                1,                      // count
+                MPI_UNSIGNED_LONG_LONG, // datatype
+                MPI_MIN,                // operation
+                Chi::mpi.comm);         // communicator
+
+  const size_t avg_num_local_cells = num_global_cells / Chi::mpi.process_count;
+  const size_t num_local_ghosts = grid.cells.GetNumGhosts();
+  const double local_ghost_to_local_cell_ratio =
+    double(num_local_ghosts) / double(num_local_cells);
+
+  double average_ghost_ratio;
+  MPI_Allreduce(&local_ghost_to_local_cell_ratio, // sendbuf
+                &average_ghost_ratio,             // recvbuf
+                1,                                // count
+                MPI_DOUBLE,                       // datatype
+                MPI_SUM,                          // operation
+                Chi::mpi.comm);                   // communicator
+
+  average_ghost_ratio /= Chi::mpi.process_count;
+
+  std::stringstream outstr;
+  outstr << "Mesh statistics:\n";
+  outstr << "  Global cell count             : " << num_global_cells << "\n";
+  outstr << "  Local cell count (avg,max,min): ";
+  outstr << avg_num_local_cells << ",";
+  outstr << max_num_local_cells << ",";
+  outstr << min_num_local_cells << "\n";
+  outstr << "  Ghost-to-local ratio (avg)    : " << average_ghost_ratio;
+
+  Chi::log.Log() << "\n" << outstr.str() << "\n\n";
+
+  Chi::log.LogAllVerbose2()
+    << Chi::mpi.location_id << "Local cells=" << num_local_cells;
 }
 
 } // namespace chi_mesh

--- a/framework/mesh/MeshGenerator/MeshGenerator.h
+++ b/framework/mesh/MeshGenerator/MeshGenerator.h
@@ -40,30 +40,63 @@ public:
   static chi::InputParameters GetInputParameters();
   explicit MeshGenerator(const chi::InputParameters& params);
 
-protected:
   /**Virtual method to generate the unpartitioned mesh for the next step.*/
   virtual std::unique_ptr<UnpartitionedMesh>
   GenerateUnpartitionedMesh(std::unique_ptr<UnpartitionedMesh> input_umesh);
 
+  struct VertexListHelper
+  {
+    virtual const chi_mesh::Vertex& at(uint64_t vid) const = 0;
+  };
+  template <typename T>
+  struct STLVertexListHelper : public VertexListHelper
+  {
+    explicit STLVertexListHelper(const T& list) : list_(list) {}
+    const chi_mesh::Vertex& at(uint64_t vid) const override
+    {
+      return list_.at(vid);
+    };
+    const T& list_;
+  };
+
+protected:
   // 01
+  /**Builds a cell-graph and executes the partitioner that assigns cell
+   * partition ids based on the supplied number of parts.*/
+  std::vector<int64_t> PartitionMesh(const UnpartitionedMesh& input_umesh,
+                                     int num_parts);
+
   /**Executes the partitioner and configures the mesh as a real mesh.*/
-  virtual std::shared_ptr<MeshContinuum>
-  SetupMesh(std::unique_ptr<UnpartitionedMesh> input_umesh_ptr);
+  std::shared_ptr<MeshContinuum>
+  SetupMesh(std::unique_ptr<UnpartitionedMesh> input_umesh_ptr,
+            const std::vector<int64_t>& cell_pids);
 
   // 02 utils
+  /**Broadcasts PIDs to other locations.*/
+
+  static void BroadCastPIDs(std::vector<int64_t>& cell_pids,
+                            int root,
+                            MPI_Comm communicator);
   /**Determines if a cells needs to be included as a ghost or as a local cell.*/
   bool
-  CellHasLocalScope(const chi_mesh::UnpartitionedMesh::LightWeightCell& lwcell,
+  CellHasLocalScope(int location_id,
+                    const chi_mesh::UnpartitionedMesh::LightWeightCell& lwcell,
                     uint64_t cell_global_id,
                     const std::vector<std::set<uint64_t>>& vertex_subscriptions,
-                    const std::vector<int64_t>& cell_partition_ids);
+                    const std::vector<int64_t>& cell_partition_ids) const;
 
   /**Converts a light-weight cell to a real cell.*/
   static std::unique_ptr<chi_mesh::Cell>
   SetupCell(const UnpartitionedMesh::LightWeightCell& raw_cell,
             uint64_t global_id,
             uint64_t partition_id,
-            const std::vector<chi_mesh::Vector3>& vertices);
+            const VertexListHelper& vertices);
+
+  static void SetGridAttributes(chi_mesh::MeshContinuum& grid,
+                                MeshAttributes new_attribs,
+                                std::array<size_t, 3> ortho_Nis);
+
+  static void ComputeAndPrintStats(const chi_mesh::MeshContinuum& grid) ;
 
   const double scale_;
   const bool replicated_;

--- a/framework/mesh/MeshGenerator/MeshGenerator.h
+++ b/framework/mesh/MeshGenerator/MeshGenerator.h
@@ -62,9 +62,9 @@ public:
 protected:
   // 01
   /**Builds a cell-graph and executes the partitioner that assigns cell
-   * partition ids based on the supplied number of parts.*/
+   * partition ids based on the supplied number of partitions.*/
   std::vector<int64_t> PartitionMesh(const UnpartitionedMesh& input_umesh,
-                                     int num_parts);
+                                     int num_partitions);
 
   /**Executes the partitioner and configures the mesh as a real mesh.*/
   std::shared_ptr<MeshContinuum>
@@ -74,7 +74,7 @@ protected:
   // 02 utils
   /**Broadcasts PIDs to other locations.*/
 
-  static void BroadCastPIDs(std::vector<int64_t>& cell_pids,
+  static void BroadcastPIDs(std::vector<int64_t>& cell_pids,
                             int root,
                             MPI_Comm communicator);
   /**Determines if a cells needs to be included as a ghost or as a local cell.*/
@@ -94,7 +94,7 @@ protected:
 
   static void SetGridAttributes(chi_mesh::MeshContinuum& grid,
                                 MeshAttributes new_attribs,
-                                std::array<size_t, 3> ortho_Nis);
+                                std::array<size_t, 3> ortho_cells_per_dimension);
 
   static void ComputeAndPrintStats(const chi_mesh::MeshContinuum& grid) ;
 

--- a/framework/mesh/MeshGenerator/MeshGenerator_01_setupmesh.cc
+++ b/framework/mesh/MeshGenerator/MeshGenerator_01_setupmesh.cc
@@ -11,7 +11,7 @@ namespace chi_mesh
 /**Builds a cell-graph and executes the partitioner.*/
 std::vector<int64_t>
 MeshGenerator::PartitionMesh(const UnpartitionedMesh& input_umesh,
-                             int num_parts)
+                             int num_partitions)
 {
   const auto& raw_cells = input_umesh.GetRawCells();
   const size_t num_raw_cells = raw_cells.size();
@@ -43,7 +43,7 @@ MeshGenerator::PartitionMesh(const UnpartitionedMesh& input_umesh,
 
   //============================================= Execute partitioner
   std::vector<int64_t> cell_pids =
-    partitioner_->Partition(cell_graph, cell_centroids, num_parts);
+    partitioner_->Partition(cell_graph, cell_centroids, num_partitions);
 
   return cell_pids;
 }

--- a/framework/mesh/MeshGenerator/MeshGenerator_02_utils.cc
+++ b/framework/mesh/MeshGenerator/MeshGenerator_02_utils.cc
@@ -5,7 +5,7 @@ namespace chi_mesh
 
 // ###################################################################
 /**Broadcasts PIDs to other locations.*/
-void MeshGenerator::BroadCastPIDs(std::vector<int64_t>& cell_pids,
+void MeshGenerator::BroadcastPIDs(std::vector<int64_t>& cell_pids,
                                   int root,
                                   MPI_Comm communicator)
 {

--- a/framework/mesh/MeshGenerator/OrthogonalMeshGenerator.cc
+++ b/framework/mesh/MeshGenerator/OrthogonalMeshGenerator.cc
@@ -48,6 +48,10 @@ OrthogonalMeshGenerator::OrthogonalMeshGenerator(
     node_sets_.empty(),
     "No nodes have been provided. At least one node set must be provided");
 
+  ChiInvalidArgumentIf(node_sets_.size() > 3,
+                       "More than 3 node sets have been provided. The "
+                       "maximum allowed is 3.");
+
   size_t ns = 0;
   for (const auto& node_set : node_sets_)
   {
@@ -58,10 +62,6 @@ OrthogonalMeshGenerator::OrthogonalMeshGenerator(
         " nodes. A minimum of 2 is required to define a cell.");
     ++ns;
   }
-
-  ChiInvalidArgumentIf(node_sets_.size() > 3,
-                       "More than 3 node sets have been provided. Only a "
-                       "maximum of 3 are allowed");
 
   //======================================== Check each node_set
   size_t set_number = 0;
@@ -391,7 +391,7 @@ OrthogonalMeshGenerator::CreateUnpartitioned3DOrthoMesh(
                                                   vmap[i + 1][j + 1][k],
                                                   vmap[i + 1][j + 1][k + 1],
                                                   vmap[i][j + 1][k + 1]};
-          face.neighbor = (j == max_j) ? 0 /*XMAX*/ : cmap[i][j+1][k];
+          face.neighbor = (j == max_j) ? 0 /*XMAX*/ : cmap[i][j + 1][k];
           face.has_neighbor = (j != max_j);
           cell->faces.push_back(face);
         }
@@ -403,7 +403,7 @@ OrthogonalMeshGenerator::CreateUnpartitioned3DOrthoMesh(
                                                   vmap[i][j][k + 1],
                                                   vmap[i + 1][j][k + 1],
                                                   vmap[i + 1][j][k]};
-          face.neighbor = (j == 0) ? 1 /*XMIN*/ : cmap[i][j-1][k];
+          face.neighbor = (j == 0) ? 1 /*XMIN*/ : cmap[i][j - 1][k];
           face.has_neighbor = (j != 0);
           cell->faces.push_back(face);
         }
@@ -415,7 +415,7 @@ OrthogonalMeshGenerator::CreateUnpartitioned3DOrthoMesh(
                                                   vmap[i + 1][j][k + 1],
                                                   vmap[i + 1][j + 1][k + 1],
                                                   vmap[i + 1][j + 1][k]};
-          face.neighbor = (i == max_i) ? 2 /*YMAX*/ : cmap[i+1][j][k];
+          face.neighbor = (i == max_i) ? 2 /*YMAX*/ : cmap[i + 1][j][k];
           face.has_neighbor = (i != max_i);
           cell->faces.push_back(face);
         }
@@ -427,7 +427,7 @@ OrthogonalMeshGenerator::CreateUnpartitioned3DOrthoMesh(
                                                   vmap[i][j + 1][k],
                                                   vmap[i][j + 1][k + 1],
                                                   vmap[i][j][k + 1]};
-          face.neighbor = (i == 0) ? 3 /*YMIN*/ : cmap[i-1][j][k];
+          face.neighbor = (i == 0) ? 3 /*YMIN*/ : cmap[i - 1][j][k];
           face.has_neighbor = (i != 0);
           cell->faces.push_back(face);
         }
@@ -439,7 +439,7 @@ OrthogonalMeshGenerator::CreateUnpartitioned3DOrthoMesh(
                                                   vmap[i][j + 1][k + 1],
                                                   vmap[i + 1][j + 1][k + 1],
                                                   vmap[i + 1][j][k + 1]};
-          face.neighbor = (k == max_k) ? 4 /*ZMAX*/ : cmap[i][j][k+1];
+          face.neighbor = (k == max_k) ? 4 /*ZMAX*/ : cmap[i][j][k + 1];
           face.has_neighbor = (k != max_k);
           cell->faces.push_back(face);
         }
@@ -451,7 +451,7 @@ OrthogonalMeshGenerator::CreateUnpartitioned3DOrthoMesh(
                                                   vmap[i + 1][j][k],
                                                   vmap[i + 1][j + 1][k],
                                                   vmap[i][j + 1][k]};
-          face.neighbor = (k == 0) ? 5 /*ZMIN*/ : cmap[i][j][k-1];
+          face.neighbor = (k == 0) ? 5 /*ZMIN*/ : cmap[i][j][k - 1];
           face.has_neighbor = (k != 0);
           cell->faces.push_back(face);
         }

--- a/framework/mesh/MeshGenerator/SplitFileMeshGenerator.cc
+++ b/framework/mesh/MeshGenerator/SplitFileMeshGenerator.cc
@@ -32,11 +32,12 @@ chi::InputParameters SplitFileMeshGenerator::GetInputParameters()
     " mesh files for each location.");
   params.SetDocGroup("doc_MeshGenerators");
 
-  params.AddOptionalParameter("num_parts",
-                              0,
-                              "The number of parts to generate. If zero will "
-                              "default to the number of MPI processes. Is "
-                              "ignored if the number of MPI processes > 1.");
+  params.AddOptionalParameter(
+    "num_partitions",
+    0,
+    "The number of partitions to generate. If zero will "
+    "default to the number of MPI processes. Is "
+    "ignored if the number of MPI processes > 1.");
 
   params.AddOptionalParameter(
     "split_mesh_dir_path",
@@ -59,7 +60,7 @@ chi::InputParameters SplitFileMeshGenerator::GetInputParameters()
 SplitFileMeshGenerator::SplitFileMeshGenerator(
   const chi::InputParameters& params)
   : MeshGenerator(params),
-    num_parts_(params.GetParamValue<int>("num_parts")),
+    num_parts_(params.GetParamValue<int>("num_partitions")),
     split_mesh_dir_path_(
       params.GetParamValue<std::string>("split_mesh_dir_path")),
     split_file_prefix_(params.GetParamValue<std::string>("split_file_prefix")),

--- a/framework/mesh/MeshGenerator/SplitFileMeshGenerator.cc
+++ b/framework/mesh/MeshGenerator/SplitFileMeshGenerator.cc
@@ -1,0 +1,398 @@
+#include "SplitFileMeshGenerator.h"
+
+#include "data_types/byte_array.h"
+#include "utils/chi_utils.h"
+
+#include "mesh/MeshHandler/chi_meshhandler.h"
+#include "mesh/VolumeMesher/chi_volumemesher.h"
+#include "mesh/MeshContinuum/chi_meshcontinuum.h"
+
+#include "chi_log.h"
+#include "utils/chi_timer.h"
+
+#include "ChiObjectFactory.h"
+
+#include <filesystem>
+
+#define scint static_cast<int>
+
+namespace chi_mesh
+{
+
+RegisterChiObject(chi_mesh, SplitFileMeshGenerator);
+
+// ##################################################################
+chi::InputParameters SplitFileMeshGenerator::GetInputParameters()
+{
+  chi::InputParameters params = MeshGenerator::GetInputParameters();
+
+  params.SetGeneralDescription(
+    "Generates the mesh only on location 0, thereafter partitions the mesh"
+    " but instead of broadcasting the mesh to other locations it creates binary"
+    " mesh files for each location.");
+  params.SetDocGroup("doc_MeshGenerators");
+
+  params.AddOptionalParameter("num_parts",
+                              0,
+                              "The number of parts to generate. If zero will "
+                              "default to the number of MPI processes. Is "
+                              "ignored if the number of MPI processes > 1.");
+
+  params.AddOptionalParameter(
+    "split_mesh_dir_path",
+    "SplitMesh",
+    "Path of the directory to be created for containing the split meshes.");
+
+  params.AddOptionalParameter("split_file_prefix",
+                              "split_mesh",
+                              "Prefix to use for all split mesh files");
+
+  params.AddOptionalParameter(
+    "read_only",
+    false,
+    "Controls whether the split mesh is recreated or just read.");
+
+  return params;
+}
+
+// ##################################################################
+SplitFileMeshGenerator::SplitFileMeshGenerator(
+  const chi::InputParameters& params)
+  : MeshGenerator(params),
+    num_parts_(params.GetParamValue<int>("num_parts")),
+    split_mesh_dir_path_(
+      params.GetParamValue<std::string>("split_mesh_dir_path")),
+    split_file_prefix_(params.GetParamValue<std::string>("split_file_prefix")),
+    read_only_(params.GetParamValue<bool>("read_only"))
+{
+}
+
+// ##################################################################
+void SplitFileMeshGenerator::Execute()
+{
+  const int num_mpi = Chi::mpi.process_count;
+  const int num_parts = num_mpi == 1 ? num_parts_ : num_mpi;
+
+  if (Chi::mpi.location_id == 0 and (not read_only_))
+  {
+    //======================================== Execute all input generators
+    // Note these could be empty
+    std::unique_ptr<UnpartitionedMesh> current_umesh = nullptr;
+    for (auto mesh_generator_ptr : inputs_)
+    {
+      auto new_umesh =
+        mesh_generator_ptr->GenerateUnpartitionedMesh(std::move(current_umesh));
+      current_umesh = std::move(new_umesh);
+    }
+
+    //======================================== Generate final umesh
+    current_umesh = GenerateUnpartitionedMesh(std::move(current_umesh));
+
+    Chi::log.Log() << "Writing split-mesh with " << num_parts << " parts";
+    const auto cell_pids = PartitionMesh(*current_umesh, num_parts);
+    WriteSplitMesh(cell_pids, *current_umesh, num_parts);
+    Chi::log.Log() << "Split-mesh with " << num_parts
+                   << " parts successfully created";
+  } // if home location
+
+  // Other locations wait here for files to be written
+  Chi::mpi.Barrier();
+
+  if (Chi::mpi.process_count == num_parts)
+  {
+    Chi::log.Log() << "Reading split-mesh";
+    auto mesh_info = ReadSplitMesh();
+
+    auto grid_ptr = SetupLocalMesh(mesh_info);
+
+    auto new_mesher =
+      std::make_shared<chi_mesh::VolumeMesher>(VolumeMesherType::UNPARTITIONED);
+    new_mesher->SetContinuum(grid_ptr);
+
+    if (Chi::current_mesh_handler < 0) chi_mesh::PushNewHandlerAndGetIndex();
+
+    auto& cur_hndlr = chi_mesh::GetCurrentHandler();
+    cur_hndlr.SetVolumeMesher(new_mesher);
+    Chi::log.Log() << "Done reading split-mesh files";
+  }
+  else
+  {
+    Chi::log.Log0Warning()
+      << "After creating a split-mesh with mpi-processes < "
+         "num_parts the program will now auto terminate. This is not an error "
+         "and is the default behavior for the SplitFileMeshGenerator.";
+    Chi::Exit(EXIT_SUCCESS);
+  }
+
+  Chi::mpi.Barrier();
+}
+
+// ##################################################################
+void SplitFileMeshGenerator::WriteSplitMesh(
+  const std::vector<int64_t>& cell_pids,
+  const UnpartitionedMesh& umesh,
+  int num_parts)
+{
+  const std::filesystem::path dir_path =
+    std::filesystem::absolute(split_mesh_dir_path_);
+
+  const auto parent_path = dir_path.parent_path();
+  ChiInvalidArgumentIf(not std::filesystem::exists(parent_path),
+                       "Parent path " + parent_path.string() +
+                         " does not exist");
+
+  bool root_dir_created = true;
+  if (not std::filesystem::exists(dir_path))
+    root_dir_created = std::filesystem::create_directories(dir_path);
+
+  ChiLogicalErrorIf(not root_dir_created,
+                    "Failed to create directory " + dir_path.string());
+
+  const auto& vertex_subs = umesh.GetVertextCellSubscriptions();
+  const auto& raw_cells = umesh.GetRawCells();
+  const auto& raw_vertices = umesh.GetVertices();
+
+  for (int pid = 0; pid < num_parts; ++pid)
+  {
+    const std::filesystem::path file_path = dir_path.string() + "/" +
+                                            split_file_prefix_ + "_" +
+                                            std::to_string(pid) + ".cmesh";
+
+    std::ofstream ofile(file_path.string(),
+                        std::ios_base::binary | std::ios_base::out);
+
+    ChiLogicalErrorIf(not ofile.is_open(),
+                      "Failed to open " + file_path.string());
+
+    // Appropriate cells and vertices to the current part being writting
+    std::vector<CellPIDGID> cells_needed;
+    std::set<uint64_t> vertices_needed;
+    {
+      uint64_t cell_global_id = 0;
+      for (const auto& raw_cell : raw_cells)
+      {
+        const auto cell_pid = cell_pids[cell_global_id];
+        if (CellHasLocalScope(
+              pid, *raw_cell, cell_global_id, vertex_subs, cell_pids))
+        {
+          cells_needed.emplace_back(cell_pid, cell_global_id);
+
+          for (uint64_t vid : raw_cell->vertex_ids)
+            vertices_needed.insert(vid);
+        }
+        ++cell_global_id;
+      } // for raw cell
+    }
+
+    //================================================ Write mesh attributes
+    //                                                 and general info
+    const auto& mesh_options = umesh.GetMeshOptions();
+
+    chi::WriteBinaryValue(ofile, num_parts); // int
+
+    chi::WriteBinaryValue(ofile, scint(umesh.GetMeshAttributes())); // int
+    chi::WriteBinaryValue(ofile, mesh_options.ortho_Nx);            // size_t
+    chi::WriteBinaryValue(ofile, mesh_options.ortho_Ny);            // size_t
+    chi::WriteBinaryValue(ofile, mesh_options.ortho_Nz);            // size_t
+
+    chi::WriteBinaryValue(ofile, raw_vertices.size()); // size_t
+
+    //================================================ Write the boundary map
+    const auto& bndry_map = mesh_options.boundary_id_map;
+    chi::WriteBinaryValue(ofile, bndry_map.size()); // size_t
+    for (const auto& [bid, bname] : bndry_map)
+    {
+      chi::WriteBinaryValue(ofile, bid); // uint64_t
+      const size_t num_chars = bname.size();
+      chi::WriteBinaryValue(ofile, num_chars);     // size_t
+      ofile.write(bname.data(), scint(num_chars)); // characters
+    }
+
+    //================================================ Write how many cells
+    //                                                 and vertices in file
+    chi::WriteBinaryValue(ofile, cells_needed.size());    // size_t
+    chi::WriteBinaryValue(ofile, vertices_needed.size()); // size_t
+
+    //================================================ Write cells
+    for (const auto& [cell_pid, cell_global_id] : cells_needed)
+    {
+      const auto& cell = *raw_cells.at(cell_global_id);
+      chi_data_types::ByteArray serial_data;
+      serial_data.Write(cell_pid);       // int
+      serial_data.Write(cell_global_id); // uint64_t
+      SerializeCell(cell, serial_data);
+      ofile.write((char*)serial_data.Data().data(), scint(serial_data.Size()));
+    }
+
+    //================================================ Write vertices
+    for (const uint64_t vid : vertices_needed)
+    {
+      chi_data_types::ByteArray serial_data;
+      serial_data.Write(vid); // uint64_t
+      serial_data.Write(raw_vertices[vid]);
+      ofile.write((char*)serial_data.Data().data(), scint(serial_data.Size()));
+    }
+
+    ofile.close();
+  } // for p
+}
+
+// ##################################################################
+void SplitFileMeshGenerator::SerializeCell(
+  const UnpartitionedMesh::LightWeightCell& cell,
+  chi_data_types::ByteArray& serial_buffer)
+{
+  serial_buffer.Write(cell.type);
+  serial_buffer.Write(cell.sub_type);
+  serial_buffer.Write(cell.centroid);
+  serial_buffer.Write(cell.material_id);
+  serial_buffer.Write(cell.vertex_ids.size());
+  for (uint64_t vid : cell.vertex_ids)
+    serial_buffer.Write(vid);
+  serial_buffer.Write(cell.faces.size());
+  for (const auto& face : cell.faces)
+  {
+    serial_buffer.Write(face.vertex_ids.size());
+    for (uint64_t vid : face.vertex_ids)
+      serial_buffer.Write(vid);
+    serial_buffer.Write(face.has_neighbor);
+    serial_buffer.Write(face.neighbor);
+  }
+}
+
+SplitFileMeshGenerator::SplitMeshInfo SplitFileMeshGenerator::ReadSplitMesh()
+{
+  const int pid = Chi::mpi.location_id;
+  const std::filesystem::path dir_path =
+    std::filesystem::absolute(split_mesh_dir_path_);
+  const std::filesystem::path file_path = dir_path.string() + "/" +
+                                          split_file_prefix_ + "_" +
+                                          std::to_string(pid) + ".cmesh";
+
+  SplitMeshInfo info_block;
+  auto& cells = info_block.cells_;
+  auto& vertices = info_block.vertices_;
+  std::ifstream ifile(file_path, std::ios_base::binary | std::ios_base::in);
+
+  ChiLogicalErrorIf(not ifile.is_open(),
+                    "Failed to open " + file_path.string());
+
+  //================================================== Read mesh attributes
+  //                                                   and general info
+  const size_t file_num_parts = chi::ReadBinaryValue<int>(ifile);
+
+  ChiLogicalErrorIf(Chi::mpi.process_count != file_num_parts,
+                    "Split mesh files with prefix \"" + split_file_prefix_ +
+                      "\" has been created with " +
+                      std::to_string(file_num_parts) +
+                      " parts but is now being read with " +
+                      std::to_string(Chi::mpi.process_count) + " processes.");
+
+  info_block.mesh_attributes_ = chi::ReadBinaryValue<int>(ifile);
+  info_block.ortho_Nx_ = chi::ReadBinaryValue<size_t>(ifile);
+  info_block.ortho_Ny_ = chi::ReadBinaryValue<size_t>(ifile);
+  info_block.ortho_Nz_ = chi::ReadBinaryValue<size_t>(ifile);
+
+  info_block.num_global_vertices_ = chi::ReadBinaryValue<size_t>(ifile);
+
+  //================================================== Read boundary map
+  const size_t num_bndries = chi::ReadBinaryValue<size_t>(ifile);
+  for (size_t b = 0; b < num_bndries; ++b)
+  {
+    const uint64_t bid = chi::ReadBinaryValue<uint64_t>(ifile);
+    const size_t num_chars = chi::ReadBinaryValue<size_t>(ifile);
+    std::string bname(num_chars, ' ');
+    ifile.read(bname.data(), static_cast<int>(num_chars));
+
+    info_block.boundary_id_map_.insert(std::make_pair(bid, bname));
+  }
+
+  //================================================ Write how many cells
+  //                                                 and vertices in file
+  const size_t num_cells = chi::ReadBinaryValue<size_t>(ifile);
+  const size_t num_vertices = chi::ReadBinaryValue<size_t>(ifile);
+
+  //================================================== Read the cells
+  for (size_t c = 0; c < num_cells; ++c)
+  {
+    const int cell_pid = chi::ReadBinaryValue<int>(ifile);
+    const uint64_t cell_gid = chi::ReadBinaryValue<uint64_t>(ifile);
+    const CellType cell_type = chi::ReadBinaryValue<CellType>(ifile);
+    const CellType cell_sub_type = chi::ReadBinaryValue<CellType>(ifile);
+
+    UnpartitionedMesh::LightWeightCell new_cell(cell_type, cell_sub_type);
+
+    new_cell.centroid = chi::ReadBinaryValue<chi_mesh::Vector3>(ifile);
+    new_cell.material_id = chi::ReadBinaryValue<int>(ifile);
+
+    const size_t num_vids = chi::ReadBinaryValue<size_t>(ifile);
+    for (size_t v = 0; v < num_vids; ++v)
+      new_cell.vertex_ids.push_back(chi::ReadBinaryValue<uint64_t>(ifile));
+
+    const size_t num_faces = chi::ReadBinaryValue<size_t>(ifile);
+    for (size_t f = 0; f < num_faces; ++f)
+    {
+      UnpartitionedMesh::LightWeightFace new_face;
+      const size_t num_face_vids = chi::ReadBinaryValue<size_t>(ifile);
+      for (size_t v = 0; v < num_face_vids; ++v)
+        new_face.vertex_ids.push_back(chi::ReadBinaryValue<uint64_t>(ifile));
+
+      new_face.has_neighbor = chi::ReadBinaryValue<bool>(ifile);
+      new_face.neighbor = chi::ReadBinaryValue<uint64_t>(ifile);
+
+      new_cell.faces.push_back(std::move(new_face));
+    } // for f
+
+    cells.insert(
+      std::make_pair(CellPIDGID(cell_pid, cell_gid), std::move(new_cell)));
+  } // for cell c
+
+  //================================================== Read the vertices
+  for (size_t v = 0; v < num_vertices; ++v)
+  {
+    const uint64_t vid = chi::ReadBinaryValue<uint64_t>(ifile);
+    const chi_mesh::Vector3 vertex =
+      chi::ReadBinaryValue<chi_mesh::Vector3>(ifile);
+    vertices.insert(std::make_pair(vid, vertex));
+  } // for vertex v
+
+  ifile.close();
+
+  return info_block;
+}
+
+std::shared_ptr<MeshContinuum>
+SplitFileMeshGenerator::SetupLocalMesh(SplitMeshInfo& mesh_info)
+{
+  auto grid_ptr = chi_mesh::MeshContinuum::New();
+
+  grid_ptr->GetBoundaryIDMap() = mesh_info.boundary_id_map_;
+
+  auto& cells = mesh_info.cells_;
+  auto& vertices = mesh_info.vertices_;
+
+  for (const auto& [vid, vertex] : vertices)
+    grid_ptr->vertices.Insert(vid, vertex);
+
+  for (const auto& [pidgid, raw_cell] : cells)
+  {
+    const auto& [cell_pid, cell_global_id] = pidgid;
+    auto cell = SetupCell(
+      raw_cell, cell_global_id, cell_pid, STLVertexListHelper(vertices));
+
+    grid_ptr->cells.push_back(std::move(cell));
+  }
+
+  SetGridAttributes(
+    *grid_ptr,
+    static_cast<MeshAttributes>(mesh_info.mesh_attributes_),
+    {mesh_info.ortho_Nx_, mesh_info.ortho_Ny_, mesh_info.ortho_Nz_});
+
+  grid_ptr->SetGlobalVertexCount(mesh_info.num_global_vertices_);
+
+  ComputeAndPrintStats(*grid_ptr);
+
+  return grid_ptr;
+}
+
+} // namespace chi_mesh

--- a/framework/mesh/MeshGenerator/SplitFileMeshGenerator.h
+++ b/framework/mesh/MeshGenerator/SplitFileMeshGenerator.h
@@ -1,0 +1,56 @@
+#ifndef CHITECH_SPLITFILEMESHGENERATOR_H
+#define CHITECH_SPLITFILEMESHGENERATOR_H
+
+#include "MeshGenerator.h"
+
+namespace chi_data_types
+{
+class ByteArray;
+}
+
+namespace chi_mesh
+{
+
+/**Generates the mesh only on location 0, thereafter partitions the mesh
+ * but instead of broadcasting the mesh to other locations it creates binary
+ * mesh files for each location.*/
+class SplitFileMeshGenerator : public MeshGenerator
+{
+public:
+  static chi::InputParameters GetInputParameters();
+  explicit SplitFileMeshGenerator(const chi::InputParameters& params);
+
+  void Execute() override;
+
+protected:
+  void WriteSplitMesh(const std::vector<int64_t>& cell_pids,
+                      const UnpartitionedMesh& umesh,
+                      int num_parts);
+  static void SerializeCell(const UnpartitionedMesh::LightWeightCell& cell,
+                            chi_data_types::ByteArray& serial_buffer);
+  typedef std::pair<int, uint64_t> CellPIDGID;
+  struct SplitMeshInfo
+  {
+    std::map<CellPIDGID, UnpartitionedMesh::LightWeightCell> cells_;
+    std::map<uint64_t, chi_mesh::Vector3> vertices_;
+    std::map<uint64_t, std::string> boundary_id_map_;
+    int mesh_attributes_;
+    size_t ortho_Nx_;
+    size_t ortho_Ny_;
+    size_t ortho_Nz_;
+    size_t num_global_vertices_;
+  };
+  SplitMeshInfo ReadSplitMesh();
+
+  static std::shared_ptr<MeshContinuum> SetupLocalMesh(SplitMeshInfo& mesh_info);
+
+  // void
+  const int num_parts_;
+  const std::string split_mesh_dir_path_;
+  const std::string split_file_prefix_;
+  const bool read_only_;
+};
+
+} // namespace chi_mesh
+
+#endif // CHITECH_SPLITFILEMESHGENERATOR_H

--- a/framework/mesh/MeshGenerator/doc/doc_MeshGenerators.h
+++ b/framework/mesh/MeshGenerator/doc/doc_MeshGenerators.h
@@ -1,4 +1,5 @@
-/**\defgroup MeshGenerator Mesh Generators
+/**\defgroup doc_MeshGenerators Mesh Generators
+\ingroup LuaMesh
 *
 We split a `MeshGenerator`'s execution into a
 phase that generates an unpartitioned mesh and a phase that then converts
@@ -127,4 +128,68 @@ chiMeshHandlerExportMeshToVTK("ZMeshTest")
 
 \image html framework/chi_mesh/MeshGenerators/ParExample2.png width=500px
 
-\ingroup LuaMesh*/
+
+## The special SplitFileMeshGenerator
+
+For very large meshes the mesh generation process could both take very long and
+require a lot of memory. The current mode of operation of the mesh generators is
+that each process builds the mesh as an unpartitioned mesh then the mesh gets
+converted to a partitioned mesh. Therefore, when a lot of processes are used,
+there could be a large memory spike, large enough to be greater than what even
+an HPC node has available. To partly address this problem we have the
+\ref chi_mesh__SplitFileMeshGenerator. This generator will process multiple mesh inputs like
+any other mesh generator but instead of building the mesh on each processor only
+the home location builds the mesh. Thereafter the mesh is partitioned and each
+processors' local-cells, ghost-cells, and relevant vertices are written to
+separate binary files. The default folder, into which these files are written,
+is named "SplitMesh" and the default file names for the meshes are
+"split_mesh_x.cmesh", where the x represents the processors rank. Both the
+folder name and file name prefixes (i.e. the "split_mesh" part) can be altered
+via input parameters.
+
+It is also possible to generate split meshes in serial by supplying the
+`num_parts` parameter. Also, if a simulation uses the same mesh over and over
+then the parameter `read_only` can be used to suppress the mesh being
+created every single time.
+
+### SplitFile Example A
+
+\code
+meshgen1 = chi_mesh.SplitFileMeshGenerator.Create
+({
+  inputs =
+  {
+    chi_mesh.OrthogonalMeshGenerator.Create({ node_sets = {xmesh,ymesh,zmesh} })
+  },
+})
+
+chi_mesh.MeshGenerator.Execute(meshgen1)
+\endcode
+
+The examples below will create, in the current working directory, the folder
+`SplitMesh` and within it `split_mesh_0.cmesh`, `split_mesh_1.cmesh`, etc.
+
+### SplitFile Example B
+
+\code
+meshgen1 = chi_mesh.SplitFileMeshGenerator.Create
+({
+  inputs = {
+    chi_mesh.OrthogonalMeshGenerator.Create({ node_sets = {xmesh,ymesh} }),
+    chi_mesh.ExtruderMeshGenerator.Create
+    ({
+      layers = {{z=Lz, n=Nz}}
+    })
+  }
+})
+
+chi_mesh.MeshGenerator.Execute(meshgen1)
+\endcode
+
+This example is the same as the one above it, however, it uses the extruder
+mesh generator in a chain.
+
+\note Partitioning and the other parameters of \ref chi_mesh__SplitFileMeshGenerator are
+identical to that of the base \ref chi_mesh__MeshGenerator.
+
+*/

--- a/framework/mesh/UnpartitionedMesh/unpartmesh_00b_connectivity.cc
+++ b/framework/mesh/UnpartitionedMesh/unpartmesh_00b_connectivity.cc
@@ -165,7 +165,6 @@ void chi_mesh::UnpartitionedMesh::BuildMeshConnectivity()
                               << " Number of boundary faces "
                                  "after connectivity: " << num_bndry_faces;
 
-  Chi::mpi.Barrier();
   Chi::log.Log() << Chi::program_timer.GetTimeString()
                 << " Done establishing cell connectivity.";
 

--- a/framework/utils/chi_timer.cc
+++ b/framework/utils/chi_timer.cc
@@ -2,6 +2,7 @@
 
 #include <cmath>
 #include <ctime>
+#include <thread>
 
 //################################################################### Default constr
 /** Default constructor.*/
@@ -61,4 +62,10 @@ std::string chi::Timer::GetLocalDateTimeString()
   s[29] = '\0';
   if (end < 30)  s[end]='\0';
   return s;
+}
+
+//###################################################################
+void chi::Sleep(std::chrono::duration<double> time)
+{
+  std::this_thread::sleep_for(time);
 }

--- a/framework/utils/chi_timer.h
+++ b/framework/utils/chi_timer.h
@@ -23,6 +23,15 @@ namespace chi
     std::string GetTimeString() const;
     static std::string GetLocalDateTimeString();
   };
+
+  /**Puts the current thread to sleep.
+  * \param time Time to sleep for.
+  *
+  * \note To specify different times `std::chrono` allows
+  * you to change the unit with, e.g.,
+  * `chi::Sleep(std::chrono::milliseconds(100))` sleeps for 100 milliseconds,
+  * `std::Sleep(std::chrono::seconds(1))` sleeps for 1 second.*/
+  void Sleep(std::chrono::duration<double> time);
 }
 
 #endif

--- a/framework/utils/chi_utils.h
+++ b/framework/utils/chi_utils.h
@@ -5,6 +5,7 @@
 #include <string>
 #include <vector>
 #include <algorithm>
+#include <fstream>
 
 /**Miscellaneous utilities. These utilities should have no dependencies.*/
 namespace chi
@@ -72,6 +73,20 @@ inline constexpr uint32_t hash_djb2a(const std::string_view sv)
 inline constexpr uint32_t operator"" _hash(const char* str, size_t len)
 {
   return hash_djb2a(std::string_view{str, len});
+}
+
+template<typename T>
+void WriteBinaryValue(std::ofstream& output_file, T value)
+{
+  output_file.write((char*)&value, sizeof(T));
+}
+template<typename T>
+T ReadBinaryValue(std::ifstream& input_file)
+{
+  T value;
+  input_file.read((char*)&value, sizeof(T));
+
+  return value;
 }
 } // namespace chi
 

--- a/test/framework/chi_mesh/YTests.json
+++ b/test/framework/chi_mesh/YTests.json
@@ -4,7 +4,7 @@
     [
       {
         "type" : "StrCompare",
-        "key" : "MeshGenerator: Cells created = 3242"
+        "key" : "Global cell count             : 3242"
       }
     ]
   }

--- a/test/modules/LinearBoltzmannSolvers/Transport_Steady/Transport3D_6ASplitMesh.lua
+++ b/test/modules/LinearBoltzmannSolvers/Transport_Steady/Transport3D_6ASplitMesh.lua
@@ -1,0 +1,153 @@
+-- 3D Transport test with split-mesh + ortho mesh.
+-- SDM: PWLD
+-- Test: max-grp0(latest) =  1.131566e-01
+--       max-grp19(latest) = 7.340585e-04
+
+num_procs = 4
+
+
+
+
+
+--############################################### Check num_procs
+if (check_num_procs==nil and chi_number_of_processes ~= num_procs) then
+  chiLog(LOG_0ERROR,"Incorrect amount of processors. " ..
+    "Expected "..tostring(num_procs)..
+    ". Pass check_num_procs=false to override if possible.")
+  os.exit(false)
+end
+
+-- Cells
+div = 8
+Nx = math.floor(128/div)
+Ny = math.floor(128/div)
+Nz = math.floor(256/div)
+
+-- Dimensions
+Lx = 10.0
+Ly = 10.0
+Lz = 10.0
+
+xmesh = {}
+xmin = 0.0
+dx = Lx/Nx
+for i = 1, (Nx+1) do
+  k = i-1
+  xmesh[i] = xmin + k*dx
+end
+
+ymesh = {}
+ymin = 0.0
+dy = Ly/Ny
+for i = 1, (Ny+1) do
+  k = i-1
+  ymesh[i] = ymin + k*dy
+end
+
+zmesh = {}
+zmin = 0.0
+dz = Lz/Nz
+for i = 1, (Nz+1) do
+  k = i-1
+  zmesh[i] = zmin + k*dz
+end
+
+meshgen1 = chi_mesh.SplitFileMeshGenerator.Create
+({
+  inputs =
+  {
+    chi_mesh.OrthogonalMeshGenerator.Create({ node_sets = {xmesh,ymesh,zmesh} })
+  },
+})
+
+chi_mesh.MeshGenerator.Execute(meshgen1)
+
+--chiMeshHandlerExportMeshToVTK("ZMesh")
+
+chiVolumeMesherSetMatIDToAll(0)
+
+--############################################### Add materials
+materials = {}
+materials[1] = chiPhysicsAddMaterial("Test Material");
+
+chiPhysicsMaterialAddProperty(materials[1],TRANSPORT_XSECTIONS)
+
+chiPhysicsMaterialAddProperty(materials[1],ISOTROPIC_MG_SOURCE)
+
+
+num_groups = 21
+chiPhysicsMaterialSetProperty(materials[1],TRANSPORT_XSECTIONS,
+  CHI_XSFILE,"xs_graphite_pure.cxs")
+
+src={}
+for g=1,num_groups do
+  src[g] = 0.0
+end
+chiPhysicsMaterialSetProperty(materials[1],ISOTROPIC_MG_SOURCE,FROM_ARRAY,src)
+
+--############################################### Setup Physics
+pquad0 = chiCreateProductQuadrature(GAUSS_LEGENDRE_CHEBYSHEV,2, 4)
+
+lbs_block =
+{
+  num_groups = num_groups,
+  groupsets =
+  {
+    {
+      groups_from_to = {0, 20},
+      angular_quadrature_handle = pquad0,
+      angle_aggregation_type = "polar",
+      angle_aggregation_num_subsets = 1,
+      groupset_num_subsets = 1,
+      inner_linear_method = "gmres",
+      l_abs_tol = 1.0e-6,
+      l_max_its = 300,
+      gmres_restart_interval = 100,
+    },
+  },
+  sweep_type = "CBC",
+}
+bsrc={}
+for g=1,num_groups do
+  bsrc[g] = 0.0
+end
+bsrc[1] = 1.0/4.0/math.pi;
+lbs_options =
+{
+  boundary_conditions = { { name = "xmin", type = "incident_isotropic",
+                            group_strength=bsrc}},
+  scattering_order = 1,
+  save_angular_flux = true
+}
+
+phys1 = lbs.DiscreteOrdinatesSolver.Create(lbs_block)
+lbs.SetOptions(phys1, lbs_options)
+
+--############################################### Initialize and Execute Solver
+ss_solver = lbs.SteadyStateSolver.Create({lbs_solver_handle = phys1})
+
+chiSolverInitialize(ss_solver)
+chiSolverExecute(ss_solver)
+
+--############################################### Get field functions
+fflist,count = chiLBSGetScalarFieldFunctionList(phys1)
+
+pp1 = chi.CellVolumeIntegralPostProcessor.Create
+({
+  name="max-grp0",
+  field_function = fflist[1],
+  compute_volume_average = true,
+  print_numeric_format = "scientific"
+})
+pp2 = chi.CellVolumeIntegralPostProcessor.Create
+({
+  name="max-grp19",
+  field_function = fflist[20],
+  compute_volume_average = true,
+  print_numeric_format = "scientific"
+})
+chi.ExecutePostProcessors({ pp1, pp2 })
+
+if (master_export == nil) then
+  chiExportMultiFieldFunctionToVTK(fflist,"ZPhi")
+end

--- a/test/modules/LinearBoltzmannSolvers/Transport_Steady/Transport3D_6BSplitMesh.lua
+++ b/test/modules/LinearBoltzmannSolvers/Transport_Steady/Transport3D_6BSplitMesh.lua
@@ -1,0 +1,156 @@
+-- 3D Transport test with split-mesh + 2D ortho mesh + extruded mesh.
+-- SDM: PWLD
+-- Test: Max-value1=6.55387e+00
+--       Max-value2=1.02940e+00
+
+num_procs = 4
+
+
+
+
+
+--############################################### Check num_procs
+if (check_num_procs==nil and chi_number_of_processes ~= num_procs) then
+  chiLog(LOG_0ERROR,"Incorrect amount of processors. " ..
+    "Expected "..tostring(num_procs)..
+    ". Pass check_num_procs=false to override if possible.")
+  os.exit(false)
+end
+
+-- Cells
+div = 8
+Nx = math.floor(128/div)
+Ny = math.floor(128/div)
+Nz = math.floor(256/div)
+
+-- Dimensions
+Lx = 10.0
+Ly = 10.0
+Lz = 10.0
+
+xmesh = {}
+xmin = 0.0
+dx = Lx/Nx
+for i = 1, (Nx+1) do
+  k = i-1
+  xmesh[i] = xmin + k*dx
+end
+
+ymesh = {}
+ymin = 0.0
+dy = Ly/Ny
+for i = 1, (Ny+1) do
+  k = i-1
+  ymesh[i] = ymin + k*dy
+end
+
+zmesh = {}
+zmin = 0.0
+dz = Lz/Nz
+for i = 1, (Nz+1) do
+  k = i-1
+  zmesh[i] = zmin + k*dz
+end
+
+meshgen1 = chi_mesh.SplitFileMeshGenerator.Create
+({
+  inputs = {
+    chi_mesh.OrthogonalMeshGenerator.Create({ node_sets = {xmesh,ymesh} }),
+    chi_mesh.ExtruderMeshGenerator.Create
+    ({
+      layers = {{z=Lz, n=Nz}}
+    })
+  }
+})
+
+chi_mesh.MeshGenerator.Execute(meshgen1)
+
+--chiMeshHandlerExportMeshToVTK("ZMesh")
+
+chiVolumeMesherSetMatIDToAll(0)
+
+--############################################### Add materials
+materials = {}
+materials[1] = chiPhysicsAddMaterial("Test Material");
+
+chiPhysicsMaterialAddProperty(materials[1],TRANSPORT_XSECTIONS)
+
+chiPhysicsMaterialAddProperty(materials[1],ISOTROPIC_MG_SOURCE)
+
+
+num_groups = 21
+chiPhysicsMaterialSetProperty(materials[1],TRANSPORT_XSECTIONS,
+  CHI_XSFILE,"xs_graphite_pure.cxs")
+
+src={}
+for g=1,num_groups do
+  src[g] = 0.0
+end
+chiPhysicsMaterialSetProperty(materials[1],ISOTROPIC_MG_SOURCE,FROM_ARRAY,src)
+
+--############################################### Setup Physics
+pquad0 = chiCreateProductQuadrature(GAUSS_LEGENDRE_CHEBYSHEV,2, 4)
+
+lbs_block =
+{
+  num_groups = num_groups,
+  groupsets =
+  {
+    {
+      groups_from_to = {0, 20},
+      angular_quadrature_handle = pquad0,
+      angle_aggregation_type = "polar",
+      angle_aggregation_num_subsets = 1,
+      groupset_num_subsets = 1,
+      inner_linear_method = "gmres",
+      l_abs_tol = 1.0e-6,
+      l_max_its = 300,
+      gmres_restart_interval = 100,
+    },
+  },
+  sweep_type = "CBC",
+}
+bsrc={}
+for g=1,num_groups do
+  bsrc[g] = 0.0
+end
+bsrc[1] = 1.0/4.0/math.pi;
+lbs_options =
+{
+  boundary_conditions = { { name = "xmin", type = "incident_isotropic",
+                            group_strength=bsrc}},
+  scattering_order = 1,
+  save_angular_flux = true
+}
+
+phys1 = lbs.DiscreteOrdinatesSolver.Create(lbs_block)
+lbs.SetOptions(phys1, lbs_options)
+
+--############################################### Initialize and Execute Solver
+ss_solver = lbs.SteadyStateSolver.Create({lbs_solver_handle = phys1})
+
+chiSolverInitialize(ss_solver)
+chiSolverExecute(ss_solver)
+
+--############################################### Get field functions
+fflist,count = chiLBSGetScalarFieldFunctionList(phys1)
+
+pp1 = chi.CellVolumeIntegralPostProcessor.Create
+({
+  name="max-grp0",
+  field_function = fflist[1],
+  compute_volume_average = true,
+  print_numeric_format = "scientific"
+})
+pp2 = chi.CellVolumeIntegralPostProcessor.Create
+({
+  name="max-grp19",
+  field_function = fflist[20],
+  compute_volume_average = true,
+  print_numeric_format = "scientific"
+})
+chi.ExecutePostProcessors({ pp1, pp2 })
+
+if (master_export == nil) then
+  chiExportMultiFieldFunctionToVTK(fflist,"ZPhi")
+end

--- a/test/modules/LinearBoltzmannSolvers/Transport_Steady/YTests.json
+++ b/test/modules/LinearBoltzmannSolvers/Transport_Steady/YTests.json
@@ -375,5 +375,49 @@
         "tol": 0.0001
       }
     ]
+  },
+  {
+    "file": "Transport3D_6ASplitMesh.lua",
+    "comment": "3D LinearBSolver Test Split mesh configuration A",
+    "num_procs": 4,
+    "weight_class" : "intermediate",
+    "checks": [
+      {
+        "type": "FloatCompare",
+        "key": "max-grp0(latest)",
+        "wordnum" : 4,
+        "gold": 1.131566e-01,
+        "tol": 1.0e-6
+      },
+      {
+        "type": "FloatCompare",
+        "key": "max-grp19(latest)",
+        "wordnum" : 4,
+        "gold": 7.340585e-04,
+        "tol": 1.0e-9
+      }
+    ]
+  },
+  {
+    "file": "Transport3D_6BSplitMesh.lua",
+    "comment": "3D LinearBSolver Test Split mesh configuration A",
+    "num_procs": 4,
+    "weight_class" : "intermediate",
+    "checks": [
+      {
+        "type": "FloatCompare",
+        "key": "max-grp0(latest)",
+        "wordnum" : 4,
+        "gold": 1.131566e-01,
+        "tol": 1.0e-6
+      },
+      {
+        "type": "FloatCompare",
+        "key": "max-grp19(latest)",
+        "wordnum" : 4,
+        "gold": 7.340585e-04,
+        "tol": 1.0e-9
+      }
+    ]
   }
 ]


### PR DESCRIPTION
This temporarily addresses the issue with the high memory consumption when building meshes.

The `SplitFileMeshGenerator` is very much like MOOSE's capability, just I think a little easier to use since your simulation does not have to turn it on or off all the time.

It essentially builds the mesh only on location 0 then partitions it and writes the necessary pieces to chunks of binary files.