### PR TITLE
Add missing headers

### DIFF
--- a/framework/utils/print_iter_progress.cc
+++ b/framework/utils/print_iter_progress.cc
@@ -2,6 +2,7 @@
 
 #include <cmath>
 #include <iomanip>
+#include <iostream>
 #include <sstream>
 
 //###################################################################


### PR DESCRIPTION
These are required for modern clang builds.