### PR TITLE
Hot fix for slow SplitFileMeshGenerator

### DIFF
--- a/framework/data_types/byte_array.h
+++ b/framework/data_types/byte_array.h
@@ -8,135 +8,134 @@
 
 namespace chi_data_types
 {
-  class ByteArray
+class ByteArray
+{
+protected:
+  std::vector<std::byte> raw_data_;
+  size_t offset_ = 0;
+
+public:
+  ByteArray() = default;
+  explicit ByteArray(const size_t raw_data_size) : raw_data_(raw_data_size) {}
+  explicit ByteArray(std::vector<std::byte>&& raw_data)
+    : raw_data_(std::move(raw_data))
   {
-  protected:
-    std::vector<std::byte> raw_data_;
-    size_t                 offset_=0;
+  }
+  explicit ByteArray(const std::vector<std::byte>& raw_data)
+    : raw_data_(raw_data)
+  {
+  }
 
-  public:
-    ByteArray() = default;
-    explicit
-    ByteArray(const size_t raw_data_size) : raw_data_(raw_data_size) {}
-    explicit
-    ByteArray(std::vector<std::byte>&& raw_data) : raw_data_(std::move(raw_data)) {}
-    explicit
-    ByteArray(const std::vector<std::byte>& raw_data) : raw_data_(raw_data) {}
+  /**Uses the template type T to convert an associated value (of type T)
+   * to a sub-array of std::bytes and adds it to the internal byte-array.
+   *
+   * The template type T must support sizeof.*/
+  template <typename T>
+  void Write(const T& value)
+  {
+    const size_t num_bytes = sizeof(T);
+    const std::byte* value_byte_array =
+      reinterpret_cast<const std::byte*>(&value);
 
+    raw_data_.insert(
+      raw_data_.end(), value_byte_array, value_byte_array + num_bytes);
+  }
 
-    /**Uses the template type T to convert an associated value (of type T)
-     * to a sub-array of std::bytes and adds it to the internal byte-array.
-     *
-     * The template type T must support sizeof.*/
-    template<typename T> void Write(const T& value)
-    {
-      const size_t num_bytes = sizeof(T);
-      const std::byte* value_byte_array =
-        reinterpret_cast<const std::byte*>(&value);
+  /**Uses the template type `T` to convert `sizeof(T)` number of bytes to
+   * a value of type `T`. The bytes are pulled from the internal byte-array
+   * starting at the internal address `m_offset` which can be viewed with a
+   * call to `Offset()`. This offset is incremented by the amount of bytes
+   * used and can be reset with a call to `Seek(0)`.
+   *
+   * Bounds-checking is performed by checking if the internal byte array
+   * has the required number of bytes available. If this check fails then
+   * this call will return an `out_of_range` exception.*/
+  template <typename T>
+  T Read()
+  {
+    const size_t num_bytes = sizeof(T);
+    if ((offset_ + num_bytes - 1) >= raw_data_.size())
+      throw std::out_of_range(
+        std::string("ByteArray reading error. ") +
+        " Typename: " + std::string(typeid(T).name()) + " m_offset: " +
+        std::to_string(offset_) + " size: " + std::to_string(raw_data_.size()) +
+        " num_bytes to read: " + std::to_string(num_bytes));
 
-      for (size_t b=0; b<num_bytes; ++b)
-        raw_data_.push_back(value_byte_array[b]);
-    }
+    T value = *reinterpret_cast<T*>(&raw_data_[offset_]);
+    offset_ += num_bytes;
 
-    /**Uses the template type `T` to convert `sizeof(T)` number of bytes to
-     * a value of type `T`. The bytes are pulled from the internal byte-array
-     * starting at the internal address `m_offset` which can be viewed with a
-     * call to `Offset()`. This offset is incremented by the amount of bytes
-     * used and can be reset with a call to `Seek(0)`.
-     *
-     * Bounds-checking is performed by checking if the internal byte array
-     * has the required number of bytes available. If this check fails then
-     * this call will return an `out_of_range` exception.*/
-    template<typename T> T Read()
-    {
-      const size_t num_bytes = sizeof(T);
-      if ((offset_ + num_bytes - 1) >= raw_data_.size())
-        throw std::out_of_range(
-          std::string("ByteArray reading error. ") +
-          " Typename: " + std::string(typeid(T).name()) +
-          " m_offset: " + std::to_string(offset_) +
-          " size: " + std::to_string(raw_data_.size()) +
-          " num_bytes to read: " + std::to_string(num_bytes));
+    return value;
+  }
 
-      T value = *reinterpret_cast<T*>(&raw_data_[offset_]);
-      offset_ += num_bytes;
+  /**Uses the template type T to convert sizeof(T) number of bytes to
+   * a value of type T. The bytes are pulled from the internal byte-array
+   * starting at the internal address specified by the argument "address".
+   * An optional argument next_address can be used to return the location
+   * of the value after the value read.
+   * This offset is the given "address" argument incremented by the amount
+   * of bytes used.
+   *
+   * Bounds-checking is performed by checking if the internal byte array
+   * has the required number of bytes available. If this check fails then
+   * this call will return an `out_of_range` exception.*/
+  template <typename T>
+  T Read(const size_t address, size_t* next_address = nullptr) const
+  {
+    const size_t num_bytes = sizeof(T);
+    if ((address + num_bytes - 1) >= raw_data_.size())
+      throw std::logic_error(
+        std::string("ByteArray reading error. ") + " Typename: " +
+        std::string(typeid(T).name()) + " address: " + std::to_string(address) +
+        " size: " + std::to_string(raw_data_.size()) +
+        " num_bytes to read: " + std::to_string(num_bytes));
 
-      return value;
-    }
+    T value = *reinterpret_cast<const T*>(&raw_data_[address]);
+    if (next_address != nullptr) *next_address = address + num_bytes;
 
-    /**Uses the template type T to convert sizeof(T) number of bytes to
-     * a value of type T. The bytes are pulled from the internal byte-array
-     * starting at the internal address specified by the argument "address".
-     * An optional argument next_address can be used to return the location
-     * of the value after the value read.
-     * This offset is the given "address" argument incremented by the amount
-     * of bytes used.
-     *
-     * Bounds-checking is performed by checking if the internal byte array
-     * has the required number of bytes available. If this check fails then
-     * this call will return an `out_of_range` exception.*/
-    template<typename T> T Read(const size_t address,
-                                size_t* next_address = nullptr) const
-    {
-      const size_t num_bytes = sizeof(T);
-      if ((address + num_bytes - 1) >= raw_data_.size())
-        throw std::logic_error(
-          std::string("ByteArray reading error. ") +
-          " Typename: " + std::string(typeid(T).name()) +
-          " address: " + std::to_string(address) +
-          " size: " + std::to_string(raw_data_.size()) +
-          " num_bytes to read: " + std::to_string(num_bytes));
+    return value;
+  }
 
-      T value = *reinterpret_cast<const T*>(&raw_data_[address]);
-      if (next_address != nullptr) *next_address = address + num_bytes;
+  /**Appends a `ByteArray` to the current internal byte array.*/
+  void Append(const ByteArray& other_raw)
+  {
+    auto& master = raw_data_;
 
-      return value;
-    }
+    const auto& slave = other_raw.Data();
+    master.insert(master.end(), slave.begin(), slave.end());
+  }
 
-    /**Appends a `ByteArray` to the current internal byte array.*/
-    void Append(const ByteArray& other_raw)
-    {
-      auto& master = raw_data_;
+  /**Appends bytes from a `std::vector<std::byte>` to the internal
+   * byte array.*/
+  void Append(const std::vector<std::byte>& other_raw)
+  {
+    auto& master = raw_data_;
 
-      const auto& slave = other_raw.Data();
-      for (std::byte slave_value : slave)
-        master.push_back(slave_value);
-    }
+    const auto& slave = other_raw;
+    master.insert(master.end(), slave.begin(), slave.end());
+  }
 
-    /**Appends bytes from a `std::vector<std::byte>` to the internal
-     * byte array.*/
-    void Append(const std::vector<std::byte>& other_raw)
-    {
-      auto& master = raw_data_;
+  /**Clears the internal byte array and resets the address offset to zero.*/
+  void Clear()
+  {
+    raw_data_.clear();
+    offset_ = 0;
+  }
 
-      const auto& slave = other_raw;
-      for (std::byte slave_value : slave)
-        master.push_back(slave_value);
-    }
+  /**Moves the address marker to the supplied address.*/
+  void Seek(const size_t address = 0) { offset_ = address; }
+  /**Returns the internal address marker position.*/
+  size_t Offset() const { return offset_; }
+  /**Determines if the internal address marker is beyond the internal
+   * byte array.*/
+  bool EndOfBuffer() const { return offset_ >= raw_data_.size(); }
+  /**Returns the current size of the internal byte array.*/
+  size_t Size() const { return raw_data_.size(); }
 
-    /**Clears the internal byte array and resets the address offset to zero.*/
-    void Clear()
-    {
-      raw_data_.clear();
-      offset_ = 0;
-    }
+  /**Returns a reference to the internal byte array.*/
+  std::vector<std::byte>& Data() { return raw_data_; }
+  /**Returns a const reference of the internal byte array.*/
+  const std::vector<std::byte>& Data() const { return raw_data_; }
+};
+} // namespace chi_data_types
 
-    /**Moves the address marker to the supplied address.*/
-    void Seek(const size_t address=0) { offset_ = address;}
-    /**Returns the internal address marker position.*/
-    size_t Offset() const {return offset_;}
-    /**Determines if the internal address marker is beyond the internal
-     * byte array.*/
-    bool EndOfBuffer() const {return offset_ >= raw_data_.size();}
-    /**Returns the current size of the internal byte array.*/
-    size_t Size() const {return raw_data_.size();}
-
-    /**Returns a reference to the internal byte array.*/
-    std::vector<std::byte>& Data() {return raw_data_;}
-    /**Returns a const reference of the internal byte array.*/
-    const std::vector<std::byte>& Data() const {return raw_data_;}
-  };
-}//namespace chi_data_types
-
-
-#endif //CHITECH_BYTE_ARRAY_H
+#endif // CHITECH_BYTE_ARRAY_H

--- a/framework/logging/TimingLog.cc
+++ b/framework/logging/TimingLog.cc
@@ -85,6 +85,7 @@ void TimingBlock::TimeSectionEnd()
   const double delta_t = Chi::program_timer.GetTime() - reference_time_;
   total_time_ += delta_t;
   num_occurences_ += 1;
+  last_delta_time_ = delta_t;
 }
 
 size_t TimingBlock::NumberOfOccurences() const { return num_occurences_; }
@@ -96,6 +97,11 @@ double TimingBlock::AverageTime() const
   if (num_occurences_ == 0) return 0.0;
 
   return total_time_ / static_cast<double>(num_occurences_);
+}
+
+double TimingBlock::LastDelta() const
+{
+  return last_delta_time_;
 }
 
 void TimingBlock::AddChild(const TimingBlock& child_block)

--- a/framework/logging/TimingLog.h
+++ b/framework/logging/TimingLog.h
@@ -61,6 +61,8 @@ public:
   double TotalTime() const;
   /**Returns the average time per occurence.*/
   double AverageTime() const;
+  /**Returns the last computed time differential.*/
+  double LastDelta() const;
 
   /**Makes a string table of the timing block and all its children.*/
   std::string MakeGraphString();
@@ -79,6 +81,7 @@ protected:
   size_t num_occurences_ = 0;
   double total_time_ = 0.0;
   double reference_time_ = 0.0;
+  double last_delta_time_ = 0.0;
   std::vector<const TimingBlock*> children_;
 };
 

--- a/framework/mesh/MeshGenerator/SplitFileMeshGenerator.h
+++ b/framework/mesh/MeshGenerator/SplitFileMeshGenerator.h
@@ -49,6 +49,7 @@ protected:
   const std::string split_mesh_dir_path_;
   const std::string split_file_prefix_;
   const bool read_only_;
+  const bool verbose_;
 };
 
 } // namespace chi_mesh


### PR DESCRIPTION
This was a very strange thing to improve. Took a lot of profiling. The change is not obvious but all the delay ended up being in the identification of ghost cells and vertices. If N is the amount of cells, and N_p is the number of partitions, ... then the algorithm ended up being N*N_p + 2(N/N_P). Reduced to about 3 (N/N_p). So it ends up going faster the more parts you do.

I also implemented manual buffering of the binary writes which ended up reducing file write times by half.