### PR TITLE
Better timing block

### DIFF
--- a/framework/chi_runtime.cc
+++ b/framework/chi_runtime.cc
@@ -189,6 +189,8 @@ int Chi::Initialize(int argc, char** argv, MPI_Comm communicator)
 
   run_time::InitPetSc(argc, argv);
 
+  auto& t_main = Chi::log.CreateTimingBlock("ChiTech");
+  t_main.TimeSectionBegin();
   chi::SystemWideEventPublisher::GetInstance().PublishEvent(chi::Event(
     "ProgramStart", chi::GetStandardEventCode("ProgramStart")));
 
@@ -213,6 +215,8 @@ int Chi::run_time::InitPetSc(int argc, char** argv)
  * */
 void Chi::Finalize()
 {
+  auto& t_main = Chi::log.GetTimingBlock("ChiTech");
+  t_main.TimeSectionEnd();
   chi::SystemWideEventPublisher::GetInstance().PublishEvent(chi::Event(
     "ProgramExecuted", chi::GetStandardEventCode("ProgramExecuted")));
   meshhandler_stack.clear();

--- a/framework/logging/TimingLog.cc
+++ b/framework/logging/TimingLog.cc
@@ -1,0 +1,236 @@
+#include "TimingLog.h"
+
+#include "utils/chi_timer.h"
+
+#include "chi_runtime.h"
+
+#include "chi_log_exceptions.h"
+
+#include <sstream>
+
+namespace chi
+{
+
+TimingBlock&
+TimingLog::CreateTimingBlock(const std::string& name,
+                             const std::string& parent_name /*=""*/)
+{
+  ChiInvalidArgumentIf(timing_blocks_.count(name) != 0,
+                       "TimingBlock with name \"" + name +
+                         "\" already exists"
+                         " in the logger");
+  auto block_ptr = std::make_unique<TimingBlock>(name);
+  auto saved_pointer = &(*block_ptr);
+  timing_blocks_[name] = std::move(block_ptr);
+
+  if (parent_name.empty())
+  {
+    if (name != "ChiTech")
+    {
+      auto iter = timing_blocks_.find("ChiTech");
+      ChiLogicalErrorIf(
+        iter == timing_blocks_.end(),
+        "Bad error, could not fine the \"ChiTech\" timing block");
+
+      iter->second->AddChild(*saved_pointer);
+    }
+
+    return *saved_pointer;
+  }
+
+  auto iter = timing_blocks_.find(parent_name);
+
+  ChiInvalidArgumentIf(iter == timing_blocks_.end(),
+                       "Parent name \"" + parent_name + "\" does not exist.");
+
+  auto& parent = iter->second;
+  parent->AddChild(*saved_pointer);
+
+  return *saved_pointer;
+}
+
+TimingBlock&
+TimingLog::CreateOrGetTimingBlock(const std::string& name,
+                                  const std::string& parent_name /*=""*/)
+{
+  auto iter = timing_blocks_.find(name);
+
+  if (iter == timing_blocks_.end()) return CreateTimingBlock(name, parent_name);
+
+  return *iter->second;
+}
+
+TimingBlock& TimingLog::GetTimingBlock(const std::string& name)
+{
+  auto iter = timing_blocks_.find(name);
+
+  ChiInvalidArgumentIf(iter == timing_blocks_.end(),
+                       "Timing block with name \"" + name +
+                         "\" does not exist.");
+
+  return *iter->second;
+}
+
+// ##################################################################
+
+TimingBlock::TimingBlock(const std::string& name) : name_(name) {}
+
+void TimingBlock::TimeSectionBegin()
+{
+  reference_time_ = Chi::program_timer.GetTime();
+}
+
+void TimingBlock::TimeSectionEnd()
+{
+  const double delta_t = Chi::program_timer.GetTime() - reference_time_;
+  total_time_ += delta_t;
+  num_occurences_ += 1;
+}
+
+size_t TimingBlock::NumberOfOccurences() const { return num_occurences_; }
+
+double TimingBlock::TotalTime() const { return total_time_; }
+
+double TimingBlock::AverageTime() const
+{
+  if (num_occurences_ == 0) return 0.0;
+
+  return total_time_ / static_cast<double>(num_occurences_);
+}
+
+void TimingBlock::AddChild(const TimingBlock& child_block)
+{
+  children_.push_back(&child_block);
+}
+
+std::string TimingBlock::MakeGraphString()
+{
+  if (name_ == "ChiTech") TimeSectionEnd();
+
+  std::vector<std::vector<std::string>> string_matrix;
+
+  AppendGraphEntry(string_matrix, nullptr, "");
+
+  const size_t J = 5;
+  const size_t I = string_matrix.size();
+
+  std::vector<size_t> max_col_widths(J, 0);
+  for (size_t i = 0; i < I; ++i)
+    for (size_t j = 0; j < J; ++j)
+      max_col_widths[j] =
+        std::max(max_col_widths[j], string_matrix[i][j].size());
+
+  std::vector<std::string> headers = {"Section Name",
+                                      "#calls",
+                                      "Total time[s]",
+                                      "Average time[s]",
+                                      "% of parent"};
+
+  for (size_t j = 0; j < J; ++j)
+    max_col_widths[j] = std::max(max_col_widths[j], headers[j].size());
+
+  /**Lambda to left pad an entry.*/
+  auto LeftPad = [](std::string& entry, size_t width)
+  {
+    const size_t pad_size = width - entry.size();
+    entry = std::string(pad_size, ' ').append(entry);
+  };
+  /**Lambda to right pad an entry.*/
+  auto RightPad = [](std::string& entry, size_t width)
+  {
+    const size_t pad_size = width - entry.size();
+    entry.append(std::string(pad_size, ' '));
+  };
+
+  std::stringstream outstr;
+
+  auto HDIV = [&outstr, &max_col_widths]()
+  {
+    outstr << "*-";
+    for (size_t j = 0; j < J; ++j)
+    {
+      outstr << std::string(max_col_widths[j] + 1, '-');
+      if (j < (J - 1)) outstr << "*-";
+    }
+    outstr << "*\n";
+  };
+
+  HDIV();
+
+  outstr << "| ";
+  for (size_t j = 0; j < J; ++j)
+  {
+    if (j == 0) RightPad(headers[j], max_col_widths[j]);
+    else
+      LeftPad(headers[j], max_col_widths[j] + 1);
+    outstr << headers[j] << " |";
+  }
+  outstr << "\n";
+
+  HDIV();
+
+  for (size_t i = 0; i < I; ++i)
+  {
+    outstr << "| ";
+    for (size_t j = 0; j < J; ++j)
+    {
+      if (j == 0) RightPad(string_matrix[i][j], max_col_widths[j]);
+      else
+        LeftPad(string_matrix[i][j], max_col_widths[j] + 1);
+      outstr << string_matrix[i][j] << " |";
+    }
+    outstr << "\n";
+  }
+
+  HDIV();
+
+  return outstr.str();
+}
+
+//  NOLINTBEGIN(misc-no-recursion)
+void TimingBlock::AppendGraphEntry(
+  std::vector<std::vector<std::string>>& string_matrix,
+  const TimingBlock* parent,
+  const std::string& indent) const
+{
+  std::vector<std::string> entry;
+
+  const double parent_total_time = parent ? parent->TotalTime() : 0.0;
+  const double relative_time =
+    parent_total_time > 1.0e-12 ? total_time_ * 100.0 / parent_total_time : 0.0;
+
+  entry.push_back(indent + name_);
+  entry.push_back(std::to_string(num_occurences_));
+
+  {
+    char buffer[20];
+    ChiLogicalErrorIf(snprintf(buffer, 20, "%.5g", total_time_ / 1000.0) < 0,
+                      "Failed to convert total_time = " +
+                        std::to_string(total_time_));
+    entry.push_back(buffer);
+  }
+
+  {
+    char buffer[20];
+    ChiLogicalErrorIf(snprintf(buffer, 20, "%.5g", AverageTime() / 1000.0) < 0,
+                      "Failed to convert AverageTime = " +
+                        std::to_string(AverageTime()));
+    entry.push_back(buffer);
+  }
+
+  {
+    char buffer[10];
+    ChiLogicalErrorIf(snprintf(buffer, 10, "%.2f%%", relative_time) < 0,
+                      "Failed to convert relative_time = " +
+                        std::to_string(relative_time));
+    entry.push_back(parent ? buffer : "--");
+  }
+
+  string_matrix.push_back(std::move(entry));
+
+  for (auto& child_ptr : children_)
+    child_ptr->AppendGraphEntry(string_matrix, this, indent + "  ");
+}
+//  NOLINTEND(misc-no-recursion)
+
+} // namespace chi

--- a/framework/logging/TimingLog.h
+++ b/framework/logging/TimingLog.h
@@ -1,0 +1,87 @@
+#ifndef CHITECH_TIMINGLOG_H
+#define CHITECH_TIMINGLOG_H
+
+#include <cstddef>
+#include <map>
+#include <string>
+#include <vector>
+#include <memory>
+
+namespace chi
+{
+
+class TimingBlock;
+
+/**Utility class for defining time logs.*/
+class TimingLog
+{
+public:
+  /**Creates a time block and returns a reference to it. If the name
+   * is already taken or the parent name is not found then this method
+   * throws `std::invalid_argument`. The parent name may be empty, i.e. "",
+   * which will revert to the main timing block "ChiTech"*/
+  TimingBlock& CreateTimingBlock(const std::string& name,
+                                 const std::string& parent_name = "");
+  /**If the timing block with the given exists, this method returns that block,
+   * otherwise it creates a time block and returns a reference to it. If the
+   * parent name is not found then this method throws `std::invalid_argument`.
+   * The parent name may be empty, i.e. "", which will revert to the main timing
+   * block "ChiTech"*/
+  TimingBlock& CreateOrGetTimingBlock(const std::string& name,
+                                      const std::string& parent_name = "");
+  /**Returns a reference to the timing block with the given name. If a timing
+   * block with that name does not exist then this method will throw
+   * `std::invalid_argument`.*/
+  TimingBlock& GetTimingBlock(const std::string& name);
+
+protected:
+  std::map<std::string, std::unique_ptr<TimingBlock>> timing_blocks_;
+};
+
+/**Hierarchical timing block to efficiently capture timing.*/
+class TimingBlock
+{
+public:
+  /**Constructs the given block with the given name.*/
+  explicit TimingBlock(const std::string& name);
+  /**Deleted copy constructor.*/
+  TimingBlock(const TimingBlock& other) = delete;
+  /**Deleted move constructor.*/
+  TimingBlock(TimingBlock&& other) = delete;
+
+  /**Begins a timing section by resetting the reference time.*/
+  void TimeSectionBegin();
+  /**Ends a timing section, contributes to the total time and adds an
+   * occurrence.*/
+  void TimeSectionEnd();
+
+  /**Returns the number of timing section occurrences.*/
+  size_t NumberOfOccurences() const;
+  /**Returns the computed total time over all occurrences.*/
+  double TotalTime() const;
+  /**Returns the average time per occurence.*/
+  double AverageTime() const;
+
+  /**Makes a string table of the timing block and all its children.*/
+  std::string MakeGraphString();
+
+protected:
+  friend class TimingLog;
+  /**Adds the supplied timing black as a child.*/
+  void AddChild(const TimingBlock& child_block);
+  /**Used when building the graph, this is a recursive function that adds
+  * each entry to a matrix.*/
+  void AppendGraphEntry(std::vector<std::vector<std::string>>& string_matrix,
+                        const TimingBlock* parent,
+                        const std::string& indent) const;
+
+  const std::string name_;
+  size_t num_occurences_ = 0;
+  double total_time_ = 0.0;
+  double reference_time_ = 0.0;
+  std::vector<const TimingBlock*> children_;
+};
+
+} // namespace chi
+
+#endif // CHITECH_TIMINGLOG_H

--- a/framework/logging/chi_log.h
+++ b/framework/logging/chi_log.h
@@ -3,6 +3,7 @@
 
 #include "chi_logstream.h"
 #include "chi_log_exceptions.h"
+#include "TimingLog.h"
 
 #include <utility>
 #include <vector>
@@ -189,7 +190,7 @@ namespace chi
   [0]      3.813122000 SINGLE_OCCURRENCE C
   \endverbatim
    * */
-class ChiLog
+class ChiLog : public TimingLog
 {
 public:
   /**Logging level*/

--- a/framework/logging/lua/chi_log_lua.h
+++ b/framework/logging/lua/chi_log_lua.h
@@ -8,6 +8,7 @@ namespace chi_log_utils::lua_utils
 int chiLogSetVerbosity(lua_State* L);
 int chiLog(lua_State* L);
 int chiLogProcessEvent(lua_State* L);
+int chiLogPrintTimingGraph(lua_State* L);
 } // namespace chi_log_utils::lua_utils
 
 #endif // CHITECH_CHI_LOG_LUA_H

--- a/test/framework/log/YTests.json
+++ b/test/framework/log/YTests.json
@@ -1,0 +1,8 @@
+[
+  {
+    "file" : "timingblock_test.lua", "num_procs" : 2, "checks" :
+  [
+    { "type" :  "ErrorCode", "error_code" :  0}
+  ]
+  }
+]

--- a/test/framework/log/timingblock_test.cc
+++ b/test/framework/log/timingblock_test.cc
@@ -1,0 +1,56 @@
+#include "chi_runtime.h"
+#include "chi_log.h"
+
+#include "console/chi_console.h"
+
+#include "utils/chi_timer.h"
+
+namespace chi_unit_tests
+{
+
+chi::ParameterBlock LogTimingInfoTest(const chi::InputParameters&);
+
+RegisterWrapperFunction(/*namespace_name=*/chi_unit_tests,
+                        /*name_in_lua=*/LogTimingInfoTest,
+                        /*syntax_function=*/nullptr,
+                        /*actual_function=*/LogTimingInfoTest);
+
+
+chi::ParameterBlock LogTimingInfoTest(const chi::InputParameters&)
+{
+  Chi::log.Log() << "LogTiming test";
+  auto& t_main = Chi::log.CreateTimingBlock("Timing_Main");
+  t_main.TimeSectionBegin();
+  {
+    // Some overhead
+    chi::Sleep(std::chrono::milliseconds(200));
+
+    auto& t_1 = Chi::log.CreateOrGetTimingBlock("Part1", "Timing_Main");
+    t_1.TimeSectionBegin();
+    {
+      chi::Sleep(std::chrono::milliseconds(300));
+    }
+    t_1.TimeSectionEnd();
+
+    auto& t_2 = Chi::log.CreateOrGetTimingBlock("Part2", "Timing_Main");
+    t_2.TimeSectionBegin();
+    {
+      chi::Sleep(std::chrono::milliseconds(333));
+    }
+    t_2.TimeSectionEnd();
+
+    auto& t_3 = Chi::log.GetTimingBlock("Part2");
+    t_3.TimeSectionBegin();
+    {
+      chi::Sleep(std::chrono::milliseconds(123));
+    }
+    t_3.TimeSectionEnd();
+  }
+  t_main.TimeSectionEnd();
+
+  Chi::log.Log() << Chi::log.GetTimingBlock("ChiTech").MakeGraphString();
+
+  return chi::ParameterBlock{};
+}
+
+}

--- a/test/framework/log/timingblock_test.lua
+++ b/test/framework/log/timingblock_test.lua
@@ -1,0 +1,4 @@
+chi_unit_tests.LogTimingInfoTest()
+
+chiLogPrintTimingGraph()
+chiLogPrintTimingGraph(1)


### PR DESCRIPTION
## Highlights
This is a fairly simple addition. I created the `RepeatingEvent` system a long time a go to visualize sweeps in parallel, however, that ended up being used for sweep timing too. The flaw in that system is that it keeps a history and therefore if one naively used it for timing in very granular codes (like within a cell/face loop) then you would see something that looked like a memory leak because the history would grow to millions.

A much better system is now the hierarchical `chi::TimingBlock` system administered via `chi::TimingLog`, from which `ChiLog` inherits. By default there is a master timing block `ChiTech` which is the default parent for all blocks, however, parents for sub-blocks can be assigned to build a timing or performance graph.

## Example:
This is also a test in the test-system:
```c++
 auto& t_main = Chi::log.CreateTimingBlock("Timing_Main");
  t_main.TimeSectionBegin();
  {
    // Some overhead
    chi::Sleep(std::chrono::milliseconds(200));

    auto& t_1 = Chi::log.CreateOrGetTimingBlock("Part1", "Timing_Main");
    t_1.TimeSectionBegin();
    {
      chi::Sleep(std::chrono::milliseconds(300));
    }
    t_1.TimeSectionEnd();

    auto& t_2 = Chi::log.CreateOrGetTimingBlock("Part2", "Timing_Main");
    t_2.TimeSectionBegin();
    {
      chi::Sleep(std::chrono::milliseconds(333));
    }
    t_2.TimeSectionEnd();

    auto& t_3 = Chi::log.GetTimingBlock("Part2");
    t_3.TimeSectionBegin();
    {
      chi::Sleep(std::chrono::milliseconds(123));
    }
    t_3.TimeSectionEnd();
  }
  t_main.TimeSectionEnd();
```

The graph can be printed via the lua language using `chiLogPrintTimingGraph()` and it looks like this:
```
[0]  *---------------*--------*---------------*-----------------*-------------*
[0]  | Section Name  | #calls | Total time[s] | Average time[s] | % of parent |
[0]  *---------------*--------*---------------*-----------------*-------------*
[0]  | ChiTech       |      1 |        0.9724 |          0.9724 |          -- |
[0]  |   Timing_Main |      1 |       0.97232 |         0.97232 |      99.99% |
[0]  |     Part1     |      1 |       0.30504 |         0.30504 |      31.37% |
[0]  |     Part2     |      2 |        0.4641 |         0.23205 |      47.73% |
[0]  *---------------*--------*---------------*-----------------*-------------*
```